### PR TITLE
Add file output option to Prometheus metrics

### DIFF
--- a/internal/component/metrics/config_prometheus.go
+++ b/internal/component/metrics/config_prometheus.go
@@ -13,6 +13,7 @@ type PrometheusConfig struct {
 	PushBasicAuth      PrometheusPushBasicAuthConfig `json:"push_basic_auth" yaml:"push_basic_auth"`
 	PushInterval       string                        `json:"push_interval" yaml:"push_interval"`
 	PushJobName        string                        `json:"push_job_name" yaml:"push_job_name"`
+	FileOutputPath     string                        `json:"file_output_path" yaml:"file_output_path"`
 }
 
 // PrometheusPushBasicAuthConfig contains parameters for establishing basic
@@ -39,5 +40,6 @@ func NewPrometheusConfig() PrometheusConfig {
 		PushBasicAuth:      NewPrometheusPushBasicAuthConfig(),
 		PushInterval:       "",
 		PushJobName:        "benthos_push",
+		FileOutputPath:     "",
 	}
 }

--- a/internal/impl/prometheus/metrics_prometheus.go
+++ b/internal/impl/prometheus/metrics_prometheus.go
@@ -352,12 +352,12 @@ func (p *prometheusMetrics) GetGaugeVec(path string, labelNames ...string) metri
 	}
 }
 
-func (p *prometheusMetrics) Close() (err error) {
+func (p *prometheusMetrics) Close() error {
 	if atomic.CompareAndSwapInt32(&p.running, 1, 0) {
 		close(p.closedChan)
 	}
 	if p.pusher != nil {
-		err = p.pusher.Push()
+		err := p.pusher.Push()
 		if err != nil {
 			return err
 		}

--- a/internal/impl/prometheus/metrics_prometheus.go
+++ b/internal/impl/prometheus/metrics_prometheus.go
@@ -51,7 +51,7 @@ If the Push Gateway requires HTTP Basic Authentication it can be configured with
 				docs.FieldString("username", "The Basic Authentication username.").HasDefault(""),
 				docs.FieldString("password", "The Basic Authentication password.").HasDefault(""),
 			).Advanced(),
-			docs.FieldString("file_output_path", "An optional file path to write the metrics to.").Advanced().HasDefault(""),
+			docs.FieldString("file_output_path", "Optional file path to a metrics file that should be written.\n").Advanced().HasDefault(""),
 		),
 	})
 }

--- a/internal/impl/prometheus/metrics_prometheus_test.go
+++ b/internal/impl/prometheus/metrics_prometheus_test.go
@@ -4,6 +4,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"testing"
 	"time"
 
@@ -150,8 +151,47 @@ func TestPrometheusHistMetrics(t *testing.T) {
 	nm, err := newPrometheus(conf, log.Noop())
 	require.NoError(t, err)
 
-	handler := nm.HandlerFunc()
+	applyTestMetrics(nm)
 
+	tmr := nm.GetTimer("timerone")
+	tmr.Timing(13)
+	tmrTwo := nm.GetTimerVec("timertwo", "label3", "label4")
+	tmrTwo.With("value4", "value5").Timing(14)
+
+	handler := nm.HandlerFunc()
+	body := getPage(t, handler)
+
+	assertContainsTestMetrics(t, body)
+	assert.Contains(t, body, "\ntimerone_sum 1.3e-08")
+	assert.Contains(t, body, "\ntimertwo_sum{label3=\"value4\",label4=\"value5\"} 1.4e-08")
+}
+
+func TestPrometheusWithFileOutputPath(t *testing.T) {
+	config := metrics.NewConfig()
+	config.Prometheus.FileOutputPath = os.TempDir() + "/benthos_metrics.prom"
+
+	defer os.Remove(config.Prometheus.FileOutputPath)
+
+	p, err := newPrometheus(config, log.Noop())
+	applyTestMetrics(p)
+
+	assert.NoError(t, err)
+	assert.NotNil(t, p)
+	assert.Nil(t, p.(*prometheusMetrics).pusher)
+	assert.Equal(t, config.Prometheus.FileOutputPath, p.(*prometheusMetrics).fileOutputPath)
+
+	err = p.Close()
+	assert.NoError(t, err)
+
+	assert.FileExists(t, config.Prometheus.FileOutputPath)
+	file, err := os.ReadFile(config.Prometheus.FileOutputPath)
+	assert.NoError(t, err)
+	assert.NotEmpty(t, file)
+
+	assertContainsTestMetrics(t, string(file))
+}
+
+func applyTestMetrics(nm metrics.Type) {
 	ctr := nm.GetCounter("counterone")
 	ctr.Incr(10)
 	ctr.Incr(11)
@@ -159,26 +199,18 @@ func TestPrometheusHistMetrics(t *testing.T) {
 	gge := nm.GetGauge("gaugeone")
 	gge.Set(12)
 
-	tmr := nm.GetTimer("timerone")
-	tmr.Timing(13)
-
 	ctrTwo := nm.GetCounterVec("countertwo", "label1")
 	ctrTwo.With("value1").Incr(10)
 	ctrTwo.With("value2").Incr(11)
 
 	ggeTwo := nm.GetGaugeVec("gaugetwo", "label2")
 	ggeTwo.With("value3").Set(12)
+}
 
-	tmrTwo := nm.GetTimerVec("timertwo", "label3", "label4")
-	tmrTwo.With("value4", "value5").Timing(14)
-
-	body := getPage(t, handler)
-
+func assertContainsTestMetrics(t *testing.T, body string) {
 	assert.Contains(t, body, "\ncounterone 21")
 	assert.Contains(t, body, "\ngaugeone 12")
-	assert.Contains(t, body, "\ntimerone_sum 1.3e-08")
 	assert.Contains(t, body, "\ncountertwo{label1=\"value1\"} 10")
 	assert.Contains(t, body, "\ncountertwo{label1=\"value2\"} 11")
 	assert.Contains(t, body, "\ngaugetwo{label2=\"value3\"} 12")
-	assert.Contains(t, body, "\ntimertwo_sum{label3=\"value4\",label4=\"value5\"} 1.4e-08")
 }

--- a/website/docs/components/metrics/prometheus.md
+++ b/website/docs/components/metrics/prometheus.md
@@ -143,7 +143,7 @@ Default: `""`
 
 ### `file_output_path`
 
-File path to a metrics file that should be written as an alternative or addition to the push gateway.
+Optional file path to a metrics file that should be written.
 
 
 Type: `string`  
@@ -161,3 +161,4 @@ include the "/metrics/jobs/..." path in the push URL.
 
 If the Push Gateway requires HTTP Basic Authentication it can be configured with
 `push_basic_auth`.
+

--- a/website/docs/components/metrics/prometheus.md
+++ b/website/docs/components/metrics/prometheus.md
@@ -49,6 +49,7 @@ metrics:
     push_basic_auth:
       username: ""
       password: ""
+    file_output_path: ""
   mapping: ""
 ```
 
@@ -140,6 +141,14 @@ The Basic Authentication password.
 Type: `string`  
 Default: `""`  
 
+### `file_output_path`
+
+File path to a metrics file that should be written as an alternative or addition to the push gateway.
+
+
+Type: `string`  
+Default: `""`  
+
 ## Push Gateway
 
 The field `push_url` is optional and when set will trigger a push of
@@ -152,4 +161,3 @@ include the "/metrics/jobs/..." path in the push URL.
 
 If the Push Gateway requires HTTP Basic Authentication it can be configured with
 `push_basic_auth`.
-


### PR DESCRIPTION
We're currently locked in some legacy windows infrastructure where the connection to a Prometheus push gateway is not possible without a lot of effort and also fetching from that server via HTTP is an issue due to security concerns.

This PR should mainly be a proof of concept to have an option to send the metrics to a file instead of a gateway or serving it via HTTP.

Unfortunately it is not possible to adapt or extend the metrics handling within our project as the metrics part is under `internal`. Maybe it could be an idea for an upcoming version to add the metrics to the public API, so we're able to implement our own metrics handler, similar to other components?

Would be nice if you could provide some feedback on whether you think this feature is useful and can be integrated without a major version increase.