### PR TITLE
aws_sqs input - Add max_number_of_messages param in order to better integrate with fifo queues

### DIFF
--- a/internal/old/input/aws_sqs.go
+++ b/internal/old/input/aws_sqs.go
@@ -63,6 +63,7 @@ You can access these metadata fields using
 			docs.FieldCommon("url", "The SQS URL to consume from."),
 			docs.FieldAdvanced("delete_message", "Whether to delete the consumed message once it is acked. Disabling allows you to handle the deletion using a different mechanism."),
 			docs.FieldAdvanced("reset_visibility", "Whether to set the visibility timeout of the consumed message to zero once it is nacked. Disabling honors the preset visibility timeout specified for the queue.").AtVersion("3.58.0"),
+			docs.FieldAdvanced("max_number_of_messages", "The maximum number of messages to return on one poll. Valid values: 1 to 10."),
 		}, sess.FieldSpecs()...),
 		Categories: []Category{
 			CategoryServices,

--- a/website/docs/components/inputs/aws_sqs.md
+++ b/website/docs/components/inputs/aws_sqs.md
@@ -45,6 +45,7 @@ input:
     url: ""
     delete_message: true
     reset_visibility: true
+    max_number_of_messages: 10
     region: ""
     endpoint: ""
     credentials:
@@ -106,6 +107,14 @@ Whether to set the visibility timeout of the consumed message to zero once it is
 Type: `bool`  
 Default: `true`  
 Requires version 3.58.0 or newer  
+
+### `max_number_of_messages`
+
+The maximum number of messages to return on one poll. Valid values: 1 to 10.
+
+
+Type: `int`  
+Default: `10`  
 
 ### `region`
 


### PR DESCRIPTION
Currently when benthos's aws_sqs input module calls [receiveMessage](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_ReceiveMessage.html), it passes in the maximum number of messages allowed to be pulled at once: 10
This increases the efficiency of most queues but it can lead to some weird edge case behavior around fifo queues leading to a situation where the messages are not processed in order if the consumer of the queue responds with a nack. The only way to guarantee that is to only pull 1 message at a time.

This PR makes the number of messages pulled extendable by adding a param of "max_number_of_messages"

I noticed that there were a scattering of `10s` across the code and from my reading they seem to align with the number of messages inflight (number of messages pulled at once), so I modified those to match the new specified maxNumberOfMessages.