### PR TITLE
Set the lazy quotes field for a csv reader in the constructor

### DIFF
--- a/internal/codec/reader.go
+++ b/internal/codec/reader.go
@@ -214,7 +214,7 @@ func partReader(codec string, conf ReaderConfig) (ReaderConstructor, bool, error
 		}, true, nil
 	case "csv":
 		return func(path string, r io.ReadCloser, fn ReaderAckFn) (Reader, error) {
-			return newCSVReader(r, fn, nil)
+			return newCSVReader(r, fn, nil, nil)
 		}, true, nil
 	case "tar":
 		return newTarReader, true, nil
@@ -239,7 +239,7 @@ func partReader(codec string, conf ReaderConfig) (ReaderConstructor, bool, error
 		}
 		byRune := byRunes[0]
 		return func(path string, r io.ReadCloser, fn ReaderAckFn) (Reader, error) {
-			return newCSVReader(r, fn, &byRune)
+			return newCSVReader(r, fn, &byRune, nil)
 		}, true, nil
 	}
 	if strings.HasPrefix(codec, "chunker:") {
@@ -426,11 +426,15 @@ type csvReader struct {
 	pending  int32
 }
 
-func newCSVReader(r io.ReadCloser, ackFn ReaderAckFn, customComma *rune) (Reader, error) {
+func newCSVReader(r io.ReadCloser, ackFn ReaderAckFn, customComma *rune, lazyQuotes *bool) (Reader, error) {
 	scanner := csv.NewReader(r)
 	scanner.ReuseRecord = true
 	if customComma != nil {
 		scanner.Comma = *customComma
+	}
+
+	if lazyQuotes != nil {
+		scanner.LazyQuotes = *lazyQuotes
 	}
 
 	headers, err := scanner.Read()


### PR DESCRIPTION
https://github.com/benthosdev/benthos/issues/1038

Rough draft implementation, but it seems to follow their current pattern of how they configure their `csvReader` type (looking at how the `customComma` field is set)