### PR TITLE
Add LazyQuotes parameter to CSV input

### DIFF
--- a/website/docs/components/inputs/csv.md
+++ b/website/docs/components/inputs/csv.md
@@ -33,6 +33,7 @@ input:
     paths: []
     parse_header_row: true
     delimiter: ','
+    lazy_quotes: false
 ```
 
 </TabItem>
@@ -47,6 +48,7 @@ input:
     parse_header_row: true
     delimiter: ','
     batch_count: 1
+    lazy_quotes: false
 ```
 
 </TabItem>
@@ -118,6 +120,14 @@ Optionally process records in batches. This can help to speed up the consumption
 
 Type: `int`  
 Default: `1`  
+
+### `lazy_quotes`
+
+If LazyQuotes is true, a quote may appear in an unquoted field and a non-doubled quote may appear in a quoted field.
+
+
+Type: `bool`  
+Default: `false`  
 
 This input is particularly useful when consuming CSV from files too large to
 parse entirely within memory. However, in cases where CSV is consumed from other


### PR DESCRIPTION
Fixes #1038 

Maybe the file input [codec](https://www.benthos.dev/docs/components/inputs/file#codec) should be adjusted to take this parameter in a future PR, as well a codec option to set `parse_header_row` in order to read in CSV files with no header row.