### PR TITLE
implement redis_hybrid cache

### DIFF
--- a/docs/caches/README.md
+++ b/docs/caches/README.md
@@ -49,7 +49,8 @@ cache is the same for both inputs.
 3. [`memcached`](#memcached)
 4. [`memory`](#memory)
 5. [`redis`](#redis)
-6. [`s3`](#s3)
+6. [`redis_hybrid`](#redis_hybrid)
+7. [`s3`](#s3)
 
 ## `dynamodb`
 
@@ -173,6 +174,24 @@ redis:
 
 Use a Redis instance as a cache. The expiration can be set to zero or an empty
 string in order to set no expiration.
+
+## `redis_hybrid`
+
+``` yaml
+type: redis_hybrid
+redis_hybrid:
+  expiration: 24h
+  invalidation_channel: benthos_redis_hybrid
+  local_cache_size: 1.073741824e+09
+  prefix: ""
+  retries: 3
+  retry_period: 500ms
+  url: tcp://localhost:6379
+```
+
+Use a in-memory cache that acts as a read-through cache onto Redis. Any changes
+will cause distributed invalidation via a Redis pubsub channel, which can be
+configured.
 
 ## `s3`
 

--- a/docs/outputs/README.md
+++ b/docs/outputs/README.md
@@ -284,6 +284,7 @@ types:
 - memcached
 - memory
 - redis
+- redis_hybrid
 - s3
 
 Like follows:

--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd // indirect
 	github.com/colinmarc/hdfs v1.1.3
 	github.com/containerd/continuity v0.0.0-20181203112020-004b46473808 // indirect
+	github.com/dgraph-io/ristretto v0.0.0-20191114170855-99d1bbbf28e6
 	github.com/docker/go-connections v0.4.0 // indirect
 	github.com/docker/go-units v0.3.3 // indirect
 	github.com/eapache/go-resiliency v1.2.0 // indirect

--- a/lib/cache/constructor.go
+++ b/lib/cache/constructor.go
@@ -49,39 +49,42 @@ var Constructors = map[string]TypeSpec{}
 
 // String constants representing each cache type.
 const (
-	TypeDynamoDB  = "dynamodb"
-	TypeFile      = "file"
-	TypeMemcached = "memcached"
-	TypeMemory    = "memory"
-	TypeRedis     = "redis"
-	TypeS3        = "s3"
+	TypeDynamoDB    = "dynamodb"
+	TypeFile        = "file"
+	TypeMemcached   = "memcached"
+	TypeMemory      = "memory"
+	TypeRedis       = "redis"
+	TypeRedisHybrid = "redis_hybrid"
+	TypeS3          = "s3"
 )
 
 //------------------------------------------------------------------------------
 
 // Config is the all encompassing configuration struct for all cache types.
 type Config struct {
-	Type      string          `json:"type" yaml:"type"`
-	DynamoDB  DynamoDBConfig  `json:"dynamodb" yaml:"dynamodb"`
-	File      FileConfig      `json:"file" yaml:"file"`
-	Memcached MemcachedConfig `json:"memcached" yaml:"memcached"`
-	Memory    MemoryConfig    `json:"memory" yaml:"memory"`
-	Plugin    interface{}     `json:"plugin,omitempty" yaml:"plugin,omitempty"`
-	Redis     RedisConfig     `json:"redis" yaml:"redis"`
-	S3        S3Config        `json:"s3" yaml:"s3"`
+	Type        string            `json:"type" yaml:"type"`
+	DynamoDB    DynamoDBConfig    `json:"dynamodb" yaml:"dynamodb"`
+	File        FileConfig        `json:"file" yaml:"file"`
+	Memcached   MemcachedConfig   `json:"memcached" yaml:"memcached"`
+	Memory      MemoryConfig      `json:"memory" yaml:"memory"`
+	Plugin      interface{}       `json:"plugin,omitempty" yaml:"plugin,omitempty"`
+	Redis       RedisConfig       `json:"redis" yaml:"redis"`
+	RedisHybrid RedisHybridConfig `json:"redis_hybrid" yaml:"redis_hybrid"`
+	S3          S3Config          `json:"s3" yaml:"s3"`
 }
 
 // NewConfig returns a configuration struct fully populated with default values.
 func NewConfig() Config {
 	return Config{
-		Type:      "memory",
-		DynamoDB:  NewDynamoDBConfig(),
-		File:      NewFileConfig(),
-		Memcached: NewMemcachedConfig(),
-		Memory:    NewMemoryConfig(),
-		Plugin:    nil,
-		Redis:     NewRedisConfig(),
-		S3:        NewS3Config(),
+		Type:        "memory",
+		DynamoDB:    NewDynamoDBConfig(),
+		File:        NewFileConfig(),
+		Memcached:   NewMemcachedConfig(),
+		Memory:      NewMemoryConfig(),
+		Plugin:      nil,
+		Redis:       NewRedisConfig(),
+		RedisHybrid: NewRedisHybridConfig(),
+		S3:          NewS3Config(),
 	}
 }
 

--- a/lib/cache/redis_hybrid.go
+++ b/lib/cache/redis_hybrid.go
@@ -1,0 +1,224 @@
+// Copyright (c) 2018 Ashley Jeffs
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package cache
+
+import (
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/Jeffail/benthos/v3/lib/log"
+	"github.com/Jeffail/benthos/v3/lib/metrics"
+	"github.com/Jeffail/benthos/v3/lib/types"
+	"github.com/dgraph-io/ristretto"
+)
+
+//------------------------------------------------------------------------------
+
+func init() {
+	Constructors[TypeRedisHybrid] = TypeSpec{
+		constructor: NewRedisHybrid,
+		description: `
+Use a in-memory cache that acts as a read-through cache onto Redis. Any changes
+will cause distributed invalidation via a Redis pubsub channel, which can be
+configured.`,
+	}
+}
+
+//------------------------------------------------------------------------------
+
+// RedisHybridConfig is a config struct for a redis connection and local cache.
+type RedisHybridConfig struct {
+	URL                 string `json:"url" yaml:"url"`
+	Prefix              string `json:"prefix" yaml:"prefix"`
+	Expiration          string `json:"expiration" yaml:"expiration"`
+	Retries             int    `json:"retries" yaml:"retries"`
+	RetryPeriod         string `json:"retry_period" yaml:"retry_period"`
+	InvalidationChannel string `json:"invalidation_channel" yaml:"invalidation_channel"`
+	LocalCacheSize      int    `json:"local_cache_size" yaml:"local_cache_size"`
+}
+
+// NewRedisHybridConfig returns a RedisHybridConfig with default values.
+func NewRedisHybridConfig() RedisHybridConfig {
+	return RedisHybridConfig{
+		URL:                 "tcp://localhost:6379",
+		Prefix:              "",
+		Expiration:          "24h",
+		Retries:             3,
+		RetryPeriod:         "500ms",
+		InvalidationChannel: "benthos_redis_hybrid",
+		LocalCacheSize:      1 << 30,
+	}
+}
+
+//------------------------------------------------------------------------------
+
+// RedisHybrid is a cache that connects to redis servers.
+type RedisHybrid struct {
+	log      log.Modular
+	redis    *Redis
+	mem      *ristretto.Cache
+	invalKey string
+}
+
+// NewRedisHybrid returns a RedisHybrid processor.
+func NewRedisHybrid(
+	conf Config, mgr types.Manager, log log.Modular, stats metrics.Type,
+) (types.Cache, error) {
+	mem, err := ristretto.NewCache(&ristretto.Config{
+		NumCounters: 1e7,     // number of keys to track frequency of (10M).
+		MaxCost:     1 << 30, // maximum cost of cache (1GB).
+		BufferItems: 64,      // number of keys per Get buffer.
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to build in-memory cache: %w", err)
+	}
+	conf.Redis = RedisConfig{
+		URL:         conf.RedisHybrid.URL,
+		Prefix:      conf.RedisHybrid.Prefix,
+		Expiration:  conf.RedisHybrid.Expiration,
+		Retries:     conf.RedisHybrid.Retries,
+		RetryPeriod: conf.RedisHybrid.RetryPeriod,
+	}
+	redisCache, err := NewRedis(conf, mgr, log, stats)
+	if err != nil {
+		return nil, fmt.Errorf("failed to build redis cache: %w", err)
+	}
+
+	redis, ok := redisCache.(*Redis)
+	if !ok {
+		return nil, fmt.Errorf("failed to assert redis cache type")
+	}
+
+	r := &RedisHybrid{
+		log:      log,
+		redis:    redis,
+		invalKey: conf.RedisHybrid.InvalidationChannel,
+		mem:      mem,
+	}
+	go r.invalidationListener()
+	return r, nil
+}
+
+//------------------------------------------------------------------------------
+
+// Get attempts to locate and return a cached value by its key, returns an error
+// if the key does not exist or if the operation failed.
+func (r *RedisHybrid) Get(key string) ([]byte, error) {
+	// first check in local cache
+	if val, found := r.mem.Get(key); found {
+		valBytes, ok := val.([]byte)
+		if !ok {
+			return nil, errors.New("bad type in cache")
+		}
+		return valBytes, nil
+	}
+
+	// get from remote cache
+	val, err := r.redis.Get(key)
+	if err != nil {
+		return nil, err
+	}
+
+	// set in local cache if found remotely
+	r.mem.Set(key, val, 0)
+
+	return val, nil
+}
+
+func (r *RedisHybrid) invalidationListener() {
+	for msg := range r.redis.client.Subscribe(r.invalKey).Channel() {
+		r.mem.Del(string(msg.Payload))
+	}
+}
+
+// Set attempts to set the value of a key.
+func (r *RedisHybrid) Set(key string, value []byte) error {
+	// set in redis
+	if err := r.redis.Set(key, value); err != nil {
+		return err
+	}
+
+	// send invalidation message
+	if err := r.redis.client.Publish(r.invalKey, []byte(key)).Err(); err != nil {
+		r.log.Errorf("redis PUBLISH error %v\n", err)
+	}
+
+	return nil
+}
+
+// SetMulti attempts to set the value of multiple keys, returns an error if any
+// keys fail.
+func (r *RedisHybrid) SetMulti(items map[string][]byte) error {
+	// TODO: Come back and optimise this.
+	for k, v := range items {
+		if err := r.Set(k, v); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// Add attempts to set the value of a key only if the key does not already exist
+// and returns an error if the key already exists or if the operation fails.
+func (r *RedisHybrid) Add(key string, value []byte) error {
+	// check local cache
+	if _, found := r.mem.Get(key); found {
+		return types.ErrKeyAlreadyExists
+	}
+
+	// run add on underlying redis cache
+	if err := r.redis.Add(key, value); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Delete attempts to remove a key.
+func (r *RedisHybrid) Delete(key string) error {
+	// remove from local cache.
+	//   the invalidation message would do this,
+	//   but it will be idempotent and more accurate to do it twice.
+	r.mem.Del(key)
+
+	// remove from remote cache
+	r.redis.Delete(key)
+
+	// send invalidation message for key
+	if err := r.redis.client.Publish(r.invalKey, []byte(key)).Err(); err != nil {
+		r.log.Errorf("redis PUBLISH error %v\n", err)
+	}
+
+	return nil
+}
+
+// CloseAsync shuts down the cache.
+func (r *RedisHybrid) CloseAsync() {
+}
+
+// WaitForClose blocks until the cache has closed down.
+func (r *RedisHybrid) WaitForClose(timeout time.Duration) error {
+	r.redis.client.Close()
+	return nil
+}
+
+//-----------------------------------------------------------------------------


### PR DESCRIPTION
@Jeffail here is a pattern for a using a in-memory cache ([risretto](https://github.com/dgraph-io/ristretto), its great) as a read-through onto redis, coupled with a invalidation channel so it can be used as a distributed in-memory cache using redis as a broker.

I would have loved to do this without requiring a redis specifically, but the invalidation channel is important for the distributed nature of this cache type, and the other caches do not implement a similar mechanism.