### PR TITLE
jetstream: add support of pull consumers

### DIFF
--- a/internal/impl/nats/integration_test.go
+++ b/internal/impl/nats/integration_test.go
@@ -82,3 +82,81 @@ input:
 		integration.StreamTestOptPort(resource.GetPort("4222/tcp")),
 	)
 }
+
+func TestIntegrationNatsPullConsumer(t *testing.T) {
+	integration.CheckSkip(t)
+	t.Parallel()
+
+	pool, err := dockertest.NewPool("")
+	require.NoError(t, err)
+
+	pool.MaxWait = time.Second * 30
+	resource, err := pool.RunWithOptions(&dockertest.RunOptions{
+		Repository: "nats",
+		Tag:        "latest",
+		Cmd:        []string{"--js"},
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		assert.NoError(t, pool.Purge(resource))
+	})
+
+	var natsConn *nats.Conn
+	resource.Expire(900)
+	require.NoError(t, pool.Retry(func() error {
+		natsConn, err = nats.Connect(fmt.Sprintf("tcp://localhost:%v", resource.GetPort("4222/tcp")))
+		return err
+	}))
+	t.Cleanup(func() {
+		natsConn.Close()
+	})
+
+	template := `
+output:
+  nats_jetstream:
+    urls: [ nats://localhost:$PORT ]
+    subject: subject-$ID
+
+input:
+  nats_jetstream:
+    urls: [ nats://localhost:$PORT ]
+    durable: durable-$ID
+    stream: stream-$ID
+    bind: true
+`
+	suite := integration.StreamTests(
+		integration.StreamTestOpenClose(),
+		// integration.StreamTestMetadata(), TODO
+		integration.StreamTestSendBatch(10),
+		integration.StreamTestAtLeastOnceDelivery(), // TODO: SubscribeSync doesn't seem to honor durable setting
+		integration.StreamTestStreamParallel(1000),
+		integration.StreamTestStreamSequential(1000),
+		integration.StreamTestStreamParallelLossy(1000),
+		integration.StreamTestStreamParallelLossyThroughReconnect(1000),
+	)
+	suite.Run(
+		t, template,
+		integration.StreamTestOptPreTest(func(t testing.TB, ctx context.Context, testID string, vars *integration.StreamTestConfigVars) {
+			js, err := natsConn.JetStream()
+			require.NoError(t, err)
+
+			streamName := "stream-" + testID
+
+			_, err = js.AddStream(&nats.StreamConfig{
+				Name:     streamName,
+				Subjects: []string{"subject-" + testID},
+			})
+			require.NoError(t, err)
+
+			_, err = js.AddConsumer(streamName, &nats.ConsumerConfig{
+				Durable:       "durable-" + testID,
+				DeliverPolicy: nats.DeliverAllPolicy,
+				AckPolicy:     nats.AckExplicitPolicy,
+			})
+			require.NoError(t, err)
+		}),
+		integration.StreamTestOptSleepAfterInput(100*time.Millisecond),
+		integration.StreamTestOptSleepAfterOutput(100*time.Millisecond),
+		integration.StreamTestOptPort(resource.GetPort("4222/tcp")),
+	)
+}

--- a/internal/old/input/nats_jetstream.go
+++ b/internal/old/input/nats_jetstream.go
@@ -12,6 +12,8 @@ type NATSJetStreamConfig struct {
 	Subject       string      `json:"subject" yaml:"subject"`
 	Queue         string      `json:"queue" yaml:"queue"`
 	Durable       string      `json:"durable" yaml:"durable"`
+	Stream        string      `json:"stream" yaml:"stream"`
+	Bind          bool        `json:"bind" yaml:"bind"`
 	Deliver       string      `json:"deliver" yaml:"deliver"`
 	AckWait       string      `json:"ack_wait" yaml:"ack_wait"`
 	MaxAckPending int         `json:"max_ack_pending" yaml:"max_ack_pending"`

--- a/internal/template/template.go
+++ b/internal/template/template.go
@@ -187,7 +187,7 @@ func registerInputTemplate(tmpl *compiled, set *bundle.InputSet) error {
 			return nil, err
 		}
 
-		// Tempate processors inserted _before_ configured processors.
+		// Template processors inserted _before_ configured processors.
 		conf.Processors = append(conf.Processors, c.Processors...)
 
 		if tmpl.metricsMapping != nil {

--- a/website/docs/components/inputs/nats_jetstream.md
+++ b/website/docs/components/inputs/nats_jetstream.md
@@ -39,6 +39,8 @@ input:
     queue: ""
     subject: ""
     durable: ""
+    stream: ""
+    bind: false
     deliver: all
 ```
 
@@ -54,6 +56,8 @@ input:
     queue: ""
     subject: ""
     durable: ""
+    stream: ""
+    bind: false
     deliver: all
     ack_wait: 30s
     max_ack_pending: 1024
@@ -161,6 +165,20 @@ Preserve the state of your consumer under a durable name.
 
 
 Type: `string`  
+
+### `stream`
+
+The name of the stream to read from.
+
+
+Type: `string`  
+
+### `bind`
+
+Indicates that subscription should use an existing consumer.
+
+
+Type: `bool`  
 
 ### `deliver`
 


### PR DESCRIPTION
Add support of pull-based JetStream consumers. Example configuration:

```
input:
  label: ""
  nats_jetstream:
    urls:
      - nats://127.0.0.1:4222
    stream: "my-stream"
    durable: "my-consumer"
    bind: true
```