### PR TITLE
Add Basic Auth Support

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -107,6 +107,10 @@ func New(
 		}
 	}
 
+	if err := conf.BasicAuth.Validate(); err != nil {
+		return nil, err
+	}
+
 	t := &Type{
 		conf:      conf,
 		endpoints: map[string]string{},

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -30,19 +30,19 @@ type Config struct {
 	CertFile       string              `json:"cert_file" yaml:"cert_file"`
 	KeyFile        string              `json:"key_file" yaml:"key_file"`
 	CORS           httpdocs.ServerCORS `json:"cors" yaml:"cors"`
-	BasicAuth      *basicAuth          `json:"basic_auth" yaml:"basic_auth"`
+	BasicAuth      *BasicAuth          `json:"basic_auth" yaml:"basic_auth"`
 }
 
-type basicAuth struct {
+type BasicAuth struct {
 	Username string `json:"username" yaml:"username"`
 	Password string `json:"password" yaml:"password"`
 }
 
-func (b *basicAuth) Enabled() bool {
+func (b *BasicAuth) Enabled() bool {
 	return b.Username != "" && b.Password != ""
 }
 
-func (b *basicAuth) Matches(user, pass string) bool {
+func (b *BasicAuth) Matches(user, pass string) bool {
 	userHash := sha256.Sum256([]byte(user))
 	passHash := sha256.Sum256([]byte(pass))
 	expectedUserHash := sha256.Sum256([]byte(b.Username))
@@ -64,7 +64,7 @@ func NewConfig() Config {
 		CertFile:       "",
 		KeyFile:        "",
 		CORS:           httpdocs.NewServerCORS(),
-		BasicAuth: &basicAuth{
+		BasicAuth: &BasicAuth{
 			Username: "",
 			Password: "",
 		},
@@ -283,7 +283,7 @@ func (t *Type) RegisterEndpoint(path, desc string, handlerFunc http.HandlerFunc)
 		}
 
 		if t.conf.BasicAuth.Enabled() {
-			wrapHandler = func(next http.HandlerFunc, auth *basicAuth) http.HandlerFunc {
+			wrapHandler = func(next http.HandlerFunc, auth *BasicAuth) http.HandlerFunc {
 				return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 					user, pass, ok := r.BasicAuth()
 					if !(ok && auth.Matches(user, pass)) {

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -87,25 +87,83 @@ func TestAPIEnableCORSNoHeaders(t *testing.T) {
 }
 
 func TestAPIBasicAuth(t *testing.T) {
-	conf := api.NewConfig()
-	conf.BasicAuth.Username = "myuser"
-	conf.BasicAuth.Password = "secret"
+	secret256 := "K7gNU3sdo+OL0wNhqoVWhr3g6s1xYv72ol/pe/Unols="
+	secretMD5 := "Xr4ilOzQ4PCOq3aQ0qbuaQ=="
+	secretBcrypt := "JDJhJDEwJHRDMWs2NHc5VjA0R3JIdEE2QzQ2SC5na3o3WWNUUWlQc1RNbVNCUU8yOG8uSWg4YUUvaUcu"
+	secretScrypt := "eJ01V0+YCJxHraokLp79ijKS0z1jzVQ3vFtGx5UEEiY="
+	type testCase struct {
+		name         string
+		enabled      bool
+		algorithm    string
+		correctUser  string
+		correctPass  string
+		givenUser    string
+		givenPass    string
+		expectedErr  assert.ErrorAssertionFunc
+		expectedCode int
+	}
 
-	s, err := api.New("", "", conf, nil, log.Noop(), metrics.Noop())
-	require.NoError(t, err)
+	tests := []testCase{
+		{name: "validAuth", enabled: true, algorithm: "sha256",
+			correctUser: "myuser", correctPass: secret256,
+			givenUser: "myuser", givenPass: "secret",
+			expectedErr: assert.NoError, expectedCode: http.StatusOK},
+		{name: "validAuthMD5", enabled: true, algorithm: "md5",
+			correctUser: "myuser", correctPass: secretMD5,
+			givenUser: "myuser", givenPass: "secret",
+			expectedErr: assert.NoError, expectedCode: http.StatusOK},
+		{name: "validAuthBcrypt", enabled: true, algorithm: "bcrypt",
+			correctUser: "myuser", correctPass: secretBcrypt,
+			givenUser: "myuser", givenPass: "secret",
+			expectedErr: assert.NoError, expectedCode: http.StatusOK},
+		{name: "validAuthScrypt", enabled: true, algorithm: "scrypt",
+			correctUser: "myuser", correctPass: secretScrypt,
+			givenUser: "myuser", givenPass: "secret",
+			expectedErr: assert.NoError, expectedCode: http.StatusOK},
+		{name: "invalidAuth", enabled: true, algorithm: "sha256",
+			correctUser: "myuser", correctPass: secret256,
+			givenUser: "myuser", givenPass: "wrong",
+			expectedErr: assert.NoError, expectedCode: http.StatusUnauthorized},
+		{name: "noAuthGiven", enabled: true, algorithm: "sha256",
+			correctUser: "myuser", correctPass: secret256,
+			givenUser: "", givenPass: "", expectedErr: assert.NoError,
+			expectedCode: http.StatusUnauthorized},
+		{name: "disabledAuthWrong", enabled: false, algorithm: "sha256",
+			correctUser: "myuser", correctPass: secret256,
+			givenUser: "myuser", givenPass: "wrong",
+			expectedErr: assert.NoError, expectedCode: http.StatusOK},
+		{name: "disabledAuthNoneGiven", enabled: false, algorithm: "sha256",
+			correctUser: "myuser", correctPass: secret256,
+			givenUser: "", givenPass: "",
+			expectedErr: assert.NoError, expectedCode: http.StatusOK},
+	}
 
-	handler := s.Handler()
+	for _, tc := range tests {
+		t.Run(tc.name, func(tc testCase) func(t *testing.T) {
+			return func(t *testing.T) {
+				conf := api.NewConfig()
+				conf.BasicAuth.Enabled = tc.enabled
+				conf.BasicAuth.Algorithm = tc.algorithm
+				conf.BasicAuth.Username = tc.correctUser
+				conf.BasicAuth.PasswordHash = tc.correctPass
+				conf.BasicAuth.Salt = "EzrwNJYw2wkErVVV1P36FQ=="
 
-	request, _ := http.NewRequest("GET", "/version", http.NoBody)
-	response := httptest.NewRecorder()
-	handler.ServeHTTP(response, request)
+				s, err := api.New("", "", conf, nil, log.Noop(), metrics.Noop())
+				if ok := tc.expectedErr(t, err); !(ok && err == nil) {
+					return
+				}
 
-	assert.Equal(t, http.StatusUnauthorized, response.Code)
+				handler := s.Handler()
 
-	request, _ = http.NewRequest("GET", "/version", http.NoBody)
-	request.SetBasicAuth("myuser", "secret")
-	response = httptest.NewRecorder()
-	handler.ServeHTTP(response, request)
+				request, _ := http.NewRequest("GET", "/version", http.NoBody)
+				if tc.givenUser != "" || tc.givenPass != "" {
+					request.SetBasicAuth(tc.givenUser, tc.givenPass)
+				}
+				response := httptest.NewRecorder()
+				handler.ServeHTTP(response, request)
 
-	assert.Equal(t, http.StatusOK, response.Code)
+				assert.Equal(t, tc.expectedCode, response.Code)
+			}
+		}(tc))
+	}
 }

--- a/internal/api/docs.go
+++ b/internal/api/docs.go
@@ -19,9 +19,6 @@ func Spec() docs.FieldSpecs {
 		docs.FieldString("cert_file", "An optional certificate file for enabling TLS.").Advanced().HasDefault(""),
 		docs.FieldString("key_file", "An optional key file for enabling TLS.").Advanced().HasDefault(""),
 		httpdocs.ServerCORSFieldSpec(),
-		docs.FieldObject("basic_auth", "Require HTTP Basic Auth for the HTTP server.").WithChildren(
-			docs.FieldString("username", "Basic Auth Username").HasDefault(""),
-			docs.FieldString("password", "Basic Auth Password").HasDefault(""),
-		).Advanced(),
+		httpdocs.BasicAuthFieldSpec(),
 	}
 }

--- a/internal/api/docs.go
+++ b/internal/api/docs.go
@@ -19,5 +19,9 @@ func Spec() docs.FieldSpecs {
 		docs.FieldString("cert_file", "An optional certificate file for enabling TLS.").Advanced().HasDefault(""),
 		docs.FieldString("key_file", "An optional key file for enabling TLS.").Advanced().HasDefault(""),
 		httpdocs.ServerCORSFieldSpec(),
+		docs.FieldObject("basic_auth", "Require HTTP Basic Auth for the HTTP server.").WithChildren(
+			docs.FieldString("username", "Basic Auth Username").HasDefault(""),
+			docs.FieldString("password", "Basic Auth Password").HasDefault(""),
+		).Advanced(),
 	}
 }

--- a/internal/api/docs.go
+++ b/internal/api/docs.go
@@ -19,6 +19,13 @@ func Spec() docs.FieldSpecs {
 		docs.FieldString("cert_file", "An optional certificate file for enabling TLS.").Advanced().HasDefault(""),
 		docs.FieldString("key_file", "An optional key file for enabling TLS.").Advanced().HasDefault(""),
 		httpdocs.ServerCORSFieldSpec(),
-		httpdocs.BasicAuthFieldSpec(),
+		docs.FieldObject("basic_auth", "Allows you to specify basic authentication.").WithChildren(
+			docs.FieldBool("enabled", "Whether to use basic authentication in requests.").HasDefault(false),
+			docs.FieldString("username", "Username required to authenticate.").HasDefault(""),
+			docs.FieldString("password_hash", "Hashed password required to authenticate. (base64 encoded)").HasDefault(""),
+			docs.FieldString("realm", "realm of the protection space.").HasDefault("restricted"),
+			docs.FieldString("algorithm", "Encryption algorithm used to generate password_hash.", "md5", "sha256", "bcrypt", "scrypt").HasDefault("sha256"),
+			docs.FieldString("salt", "Salt for scrypt algorithm. (base64 encoded)").HasDefault(""),
+		).Advanced(),
 	}
 }

--- a/internal/http/docs/basic_auth.go
+++ b/internal/http/docs/basic_auth.go
@@ -1,42 +1,102 @@
 package docs
 
 import (
+	"crypto/md5"
 	"crypto/sha256"
 	"crypto/subtle"
+	"encoding/base64"
+	"errors"
+	"fmt"
 	"net/http"
+
+	"golang.org/x/crypto/bcrypt"
+	"golang.org/x/crypto/scrypt"
 
 	"github.com/benthosdev/benthos/v4/internal/docs"
 )
 
+const (
+	SCRYPT_N      = 32768
+	SCRYPT_r      = 8
+	SCRYPT_p      = 1
+	SCRYPT_KeyLen = 32
+)
+
 // BasicAuth contains the configuration fields for the HTTP BasicAuth
 type BasicAuth struct {
-	Username string `json:"username" yaml:"username"`
-	Password string `json:"password" yaml:"password"`
+	Enabled      bool   `json:"enabled" yaml:"enabled"`
+	Username     string `json:"username" yaml:"username"`
+	PasswordHash string `json:"password_hash" yaml:"password_hash"`
+	Realm        string `json:"realm" yaml:"realm"`
+	Algorithm    string `json:"algorithm" yaml:"algorithm"`
+	Salt         string `json:"salt" yaml:"salt"`
 }
 
 // NewBasicAuth returns a BasicAuth with default values
 func NewBasicAuth() BasicAuth {
 	return BasicAuth{
-		Username: "",
-		Password: "",
+		Enabled:      false,
+		Username:     "",
+		PasswordHash: "",
+		Realm:        "restricted",
+		Algorithm:    "sha256",
+		Salt:         "",
 	}
+}
+
+// Validate confirms that the BasicAuth is properly configured
+func (b BasicAuth) Validate() error {
+	if !b.Enabled {
+		return nil
+	}
+
+	if b.Username == "" || b.PasswordHash == "" {
+		return errors.New("both username and password_hash are required")
+	}
+
+	if !(b.Algorithm == "md5" || b.Algorithm == "sha256" || b.Algorithm == "bcrypt" || b.Algorithm == "scrypt") {
+		return errors.New("algorithm should be one of md5, sha256, bcrypt, or scrypt")
+	}
+
+	if b.Algorithm == "scrypt" && b.Salt == "" {
+		return errors.New("salt is required for scrypt")
+	}
+
+	if b.Algorithm == "scrypt" {
+		if _, err := base64.StdEncoding.DecodeString(b.Salt); err != nil {
+			return fmt.Errorf("invalid salt : %w", err)
+		}
+	}
+
+	return nil
 }
 
 // WrapHandler wraps the provided HTTP handler with middleware that enforces
 // BasicAuth if it's enabled.
 func (b BasicAuth) WrapHandler(next http.HandlerFunc) http.HandlerFunc {
-	if !b.enabled() {
+	if !b.Enabled {
 		return next
 	}
 
 	return func(next http.HandlerFunc, auth BasicAuth) http.HandlerFunc {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			user, pass, ok := r.BasicAuth()
-			if !(ok && auth.matches(user, pass)) {
-				w.Header().Set("WWW-Authenticate", `Basic realm="restricted", charset="UTF-8"`)
+			if !ok {
+				user = ""
+				pass = ""
+			}
+
+			if ok, err := auth.matches(user, pass); !ok || err != nil {
+				if err != nil {
+					http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+					return
+				}
+
+				w.Header().Set("WWW-Authenticate", fmt.Sprintf(`Basic realm="%s", charset="UTF-8"`, b.Realm))
 				http.Error(w, "Unauthorized", http.StatusUnauthorized)
 				return
 			}
+
 			next.ServeHTTP(w, r)
 		})
 	}(next, b)
@@ -45,23 +105,52 @@ func (b BasicAuth) WrapHandler(next http.HandlerFunc) http.HandlerFunc {
 // BasicAuthFieldSpec returns the spec for an HTTP BasicAuth component
 func BasicAuthFieldSpec() docs.FieldSpec {
 	return docs.FieldObject("basic_auth", "Require HTTP Basic Auth for the HTTP server.").WithChildren(
+		docs.FieldBool("enabled", "Enable Basic Auth").HasDefault(false),
+		docs.FieldString("realm", "Custom realm name").HasDefault("restricted"),
 		docs.FieldString("username", "Basic Auth Username").HasDefault(""),
-		docs.FieldString("password", "Basic Auth Password").HasDefault(""),
+		docs.FieldString("password_hash", "Basic Auth Password Hash").HasDefault(""),
+		docs.FieldString("algorithm", "Which hasing algorithm was used to hash the password").HasDefault("sha256"),
+		docs.FieldString("salt", "Salt for scrypt hasing algorithm").HasDefault(""),
 	).Advanced()
 }
 
-func (b BasicAuth) enabled() bool {
-	return b.Username != "" && b.Password != ""
+func (b BasicAuth) matches(user, pass string) (bool, error) {
+	expectedPassHash, err := base64.StdEncoding.DecodeString(b.PasswordHash)
+	if err != nil {
+		return false, err
+	}
+
+	userMatch := (subtle.ConstantTimeCompare([]byte(user), []byte(b.Username)) == 1)
+	passMatch := b.compareHashAndPassword(expectedPassHash, []byte(pass))
+
+	return (userMatch && passMatch), nil
 }
 
-func (b BasicAuth) matches(user, pass string) bool {
-	userHash := sha256.Sum256([]byte(user))
-	passHash := sha256.Sum256([]byte(pass))
-	expectedUserHash := sha256.Sum256([]byte(b.Username))
-	expectedPassHash := sha256.Sum256([]byte(b.Password))
+func (b BasicAuth) compareHashAndPassword(hashedPassword, password []byte) bool {
+	switch b.Algorithm {
+	case "md5":
+		v := md5.Sum(password)
+		return (subtle.ConstantTimeCompare(hashedPassword[:], v[:]) == 1)
+	case "sha256":
+		v := sha256.Sum256(password)
+		return (subtle.ConstantTimeCompare(hashedPassword[:], v[:]) == 1)
+	case "bcrypt":
+		if err := bcrypt.CompareHashAndPassword(hashedPassword, password); err != nil {
+			return false
+		}
+		return true
+	case "scrypt":
+		salt, err := base64.StdEncoding.DecodeString(b.Salt)
+		if err != nil {
+			return false
+		}
 
-	userMatch := (subtle.ConstantTimeCompare(userHash[:], expectedUserHash[:]) == 1)
-	passMatch := (subtle.ConstantTimeCompare(passHash[:], expectedPassHash[:]) == 1)
-
-	return userMatch && passMatch
+		v, err := scrypt.Key(password, salt, SCRYPT_N, SCRYPT_r, SCRYPT_p, SCRYPT_KeyLen)
+		if err != nil {
+			return false
+		}
+		return (subtle.ConstantTimeCompare(hashedPassword[:], v[:]) == 1)
+	default:
+		return false
+	}
 }

--- a/internal/http/docs/basic_auth.go
+++ b/internal/http/docs/basic_auth.go
@@ -16,10 +16,10 @@ import (
 )
 
 const (
-	SCRYPT_N      = 32768
-	SCRYPT_r      = 8
-	SCRYPT_p      = 1
-	SCRYPT_KeyLen = 32
+	scryptN      = 32768
+	scryptR      = 8
+	scryptP      = 1
+	scryptKeyLen = 32
 )
 
 // BasicAuth contains the configuration fields for the HTTP BasicAuth
@@ -92,7 +92,7 @@ func (b BasicAuth) WrapHandler(next http.HandlerFunc) http.HandlerFunc {
 					return
 				}
 
-				w.Header().Set("WWW-Authenticate", fmt.Sprintf(`Basic realm="%s", charset="UTF-8"`, b.Realm))
+				w.Header().Set("WWW-Authenticate", fmt.Sprintf(`Basic realm=%q, charset="UTF-8"`, b.Realm))
 				http.Error(w, "Unauthorized", http.StatusUnauthorized)
 				return
 			}
@@ -130,10 +130,10 @@ func (b BasicAuth) compareHashAndPassword(hashedPassword, password []byte) bool 
 	switch b.Algorithm {
 	case "md5":
 		v := md5.Sum(password)
-		return (subtle.ConstantTimeCompare(hashedPassword[:], v[:]) == 1)
+		return (subtle.ConstantTimeCompare(hashedPassword, v[:]) == 1)
 	case "sha256":
 		v := sha256.Sum256(password)
-		return (subtle.ConstantTimeCompare(hashedPassword[:], v[:]) == 1)
+		return (subtle.ConstantTimeCompare(hashedPassword, v[:]) == 1)
 	case "bcrypt":
 		if err := bcrypt.CompareHashAndPassword(hashedPassword, password); err != nil {
 			return false
@@ -145,11 +145,11 @@ func (b BasicAuth) compareHashAndPassword(hashedPassword, password []byte) bool 
 			return false
 		}
 
-		v, err := scrypt.Key(password, salt, SCRYPT_N, SCRYPT_r, SCRYPT_p, SCRYPT_KeyLen)
+		v, err := scrypt.Key(password, salt, scryptN, scryptR, scryptP, scryptKeyLen)
 		if err != nil {
 			return false
 		}
-		return (subtle.ConstantTimeCompare(hashedPassword[:], v[:]) == 1)
+		return (subtle.ConstantTimeCompare(hashedPassword, v) == 1)
 	default:
 		return false
 	}

--- a/internal/http/docs/basic_auth.go
+++ b/internal/http/docs/basic_auth.go
@@ -1,0 +1,67 @@
+package docs
+
+import (
+	"crypto/sha256"
+	"crypto/subtle"
+	"net/http"
+
+	"github.com/benthosdev/benthos/v4/internal/docs"
+)
+
+// BasicAuth contains the configuration fields for the HTTP BasicAuth
+type BasicAuth struct {
+	Username string `json:"username" yaml:"username"`
+	Password string `json:"password" yaml:"password"`
+}
+
+// NewBasicAuth returns a BasicAuth with default values
+func NewBasicAuth() BasicAuth {
+	return BasicAuth{
+		Username: "",
+		Password: "",
+	}
+}
+
+// WrapHandler wraps the provided HTTP handler with middleware that enforces
+// BasicAuth if it's enabled.
+func (b BasicAuth) WrapHandler(next http.HandlerFunc) http.HandlerFunc {
+	if !b.enabled() {
+		return next
+	}
+
+	return func(next http.HandlerFunc, auth BasicAuth) http.HandlerFunc {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			user, pass, ok := r.BasicAuth()
+			if !(ok && auth.matches(user, pass)) {
+				w.Header().Set("WWW-Authenticate", `Basic realm="restricted", charset="UTF-8"`)
+				http.Error(w, "Unauthorized", http.StatusUnauthorized)
+				return
+			}
+			next.ServeHTTP(w, r)
+		})
+	}(next, b)
+}
+
+// BasicAuthFieldSpec returns the spec for an HTTP BasicAuth component
+func BasicAuthFieldSpec() docs.FieldSpec {
+	return docs.FieldObject("basic_auth", "Require HTTP Basic Auth for the HTTP server.").WithChildren(
+		docs.FieldString("username", "Basic Auth Username").HasDefault(""),
+		docs.FieldString("password", "Basic Auth Password").HasDefault(""),
+	).Advanced()
+}
+
+func (b BasicAuth) enabled() bool {
+	return b.Username != "" && b.Password != ""
+}
+
+func (b BasicAuth) matches(user, pass string) bool {
+	userHash := sha256.Sum256([]byte(user))
+	passHash := sha256.Sum256([]byte(pass))
+	expectedUserHash := sha256.Sum256([]byte(b.Username))
+	expectedPassHash := sha256.Sum256([]byte(b.Password))
+
+	userMatch := (subtle.ConstantTimeCompare(userHash[:], expectedUserHash[:]) == 1)
+	passMatch := (subtle.ConstantTimeCompare(passHash[:], expectedPassHash[:]) == 1)
+
+	return userMatch && passMatch
+}

--- a/website/docs/components/http/about.md
+++ b/website/docs/components/http/about.md
@@ -40,7 +40,7 @@ http:
     allowed_origins: []
   basic_auth:
     username: ""
-	password: ""
+    password: ""
 ```
 
 </TabItem>

--- a/website/docs/components/http/about.md
+++ b/website/docs/components/http/about.md
@@ -6,6 +6,27 @@ When Benthos runs it kicks off an HTTP server that provides a few generally usef
 
 The configuration for this server lives under the `http` namespace, with the following default values:
 
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+<Tabs defaultValue="common" values={[
+  { label: 'Common', value: 'common', },
+  { label: 'Advanced', value: 'advanced', },
+]}>
+
+<TabItem value="common">
+
+```yaml
+http:
+  address: 0.0.0.0:4195
+  enabled: true
+  root_path: /benthos
+  debug_endpoints: false
+```
+
+</TabItem>
+<TabItem value="advanced">
+
 ```yaml
 http:
   address: 0.0.0.0:4195
@@ -17,7 +38,12 @@ http:
   cors:
     enabled: false
     allowed_origins: []
+  basic_auth:
+    username: ""
+	password: ""
 ```
+
+</TabItem>
 
 The field `enabled` can be set to `false` in order to disable the server.
 
@@ -28,6 +54,10 @@ The field `root_path` specifies a general prefix for all endpoints, this can hel
 By default Benthos will serve traffic over HTTP. In order to enforce TLS and serve traffic exclusively over HTTPS you must provide a `cert_file` and `key_file` path in your config, which point to a file containing a certificate and a matching private key for the server respectively.
 
 If the certificate is signed by a certificate authority, the `cert_file` should be the concatenation of the server's certificate, any intermediates, and the CA's certificate.
+
+## Enabling BasicAuth
+
+By default Benthos does not do any sort of authentication. Set `basic_auth.username` and `basic_auth.password` to enforce Basic authentication on all endpoints.
 
 ## Endpoints
 

--- a/website/docs/components/http/about.md
+++ b/website/docs/components/http/about.md
@@ -39,8 +39,11 @@ http:
     enabled: false
     allowed_origins: []
   basic_auth:
+    enabled: false
     username: ""
-    password: ""
+    password_hash: ""
+    algorithm: "sha256"
+    salt: ""
 ```
 
 </TabItem>
@@ -57,7 +60,9 @@ If the certificate is signed by a certificate authority, the `cert_file` should 
 
 ## Enabling BasicAuth
 
-By default Benthos does not do any sort of authentication. Set `basic_auth.username` and `basic_auth.password` to enforce Basic authentication on all endpoints.
+By default Benthos does not do any sort of authentication. Set `basic_auth.username` and `basic_auth.password_hash` to enforce Basic authentication on all endpoints. The `algorithm` can be one of `md5`, `sha256`, `bcrypt`, or `scrypt`. When using `scrypt` a `salt` is required.
+
+Both `password_hash` and `salt` should be base64 encoded.
 
 ## Endpoints
 


### PR DESCRIPTION
Adds HTTP BasicAuth support to the API server.

Closes #902 

While adding docs for `basic_auth` I pulled in the `Common` vs. `Advanced` tab layout.