### PR TITLE
Allow Makefile to take DOCKER_IMAGE ENV variable.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ PATHINSTBIN        = $(DEST_DIR)/bin
 PATHINSTTOOLS      = $(DEST_DIR)/tools
 PATHINSTSERVERLESS = $(DEST_DIR)/serverless
 PATHINSTDOCKER     = $(DEST_DIR)/docker
+DOCKER_IMAGE 	   ?= jeffail/benthos
 
 VERSION   := $(shell git describe --tags || echo "v0.0.0")
 VER_CUT   := $(shell echo $(VERSION) | cut -c2-)
@@ -71,12 +72,12 @@ docker-cgo-tags:
 	@echo "latest-cgo,$(VER_CUT)-cgo,$(VER_MAJOR).$(VER_MINOR)-cgo,$(VER_MAJOR)-cgo" > .tags
 
 docker:
-	@docker build -f ./resources/docker/Dockerfile . -t jeffail/benthos:$(VER_CUT)
-	@docker tag jeffail/benthos:$(VER_CUT) jeffail/benthos:latest
+	@docker build -f ./resources/docker/Dockerfile . -t $(DOCKER_IMAGE):$(VER_CUT)
+	@docker tag $(DOCKER_IMAGE):$(VER_CUT) $(DOCKER_IMAGE):latest
 
 docker-cgo:
-	@docker build -f ./resources/docker/Dockerfile.cgo . -t jeffail/benthos:$(VER_CUT)-cgo
-	@docker tag jeffail/benthos:$(VER_CUT)-cgo jeffail/benthos:latest-cgo
+	@docker build -f ./resources/docker/Dockerfile.cgo . -t $(DOCKER_IMAGE):$(VER_CUT)-cgo
+	@docker tag $(DOCKER_IMAGE):$(VER_CUT)-cgo $(DOCKER_IMAGE):latest-cgo
 
 fmt:
 	@go list -f {{.Dir}} ./... | xargs -I{} gofmt -w -s {}


### PR DESCRIPTION
I usually make my own images for deployment.

This small change to the Makefile allows us to do things like this:

```bash
➜  benthos git:(main) export DOCKER_IMAGE=darron/benthos
➜  benthos git:(main) make docker
[+] Building 50.9s (20/20) FINISHED
 => [internal] load build definition from Dockerfile                                                                                                                                                                                                                                                                                                                 0.0s
 => => transferring dockerfile: 914B                                                                                                                                                                                                                                                                                                                                 0.0s
 => [internal] load .dockerignore                                                                                                                                                                                                                                                                                                                                    0.0s
 => => transferring context: 108B                                                                                                                                                                                                                                                                                                                                    0.0s
 => [internal] load metadata for docker.io/library/busybox:latest                                                                                                                                                                                                                                                                                                    1.7s
 => [internal] load metadata for docker.io/library/golang:1.18                                                                                                                                                                                                                                                                                                       1.7s
 => [auth] library/busybox:pull token for registry-1.docker.io                                                                                                                                                                                                                                                                                                       0.0s
 => [auth] library/golang:pull token for registry-1.docker.io                                                                                                                                                                                                                                                                                                        0.0s
 => [build 1/7] FROM docker.io/library/golang:1.18@sha256:b203dc573d81da7b3176264bfa447bd7c10c9347689be40540381838d75eebef                                                                                                                                                                                                                                           0.0s
 => [internal] load build context                                                                                                                                                                                                                                                                                                                                    1.5s
 => => transferring context: 34.68MB                                                                                                                                                                                                                                                                                                                                 1.5s
 => [package 1/6] FROM docker.io/library/busybox@sha256:3614ca5eacf0a3a1bcc361c939202a974b4902b9334ff36eb29ffe9011aaad83                                                                                                                                                                                                                                             0.0s
 => CACHED [build 2/7] RUN useradd -u 10001 benthos                                                                                                                                                                                                                                                                                                                  0.0s
 => CACHED [build 3/7] WORKDIR /go/src/github.com/benthosdev/benthos/                                                                                                                                                                                                                                                                                                0.0s
 => CACHED [build 4/7] COPY go.* /go/src/github.com/benthosdev/benthos/                                                                                                                                                                                                                                                                                              0.0s
 => CACHED [build 5/7] RUN go mod download                                                                                                                                                                                                                                                                                                                           0.0s
 => [build 6/7] COPY . /go/src/github.com/benthosdev/benthos/                                                                                                                                                                                                                                                                                                        0.3s
 => [build 7/7] RUN make TAGS="timetzdata"                                                                                                                                                                                                                                                                                                                          46.8s
 => CACHED [package 2/6] COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/                                                                                                                                                                                                                                                                        0.0s
 => CACHED [package 3/6] COPY --from=build /etc/passwd /etc/passwd                                                                                                                                                                                                                                                                                                   0.0s
 => [package 4/6] COPY --from=build /go/src/github.com/benthosdev/benthos/target/bin/benthos .                                                                                                                                                                                                                                                                       0.2s
 => [package 5/6] COPY ./config/docker.yaml /benthos.yaml                                                                                                                                                                                                                                                                                                            0.0s
 => exporting to image                                                                                                                                                                                                                                                                                                                                               0.1s
 => => exporting layers                                                                                                                                                                                                                                                                                                                                              0.1s
 => => writing image sha256:eab722c54c8bd86b89faf6fe494c3aeb45d05b0dc41188bdde19f46b0bbbe654                                                                                                                                                                                                                                                                         0.0s
 => => naming to docker.io/darron/benthos:4.2.0-11-g52a1b049                                                                                                                                                                                                                                                                                                         0.0s

Use 'docker scan' to run Snyk tests against images to find vulnerabilities and learn how to fix them
➜  benthos git:(main) unset DOCKER_IMAGE
➜  benthos git:(main) make docker
[+] Building 0.8s (18/18) FINISHED
 => [internal] load build definition from Dockerfile                                                                                                                                                                                                                                                                                                                 0.0s
 => => transferring dockerfile: 37B                                                                                                                                                                                                                                                                                                                                  0.0s
 => [internal] load .dockerignore                                                                                                                                                                                                                                                                                                                                    0.0s
 => => transferring context: 34B                                                                                                                                                                                                                                                                                                                                     0.0s
 => [internal] load metadata for docker.io/library/busybox:latest                                                                                                                                                                                                                                                                                                    0.6s
 => [internal] load metadata for docker.io/library/golang:1.18                                                                                                                                                                                                                                                                                                       0.6s
 => [build 1/7] FROM docker.io/library/golang:1.18@sha256:b203dc573d81da7b3176264bfa447bd7c10c9347689be40540381838d75eebef                                                                                                                                                                                                                                           0.0s
 => [internal] load build context                                                                                                                                                                                                                                                                                                                                    0.1s
 => => transferring context: 90.88kB                                                                                                                                                                                                                                                                                                                                 0.1s
 => [package 1/6] FROM docker.io/library/busybox@sha256:3614ca5eacf0a3a1bcc361c939202a974b4902b9334ff36eb29ffe9011aaad83                                                                                                                                                                                                                                             0.0s
 => CACHED [build 2/7] RUN useradd -u 10001 benthos                                                                                                                                                                                                                                                                                                                  0.0s
 => CACHED [build 3/7] WORKDIR /go/src/github.com/benthosdev/benthos/                                                                                                                                                                                                                                                                                                0.0s
 => CACHED [build 4/7] COPY go.* /go/src/github.com/benthosdev/benthos/                                                                                                                                                                                                                                                                                              0.0s
 => CACHED [build 5/7] RUN go mod download                                                                                                                                                                                                                                                                                                                           0.0s
 => CACHED [build 6/7] COPY . /go/src/github.com/benthosdev/benthos/                                                                                                                                                                                                                                                                                                 0.0s
 => CACHED [build 7/7] RUN make TAGS="timetzdata"                                                                                                                                                                                                                                                                                                                    0.0s
 => CACHED [package 2/6] COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/                                                                                                                                                                                                                                                                        0.0s
 => CACHED [package 3/6] COPY --from=build /etc/passwd /etc/passwd                                                                                                                                                                                                                                                                                                   0.0s
 => CACHED [package 4/6] COPY --from=build /go/src/github.com/benthosdev/benthos/target/bin/benthos .                                                                                                                                                                                                                                                                0.0s
 => CACHED [package 5/6] COPY ./config/docker.yaml /benthos.yaml                                                                                                                                                                                                                                                                                                     0.0s
 => exporting to image                                                                                                                                                                                                                                                                                                                                               0.0s
 => => exporting layers                                                                                                                                                                                                                                                                                                                                              0.0s
 => => writing image sha256:eab722c54c8bd86b89faf6fe494c3aeb45d05b0dc41188bdde19f46b0bbbe654                                                                                                                                                                                                                                                                         0.0s
 => => naming to docker.io/jeffail/benthos:4.2.0-11-g52a1b049                                                                                                                                                                                                                                                                                                        0.0s

Use 'docker scan' to run Snyk tests against images to find vulnerabilities and learn how to fix them
➜  benthos git:(main) docker images | grep benthos
darron/benthos                                                               4.2.0-11-g52a1b049                                                 eab722c54c8b   48 seconds ago   76.8MB
darron/benthos                                                               latest                                                             eab722c54c8b   48 seconds ago   76.8MB
jeffail/benthos                                                              4.2.0-11-g52a1b049                                                 eab722c54c8b   48 seconds ago   76.8MB
jeffail/benthos                                                              latest                                                             eab722c54c8b   48 seconds ago   76.8MB
```