### PR TITLE
Update format_timestamp_strftime and parse_timestamp_strptime

### DIFF
--- a/internal/bloblang/query/methods_strings.go
+++ b/internal/bloblang/query/methods_strings.go
@@ -1238,6 +1238,12 @@ var _ = registerSimpleMethod(
 			`{"doc":{"timestamp":"2020-Aug-14"}}`,
 			`{"doc":{"timestamp":"2020-08-14T00:00:00Z"}}`,
 		),
+		NewExampleSpec(
+			"As an extension provided by the underlying formatting library, [itchyny/timefmt-go](https://github.com/itchyny/timefmt-go), the `%f` directive is supported for zero-padded microseconds, which originates from Python. Note that E and O modifier characters are not supported.",
+			`root.doc.timestamp = this.doc.timestamp.parse_timestamp_strptime("%Y-%b-%d %H:%M:%S.%f")`,
+			`{"doc":{"timestamp":"2020-Aug-14 11:50:26.371000"}}`,
+			`{"doc":{"timestamp":"2020-08-14T11:50:26.371Z"}}`,
+		),
 	).Beta().Param(ParamString("format", "The format of the target string.")),
 	func(args *ParsedParams) (simpleMethod, error) {
 		layout, err := args.FieldString("format")
@@ -1397,6 +1403,16 @@ var _ = registerSimpleMethod(
 
 			`{"created_at":"2020-08-14T11:50:26.371Z"}`,
 			`{"something_at":"2020-Aug-14 11:50:26"}`,
+		),
+		NewExampleSpec(
+			"As an extension provided by the underlying formatting library, [itchyny/timefmt-go](https://github.com/itchyny/timefmt-go), the `%f` directive is supported for zero-padded microseconds, which originates from Python. Note that E and O modifier characters are not supported.",
+			`root.something_at = this.created_at.format_timestamp_strftime("%Y-%b-%d %H:%M:%S.%f", "UTC")`,
+
+			`{"created_at":1597405526}`,
+			`{"something_at":"2020-Aug-14 11:45:26.000000"}`,
+
+			`{"created_at":"2020-08-14T11:50:26.371Z"}`,
+			`{"something_at":"2020-Aug-14 11:50:26.371000"}`,
 		),
 	).Beta().
 		Param(ParamString("format", "The output format to use.")).

--- a/website/docs/guides/bloblang/methods.md
+++ b/website/docs/guides/bloblang/methods.md
@@ -992,6 +992,18 @@ root.something_at = this.created_at.format_timestamp_strftime("%Y-%b-%d %H:%M:%S
 # Out: {"something_at":"2020-Aug-14 11:50:26"}
 ```
 
+As an extension provided by the underlying formatting library, [itchyny/timefmt-go](https://github.com/itchyny/timefmt-go), the `%f` directive is supported for zero-padded microseconds, which originates from Python. Note that E and O modifier characters are not supported.
+
+```coffee
+root.something_at = this.created_at.format_timestamp_strftime("%Y-%b-%d %H:%M:%S.%f", "UTC")
+
+# In:  {"created_at":1597405526}
+# Out: {"something_at":"2020-Aug-14 11:45:26.000000"}
+
+# In:  {"created_at":"2020-08-14T11:50:26.371Z"}
+# Out: {"something_at":"2020-Aug-14 11:50:26.371000"}
+```
+
 ### `format_timestamp_unix`
 
 :::caution BETA
@@ -1126,6 +1138,15 @@ root.doc.timestamp = this.doc.timestamp.parse_timestamp_strptime("%Y-%b-%d")
 
 # In:  {"doc":{"timestamp":"2020-Aug-14"}}
 # Out: {"doc":{"timestamp":"2020-08-14T00:00:00Z"}}
+```
+
+As an extension provided by the underlying formatting library, [itchyny/timefmt-go](https://github.com/itchyny/timefmt-go), the `%f` directive is supported for zero-padded microseconds, which originates from Python. Note that E and O modifier characters are not supported.
+
+```coffee
+root.doc.timestamp = this.doc.timestamp.parse_timestamp_strptime("%Y-%b-%d %H:%M:%S.%f")
+
+# In:  {"doc":{"timestamp":"2020-Aug-14 11:50:26.371000"}}
+# Out: {"doc":{"timestamp":"2020-08-14T11:50:26.371Z"}}
 ```
 
 ## Type Coercion


### PR DESCRIPTION
Add extra examples for the format specifier extensions supported by github.com/itchyny/timefmt-go.