### PR TITLE
Allow multiple docs in stream file

### DIFF
--- a/internal/cli/service.go
+++ b/internal/cli/service.go
@@ -98,9 +98,9 @@ func initStreamsMode(
 	}
 	logger.Infoln("Launching benthos in streams mode, use CTRL+C to close.")
 
-	if err := confReader.SubscribeStreamChanges(func(id string, newStreamConf stream.Config) bool {
-		if err = streamMgr.Update(id, newStreamConf, time.Second*30); err != nil && errors.Is(err, strmmgr.ErrStreamDoesNotExist) {
-			err = streamMgr.Create(id, newStreamConf)
+	if err := confReader.SubscribeStreamChanges(func(id string, newStreamConf []stream.Config) bool {
+		if err = streamMgr.UpdateMany(id, newStreamConf, time.Second*30); err != nil && errors.Is(err, strmmgr.ErrStreamDoesNotExist) {
+			err = streamMgr.CreateMany(id, newStreamConf)
 		}
 		if err != nil {
 			logger.Errorf("Failed to update stream %v: %v", id, err)

--- a/internal/config/reader.go
+++ b/internal/config/reader.go
@@ -164,7 +164,7 @@ func (r *Reader) SubscribeConfigChanges(fn MainUpdateFunc) error {
 // been updated. A boolean should be returned indicating whether the stream was
 // successfully updated, if false then the attempt will be made again after a
 // grace period.
-type StreamUpdateFunc func(id string, conf stream.Config) bool
+type StreamUpdateFunc func(id string, conf []stream.Config) bool
 
 // SubscribeStreamChanges registers a closure to be called whenever the
 // configuration of a stream is updated.

--- a/internal/stream/manager/from_path.go
+++ b/internal/stream/manager/from_path.go
@@ -21,16 +21,25 @@ func loadFile(dir, path, testSuffix string, confs map[string]stream.Config) ([]s
 		return nil, nil
 	}
 
-	if _, exists := confs[id]; exists {
-		return nil, fmt.Errorf("stream id (%v) collision from file: %v", id, path)
-	}
-
-	conf, lints, err := config.ReadStreamFile(path)
+	parsedConfs, lints, err := config.ReadStreamFile(path)
 	if err != nil {
 		return nil, err
 	}
 
-	confs[id] = conf
+	if len(parsedConfs) > 1 {
+		for idx, conf := range parsedConfs {
+			id := config.IndexedStreamID(id, idx)
+			if _, exists := confs[id]; exists {
+				return nil, fmt.Errorf("stream id (%v) collision from file: %v", id, path)
+			}
+			confs[id] = conf
+		}
+	} else if len(parsedConfs) > 0 {
+		if _, exists := confs[id]; exists {
+			return nil, fmt.Errorf("stream id (%v) collision from file: %v", id, path)
+		}
+		confs[id] = parsedConfs[0]
+	}
 	return lints, nil
 }
 

--- a/internal/stream/manager/type.go
+++ b/internal/stream/manager/type.go
@@ -12,6 +12,7 @@ import (
 	"github.com/benthosdev/benthos/v4/internal/component"
 	"github.com/benthosdev/benthos/v4/internal/component/metrics"
 	"github.com/benthosdev/benthos/v4/internal/component/processor"
+	"github.com/benthosdev/benthos/v4/internal/config"
 	"github.com/benthosdev/benthos/v4/internal/log"
 	"github.com/benthosdev/benthos/v4/internal/stream"
 )
@@ -161,6 +162,21 @@ func (m *Type) Create(id string, conf stream.Config) error {
 	return nil
 }
 
+func (m *Type) CreateMany(id string, confs []stream.Config) (err error) {
+	if len(confs) == 1 {
+		return m.Create(id, confs[0])
+	}
+	err = nil
+	for idx, conf := range confs {
+		id := config.IndexedStreamID(id, idx)
+		err = m.Create(id, conf)
+		if err != nil {
+			return
+		}
+	}
+	return
+}
+
 // Read attempts to obtain the status of a managed stream. Returns an error if
 // the stream does not exist.
 func (m *Type) Read(id string) (*StreamStatus, error) {
@@ -177,6 +193,21 @@ func (m *Type) Read(id string) (*StreamStatus, error) {
 	}
 
 	return wrapper, nil
+}
+
+func (m *Type) UpdateMany(id string, confs []stream.Config, timeout time.Duration) (err error) {
+	if len(confs) == 1 {
+		return m.Update(id, confs[0], timeout)
+	}
+	err = nil
+	for idx, conf := range confs {
+		id := config.IndexedStreamID(id, idx)
+		err = m.Update(id, conf, timeout)
+		if err != nil {
+			return
+		}
+	}
+	return
 }
 
 // Update attempts to stop an existing stream and replace it with a new version


### PR DESCRIPTION
This PR propose a new way to handle stream files.

It is natural to have multiple streams specified in one stream YAML file. For instance, scripts could generate several stream descriptions that may look alike or fall into the same category of functionalities. A straightforward approach by these scripts is to group those stream configurations and bundle them into one YAML file, instead of individual YAML files.

This PR will enable support for multiple documents in a stream file. Stream IDs are assigned in a way such that a suffix of form `@<document index>` is appended to the major stream ID inferred from the path of a stream file.