### PR TITLE
Fix: bloblang triple quote string parser

### DIFF
--- a/internal/bloblang/parser/combinators.go
+++ b/internal/bloblang/parser/combinators.go
@@ -408,7 +408,7 @@ func TripleQuoteString() Func {
 			input[2] != '"' {
 			return Fail(NewError(input, "quoted string"), input)
 		}
-		for i := 2; i < len(input)-2; i++ {
+		for i := 3; i < len(input)-2; i++ {
 			if input[i] == '"' &&
 				input[i+1] == '"' &&
 				input[i+2] == '"' {

--- a/internal/bloblang/parser/combinators_test.go
+++ b/internal/bloblang/parser/combinators_test.go
@@ -1454,6 +1454,11 @@ baz`,
 			remaining: `"""foo\"bar\"baz and this`,
 			err:       NewFatalError([]rune(``), errors.New("required"), "end triple-quote"),
 		},
+		"unfinished end quotes": {
+			input:     `"""""0`,
+			remaining: `"""""0`,
+			err:       NewFatalError([]rune(``), errors.New("required"), "end triple-quote"),
+		},
 	}
 
 	for name, test := range tests {


### PR DESCRIPTION
During some fuzz testing of the bloblang parser, I believe a found a bug in the `TripleQuoteParser`, which can cause a panic.

This adds a test which provokes the panic, and a fix to the array bounds in the parser. 