### PR TITLE
support setting job labels on `gcp_bigquery` output

### DIFF
--- a/internal/impl/gcp/output_bigquery.go
+++ b/internal/impl/gcp/output_bigquery.go
@@ -58,6 +58,7 @@ type gcpBigQueryOutputConfig struct {
 	AutoDetect          bool
 	IgnoreUnknownValues bool
 	MaxBadRecords       int
+	JobLabels           map[string]string
 
 	// CSV options
 	CSVOptions gcpBigQueryCSVConfig
@@ -92,6 +93,9 @@ func gcpBigQueryOutputConfigFromParsed(conf *service.ParsedConfig) (gconf gcpBig
 		return
 	}
 	if gconf.AutoDetect, err = conf.FieldBool("auto_detect"); err != nil {
+		return
+	}
+	if gconf.JobLabels, err = conf.FieldStringMap("job_labels"); err != nil {
 		return
 	}
 	if gconf.CSVOptions, err = gcpBigQueryCSVConfigFromParsed(conf.Namespace("csv")); err != nil {
@@ -180,6 +184,7 @@ For the CSV format when the field `+"`csv.header`"+` is specified a header row w
 			Description("Indicates if we should automatically infer the options and schema for CSV and JSON sources. If the table doesn't exist and this field is set to `false` the output may not be able to insert data and will throw insertion error. Be careful using this field since it delegates to the GCP BigQuery service the schema detection and values like `\"no\"` may be treated as booleans for the CSV format.").
 			Advanced().
 			Default(false)).
+		Field(service.NewStringMapField("job_labels").Description("A list of labels to add to the load job.").Default(map[string]string{})).
 		Field(service.NewObjectField("csv",
 			service.NewStringListField("header").
 				Description("A list of values to use as header for each batch of messages. If not specified the first line of each message will be used as header.").
@@ -404,6 +409,7 @@ func (g *gcpBigQueryOutput) createTableLoader(data *[]byte) *bigquery.Loader {
 
 	loader.CreateDisposition = bigquery.TableCreateDisposition(g.conf.CreateDisposition)
 	loader.WriteDisposition = bigquery.TableWriteDisposition(g.conf.WriteDisposition)
+	loader.Labels = g.conf.JobLabels
 
 	return loader
 }

--- a/website/docs/components/outputs/gcp_bigquery.md
+++ b/website/docs/components/outputs/gcp_bigquery.md
@@ -40,6 +40,7 @@ output:
     table: ""
     format: NEWLINE_DELIMITED_JSON
     max_in_flight: 64
+    job_labels: {}
     csv:
       header: []
       field_delimiter: ','
@@ -68,6 +69,7 @@ output:
     ignore_unknown_values: false
     max_bad_records: 0
     auto_detect: false
+    job_labels: {}
     csv:
       header: []
       field_delimiter: ','
@@ -213,6 +215,14 @@ Indicates if we should automatically infer the options and schema for CSV and JS
 
 Type: `bool`  
 Default: `false`  
+
+### `job_labels`
+
+A list of labels to add to the load job.
+
+
+Type: `object`  
+Default: `{}`  
 
 ### `csv`
 


### PR DESCRIPTION
This change adds a config field on the `gcp_bigquery` output that can be used to attach labels to BigQuery load jobs created by this output.