### PR TITLE
Allow to specify headers in JWT tokens

### DIFF
--- a/internal/http/docs/auth/docs.go
+++ b/internal/http/docs/auth/docs.go
@@ -84,6 +84,10 @@ func jwtFieldSpec() docs.FieldSpec {
 		docs.FieldAnything(
 			"claims", "A value used to identify the claims that issued the JWT.",
 		).Map().Advanced(),
+
+		docs.FieldAnything(
+			"headers", "A value used to identify the header that should be included in the JWT.",
+		).Map().Advanced(),
 	)
 }
 

--- a/website/docs/components/inputs/http_client.md
+++ b/website/docs/components/inputs/http_client.md
@@ -76,6 +76,7 @@ input:
       private_key_file: ""
       signing_method: ""
       claims: {}
+      headers: {}
     basic_auth:
       enabled: false
       username: ""
@@ -379,6 +380,14 @@ Default: `""`
 ### `jwt.claims`
 
 A value used to identify the claims that issued the JWT.
+
+
+Type: `object`  
+Default: `{}`  
+
+### `jwt.headers`
+
+A value used to identify the header that should be included in the JWT.
 
 
 Type: `object`  

--- a/website/docs/components/inputs/websocket.md
+++ b/website/docs/components/inputs/websocket.md
@@ -66,6 +66,7 @@ input:
       private_key_file: ""
       signing_method: ""
       claims: {}
+      headers: {}
 ```
 
 </TabItem>
@@ -326,6 +327,14 @@ Default: `""`
 ### `jwt.claims`
 
 A value used to identify the claims that issued the JWT.
+
+
+Type: `object`  
+Default: `{}`  
+
+### `jwt.headers`
+
+A value used to identify the header that should be included in the JWT.
 
 
 Type: `object`  

--- a/website/docs/components/outputs/http_client.md
+++ b/website/docs/components/outputs/http_client.md
@@ -77,6 +77,7 @@ output:
       private_key_file: ""
       signing_method: ""
       claims: {}
+      headers: {}
     basic_auth:
       enabled: false
       username: ""
@@ -366,6 +367,14 @@ Default: `""`
 ### `jwt.claims`
 
 A value used to identify the claims that issued the JWT.
+
+
+Type: `object`  
+Default: `{}`  
+
+### `jwt.headers`
+
+A value used to identify the header that should be included in the JWT.
 
 
 Type: `object`  

--- a/website/docs/components/outputs/websocket.md
+++ b/website/docs/components/outputs/websocket.md
@@ -65,6 +65,7 @@ output:
       private_key_file: ""
       signing_method: ""
       claims: {}
+      headers: {}
 ```
 
 </TabItem>
@@ -307,6 +308,14 @@ Default: `""`
 ### `jwt.claims`
 
 A value used to identify the claims that issued the JWT.
+
+
+Type: `object`  
+Default: `{}`  
+
+### `jwt.headers`
+
+A value used to identify the header that should be included in the JWT.
 
 
 Type: `object`  

--- a/website/docs/components/processors/http.md
+++ b/website/docs/components/processors/http.md
@@ -71,6 +71,7 @@ http:
     private_key_file: ""
     signing_method: ""
     claims: {}
+    headers: {}
   basic_auth:
     enabled: false
     username: ""
@@ -387,6 +388,14 @@ Default: `""`
 ### `jwt.claims`
 
 A value used to identify the claims that issued the JWT.
+
+
+Type: `object`  
+Default: `{}`  
+
+### `jwt.headers`
+
+A value used to identify the header that should be included in the JWT.
 
 
 Type: `object`  


### PR DESCRIPTION
Allow to add custom headers into JWT token.

When we try to access to google services using [JWT Auth](https://developers.google.com/identity/protocols/oauth2/service-account#jwt-auth) we need to specify the `kid` as header. At the moment is not possible to specify headers into JWT token.

Relevant informations
 - The JWT token from the original library [expose Headers property](https://github.com/dgrijalva/jwt-go/blob/v3.2.0/token.go#L23-L30)
 -  As suggested [here](https://github.com/dgrijalva/jwt-go/issues/198) to inject header the token heed to be manipulated (there aren't factory method or object methods that will allow to manipulate headers)