### PR TITLE
simplified the docker compose profiling example

### DIFF
--- a/resources/docker/profiling/README.md
+++ b/resources/docker/profiling/README.md
@@ -5,12 +5,13 @@ This docker compose sets a Benthos instance up with a custom config, [Prometheus
 
 # Set up
 
-- Run Grafana and Prometheus with `docker-compose up`.
-- Edit `config.yaml` and add whatever components you want to profile with.
-- Run Benthos with `benthos -c ./config.yaml`.
+- Run with `docker-compose up -d`.
 - Open up Grafana at [http://localhost:3000/d/PHrVlmniz/benthos-dash](http://localhost:3000/d/PHrVlmniz/benthos-dash)
+    - default user:pw is admin:admin
 - Go to [http://localhost:16686](http://localhost:16686) in order to observe opentracing events with Jaeger.
-- Use `go tool pprof http://localhost:4195/debug/pprof/profile` and similar endpoints to get profiling data.
+- Endpoints is available at [http://localhost:4195/endpoints](http://localhost:4195/endpoints) documented [here](https://www.benthos.dev/docs/components/http/about/#endpoints)
+    - Use `go tool pprof http://localhost:4195/debug/pprof/profile` and similar endpoints to get profiling data.
+- Stop with `docker-compose stop`
 
 [prometheus]: https://prometheus.io/
 [grafana]: https://grafana.com/

--- a/resources/docker/profiling/config.yaml
+++ b/resources/docker/profiling/config.yaml
@@ -1,10 +1,10 @@
 http:
-  address: 0.0.0.0:4195
+  address: :4195
   debug_endpoints: true
 
 input:
   bloblang:
-    interval: "1us"
+    interval: "1ms"
     mapping: |
       root = {
         "locations": [
@@ -15,8 +15,15 @@ input:
         ]
       }
 
+buffer:
+  memory:
+    limit: 524288000
+    batch_policy:
+      enabled: true
+      count: 10
+
 pipeline:
-  threads: 20
+  threads: 2
   processors:
     - resource: with_bloblang
     # - resource: with_jq
@@ -45,10 +52,8 @@ resources:
 metrics:
   prometheus:
     prefix: benthos
-    push_interval: 1s
-    push_job_name: benthos_push
-    push_url: "http://localhost:9091"
+    path_mapping: ""
 
-# tracer:
-#   jaeger:
-#     agent_address: 'localhost:6831'
+tracer:
+  jaeger:
+    agent_address: 'jaeger:6831'

--- a/resources/docker/profiling/docker-compose.yaml
+++ b/resources/docker/profiling/docker-compose.yaml
@@ -5,6 +5,13 @@ volumes:
  grafana_data: {}
 
 services:
+  benthos:
+    image: jeffail/benthos
+    ports: 
+      - 4195:4195
+    volumes:
+      - ./config.yaml:/benthos.yaml
+
   jaeger:
     image: jaegertracing/all-in-one
     ports:
@@ -23,30 +30,6 @@ services:
       - '--web.console.templates=/usr/share/prometheus/consoles'
     ports:
       - 9090:9090
-
-  traefik:
-    image: "traefik"
-    command:
-      - "--api.insecure=true"
-      - "--providers.docker=true"
-      - "--providers.docker.exposedbydefault=false"
-      - "--entrypoints.web.address=:80"
-    ports:
-      - "80:80"
-      - "8080:8080"
-    volumes:
-      - "/var/run/docker.sock:/var/run/docker.sock:ro"
-
-  pushgateway:
-    image: prom/pushgateway
-    ports:
-      - 9091:9091
-    labels:
-      - "traefik.enable=true"
-      - "traefik.http.routers.whoami.rule=Host(`push.localhost`)"
-      - "traefik.http.routers.whoami.entrypoints=web"
-      - "traefik.http.routers.whoami.middlewares=secured"
-      - "traefik.http.middlewares.secured.basicauth.users=foo:$$2y$$05$$zwyVyaTBE.hdSl8Xs./bJuv3nrlIgiFCsHNDvnWy4C3GRnR4L5cl6"
 
   grafana:
     image: grafana/grafana

--- a/resources/docker/profiling/prometheus/prometheus.yml
+++ b/resources/docker/profiling/prometheus/prometheus.yml
@@ -1,17 +1,8 @@
 global:
   scrape_interval:     15s
   evaluation_interval: 15s
-  external_labels:
-    monitor: 'benthos-benchmark'
 
 scrape_configs:
-  - job_name: 'prometheus'
-    scrape_interval: 5s
+  - job_name: 'benthos'
     static_configs:
-      - targets: ['localhost:9090']
-
-  - job_name: 'push_gateway'
-    scrape_interval: 5s
-    honor_labels: true
-    static_configs:
-      - targets: ['pushgateway:9091']
+      - targets: ['benthos:4195']


### PR DESCRIPTION
The main point of this pull request is to enable running the resources/docker/profiling example with one docker-compose up command.

The previous setup crashed my laptop so made some changes to make running the setup easier:
- benthos added to the docker compose file
- reduced input bloblang interval
- removed traefik, prom/pushgateway
- added buffer to the pipeline so that Grafana dashboard no longer shows "no data"
- added some missing instructions to the readme