### PR TITLE
Add support for headers in the `nats_jetstream` component

### DIFF
--- a/internal/impl/nats/input_jetstream.go
+++ b/internal/impl/nats/input_jetstream.go
@@ -373,6 +373,12 @@ func (j *jetStreamReader) Close(ctx context.Context) error {
 func convertMessage(m *nats.Msg) (*service.Message, service.AckFunc, error) {
 	msg := service.NewMessage(m.Data)
 	msg.MetaSet("nats_subject", m.Subject)
+	for k := range m.Header {
+		v := m.Header.Get(k)
+		if v != "" {
+			msg.MetaSet(k, v)
+		}
+	}
 
 	return msg, func(ctx context.Context, res error) error {
 		if res == nil {

--- a/internal/impl/nats/output_jetstream.go
+++ b/internal/impl/nats/output_jetstream.go
@@ -30,6 +30,13 @@ func natsJetStreamOutputConfig() *service.ConfigSpec {
 			Example("foo.bar.baz").
 			Example(`${! meta("kafka_topic") }`).
 			Example(`foo.${! json("meta.type") }`)).
+		Field(service.NewInterpolatedStringMapField("headers").
+			Description("Explicit message headers to add to messages.").
+			Default(map[string]interface{}{}).
+			Example(map[string]interface{}{
+				"Content-Type": "application/json",
+				"Timestamp":    `${!meta("Timestamp")}`,
+			})).
 		Field(service.NewIntField("max_in_flight").
 			Description("The maximum number of messages to have in flight at a given time. Increase this to improve throughput.").
 			Default(1024)).
@@ -60,6 +67,8 @@ type jetStreamOutput struct {
 	urls          string
 	subjectStrRaw string
 	subjectStr    *service.InterpolatedString
+	headersRaw    map[string]string
+	headers       map[string]*service.InterpolatedString
 	authConf      auth.Config
 	tlsConf       *tls.Config
 
@@ -89,6 +98,14 @@ func newJetStreamWriterFromConfig(conf *service.ParsedConfig, log *service.Logge
 	}
 
 	if j.subjectStr, err = conf.FieldInterpolatedString("subject"); err != nil {
+		return nil, err
+	}
+
+	if j.headersRaw, err = conf.FieldStringMap("headers"); err != nil {
+		return nil, err
+	}
+
+	if j.headers, err = conf.FieldInterpolatedStringMap("headers"); err != nil {
 		return nil, err
 	}
 
@@ -167,13 +184,17 @@ func (j *jetStreamOutput) Write(ctx context.Context, msg *service.Message) error
 		return service.ErrNotConnected
 	}
 
-	subject := j.subjectStr.String(msg)
+	jsmsg := nats.NewMsg(j.subjectStr.String(msg))
 	msgBytes, err := msg.AsBytes()
 	if err != nil {
 		return err
 	}
+	jsmsg.Data = msgBytes
+	for k, v := range j.headers {
+		jsmsg.Header.Add(k, v.String(msg))
+	}
 
-	_, err = jCtx.Publish(subject, msgBytes)
+	_, err = jCtx.PublishMsg(jsmsg)
 	return err
 }
 

--- a/internal/impl/nats/output_jetstream_test.go
+++ b/internal/impl/nats/output_jetstream_test.go
@@ -16,6 +16,9 @@ func TestOutputJetStreamConfigParse(t *testing.T) {
 	outputConfig := `
 urls: [ url1, url2 ]
 subject: testsubject
+headers:
+  Content-Type: application/json
+  Timestamp: ${!meta("Timestamp")}
 auth:
   nkey_file: test auth n key file
   user_credentials_file: test auth user creds file
@@ -27,8 +30,12 @@ auth:
 	e, err := newJetStreamWriterFromConfig(conf, nil)
 	require.NoError(t, err)
 
+	msg := service.NewMessage((nil))
+	msg.MetaSet("Timestamp", "1651485106")
 	assert.Equal(t, "url1,url2", e.urls)
-	assert.Equal(t, "testsubject", e.subjectStr.String(service.NewMessage(nil)))
+	assert.Equal(t, "testsubject", e.subjectStr.String(msg))
+	assert.Equal(t, "application/json", e.headers["Content-Type"].String(msg))
+	assert.Equal(t, "1651485106", e.headers["Timestamp"].String(msg))
 	assert.Equal(t, "test auth n key file", e.authConf.NKeyFile)
 	assert.Equal(t, "test auth user creds file", e.authConf.UserCredentialsFile)
 }

--- a/website/docs/components/outputs/nats_jetstream.md
+++ b/website/docs/components/outputs/nats_jetstream.md
@@ -37,6 +37,7 @@ output:
   nats_jetstream:
     urls: []
     subject: ""
+    headers: {}
     max_in_flight: 1024
 ```
 
@@ -50,6 +51,7 @@ output:
   nats_jetstream:
     urls: []
     subject: ""
+    headers: {}
     max_in_flight: 1024
     tls:
       enabled: false
@@ -128,6 +130,23 @@ subject: foo.bar.baz
 subject: ${! meta("kafka_topic") }
 
 subject: foo.${! json("meta.type") }
+```
+
+### `headers`
+
+Explicit message headers to add to messages.
+This field supports [interpolation functions](/docs/configuration/interpolation#bloblang-queries).
+
+
+Type: `object`  
+Default: `{}`  
+
+```yml
+# Examples
+
+headers:
+  Content-Type: application/json
+  Timestamp: ${!meta("Timestamp")}
 ```
 
 ### `max_in_flight`


### PR DESCRIPTION
Fixes #1238

These 3 commits:

1. add headers support in input
2. add support for a new InterpolatedStringMap configuration
3. add headers support in output

Please don't hesitate to comment.