### PR TITLE
added regex_pattern support to kafka_franz input

### DIFF
--- a/internal/impl/kafka/input_kafka_franz.go
+++ b/internal/impl/kafka/input_kafka_franz.go
@@ -97,7 +97,7 @@ type franzKafkaReader struct {
 	tlsConf         *tls.Config
 	saslConfs       []sasl.Mechanism
 	checkpointLimit int
-	regex_pattern   bool
+	regexPattern    bool
 
 	msgChan atomic.Value
 	log     *service.Logger
@@ -135,7 +135,7 @@ func newFranzKafkaReaderFromConfig(conf *service.ParsedConfig, log *service.Logg
 		f.topics = append(f.topics, strings.Split(t, ",")...)
 	}
 
-	if f.regex_pattern, err = conf.FieldBool("regex_pattern"); err != nil {
+	if f.regexPattern, err = conf.FieldBool("regex_pattern"); err != nil {
 		return nil, err
 	}
 
@@ -307,7 +307,7 @@ func (f *franzKafkaReader) Connect(ctx context.Context) error {
 		clientOpts = append(clientOpts, kgo.DialTLSConfig(f.tlsConf))
 	}
 
-	if f.regex_pattern {
+	if f.regexPattern {
 		clientOpts = append(clientOpts, kgo.ConsumeRegex())
 	}
 

--- a/website/docs/components/inputs/kafka_franz.md
+++ b/website/docs/components/inputs/kafka_franz.md
@@ -36,9 +36,9 @@ input:
   label: ""
   kafka_franz:
     seed_brokers: []
+    regex_pattern: false
     topics: []
     consumer_group: ""
-    regex_pattern: 0
 ```
 
 </TabItem>
@@ -50,10 +50,10 @@ input:
   label: ""
   kafka_franz:
     seed_brokers: []
+    regex_pattern: false
     topics: []
     consumer_group: ""
     checkpoint_limit: 1024
-    regex_pattern: 0
     tls:
       enabled: false
       skip_cert_verify: false
@@ -112,6 +112,14 @@ seed_brokers:
 seed_brokers:
   - foo:9092,bar:9092
 ```
+
+### `regex_pattern`
+
+An indicator that makes franz use regex pattern in topics.
+
+
+Type: `int`  
+Default: `false`  
 
 ### `topics`
 

--- a/website/docs/components/inputs/kafka_franz.md
+++ b/website/docs/components/inputs/kafka_franz.md
@@ -38,6 +38,7 @@ input:
     seed_brokers: []
     topics: []
     consumer_group: ""
+    regex_pattern: 0
 ```
 
 </TabItem>
@@ -52,6 +53,7 @@ input:
     topics: []
     consumer_group: ""
     checkpoint_limit: 1024
+    regex_pattern: 0
     tls:
       enabled: false
       skip_cert_verify: false
@@ -83,6 +85,7 @@ This input adds the following metadata fields to each message:
 - kafka_partition
 - kafka_offset
 - kafka_timestamp_unix
+- regex_pattern
 - All record headers
 ```
 


### PR DESCRIPTION
Added support of regex pattern with **kafka_franz** by adding regex_pattern indicator to configuration and set ConsumeRegex flag on consumer creation. consumer group will have in this case all topics that include add match topics.

This is usefully when  topics are based on some pattern and you don't need to statically supply all the list of topics needed
for example:

topic_a
topic_b
topic_c

If you need to consume them all into the same pipeline add the following pattern: [ topic_(.*) ]   
Tested locally