### PR TITLE
Add "unknown" type for templates.

### DIFF
--- a/internal/template/config.go
+++ b/internal/template/config.go
@@ -211,8 +211,12 @@ func FieldConfigSpec() docs.FieldSpecs {
 	return docs.FieldSpecs{
 		docs.FieldString("name", "The name of the field."),
 		docs.FieldString("description", "A description of the field.").HasDefault(""),
-		docs.FieldString("type", "The scalar type of the field.").HasOptions(
-			"string", "int", "float", "bool",
+		docs.FieldString("type", "The scalar type of the field.").HasAnnotatedOptions(
+			"string", "standard string type",
+			"int", "standard integer type",
+			"float", "standard float type",
+			"bool", "a boolean true/false",
+			"unknown", "allows for nesting arbitrary configuration inside of a field",
 		),
 		docs.FieldString("kind", "The kind of the field.").HasOptions(
 			"scalar", "map", "list",

--- a/template/test/dead_letter.yaml
+++ b/template/test/dead_letter.yaml
@@ -1,0 +1,43 @@
+name: dead_letter
+type: output
+status: experimental
+categories: [Utility]
+summary: Route to a dead letter queue on output failure
+fields:
+  - name: max_retries
+    description: Max times to try before routing to the dead letter
+    type: int
+  - name: output
+    description: Regular output to route messages to.
+    type: unknown
+  - name: path
+    description: file to save undeliverable messages to
+    type: string
+mapping: |
+  root.fallback = []
+
+  # Regular Output
+  root.fallback."-".retry.max_retries = this.max_retries
+  root.fallback."0".retry.output = this.output
+
+  # Dead Letter Output
+  root.fallback."-".file.path = this.path
+  root.fallback."1".file.codec = "lines"
+tests:
+  - name: Basic Unknown
+    config:
+      max_retries: 5
+      output:
+        http_client:
+          url: http://localhost:0
+      path: dead.log
+    expected:
+      fallback:
+        - retry:
+            max_retries: 5
+            output:
+              http_client:
+                url: http://localhost:0
+        - file:
+            path: dead.log
+            codec: lines

--- a/website/docs/configuration/templating.md
+++ b/website/docs/configuration/templating.md
@@ -187,7 +187,15 @@ The scalar type of the field.
 
 
 Type: `string`  
-Options: `string`, `int`, `float`, `bool`.
+
+| Option | Summary |
+|---|---|
+| `string` | standard string type |
+| `int` | standard integer type |
+| `float` | standard float type |
+| `bool` | a boolean true/false |
+| `unknown` | allows for nesting arbitrary configuration inside of a field |
+
 
 ### `fields[].kind`
 


### PR DESCRIPTION
This allows us to nest arbitrary config in a template. This a result of a [chat](https://discord.com/channels/746368194196799589/754099840354615296/963908094126096435) in Discord.