### PR TITLE
add `mod_time` metadata to `file` input

### DIFF
--- a/internal/old/input/file.go
+++ b/internal/old/input/file.go
@@ -200,15 +200,17 @@ func (f *fileConsumer) ReadWithContext(ctx context.Context) (*message.Batch, rea
 
 		msg := message.QuickBatch(nil)
 		for _, part := range parts {
-			if len(part.Get()) > 0 {
-				part.MetaSet("path", currentPath)
-
-				modTimeUnix, modTime := f.getModTime(currentPath)
-				part.MetaSet("mod_time_unix", modTimeUnix)
-				part.MetaSet("mod_time", modTime)
-
-				msg.Append(part)
+			if len(part.Get()) == 0 {
+				continue
 			}
+
+			part.MetaSet("path", currentPath)
+
+			modTimeUnix, modTime := f.getModTime(currentPath)
+			part.MetaSet("mod_time_unix", modTimeUnix)
+			part.MetaSet("mod_time", modTime)
+
+			msg.Append(part)
 		}
 		if msg.Len() == 0 {
 			_ = codecAckFn(ctx, nil)

--- a/internal/old/input/file.go
+++ b/internal/old/input/file.go
@@ -198,6 +198,8 @@ func (f *fileConsumer) ReadWithContext(ctx context.Context) (*message.Batch, rea
 			return nil, nil, err
 		}
 
+		modTimeUnix, modTime := f.getModTime(currentPath)
+
 		msg := message.QuickBatch(nil)
 		for _, part := range parts {
 			if len(part.Get()) == 0 {
@@ -205,8 +207,6 @@ func (f *fileConsumer) ReadWithContext(ctx context.Context) (*message.Batch, rea
 			}
 
 			part.MetaSet("path", currentPath)
-
-			modTimeUnix, modTime := f.getModTime(currentPath)
 			part.MetaSet("mod_time_unix", modTimeUnix)
 			part.MetaSet("mod_time", modTime)
 

--- a/internal/old/input/file.go
+++ b/internal/old/input/file.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"io"
 	"os"
+	"strconv"
 	"sync"
 	"time"
 
@@ -40,6 +41,8 @@ This input adds the following metadata fields to each message:
 
 ` + "```text" + `
 - path
+- mod_time_unix
+- mod_time (RFC3339)
 ` + "```" + `
 
 You can access these metadata fields using
@@ -199,6 +202,11 @@ func (f *fileConsumer) ReadWithContext(ctx context.Context) (*message.Batch, rea
 		for _, part := range parts {
 			if len(part.Get()) > 0 {
 				part.MetaSet("path", currentPath)
+
+				modTimeUnix, modTime := f.getModTime(currentPath)
+				part.MetaSet("mod_time_unix", modTimeUnix)
+				part.MetaSet("mod_time", modTime)
+
 				msg.Append(part)
 			}
 		}
@@ -230,4 +238,17 @@ func (f *fileConsumer) CloseAsync() {
 // timeout occurs.
 func (f *fileConsumer) WaitForClose(time.Duration) error {
 	return nil
+}
+
+func (f *fileConsumer) getModTime(currentPath string) (modTimeUnix, modTime string) {
+	fileInfo, err := os.Stat(currentPath)
+	if err == nil {
+		utcModTime := fileInfo.ModTime().UTC()
+		modTimeUnix = strconv.Itoa(int(utcModTime.Unix()))
+		modTime = utcModTime.Format(time.RFC3339)
+	} else {
+		f.log.Errorf("Failed to read metadata from file '%v'\n", currentPath)
+	}
+
+	return modTimeUnix, modTime
 }

--- a/website/docs/components/inputs/file.md
+++ b/website/docs/components/inputs/file.md
@@ -58,6 +58,8 @@ This input adds the following metadata fields to each message:
 
 ```text
 - path
+- mod_time_unix
+- mod_time (RFC3339)
 ```
 
 You can access these metadata fields using


### PR DESCRIPTION
Similar to i.e. the `aws_s3` input, the `file` input could also provide some more metadata provided via `os.FileInfo`.

In the first step, this includes `mod_time` and `mod_time_unix`. I could also add `size` but wasn't sure if that's desired or helpful as it just reflects `msg.Len()` or `len(part.Get())`.

Our project would heavily benefit from this as we filter files by modification time. We're currently using a custom input for that but we could get rid of it if that metadata would be available by default.

Let me know what you think 😉 