### PR TITLE
Allow multiple input batches in tests.

### DIFF
--- a/config/test/deduplicate.yaml
+++ b/config/test/deduplicate.yaml
@@ -17,9 +17,16 @@ tests:
         - content: '2'
         - content: '3'
         - content: '4'
+        - content: '3'
+        - content: '3'
+        - content: '3'
       -
         - content: '4'
+        - content: '1'
+        - content: '1'
         - content: '3'
+        - content: '4'
+        - content: '4'
         - content: '2'
         - content: '1'
     output_batches:

--- a/config/test/deduplicate.yaml
+++ b/config/test/deduplicate.yaml
@@ -1,0 +1,30 @@
+pipeline:
+  processors:
+    - dedupe:
+        cache: local
+        key: ${! content() }
+
+cache_resources:
+  - label: local
+    memory:
+      default_ttl: 1m
+
+tests:
+  - name: de-duplicate across batches
+    input_batches:
+      -
+        - content: '1'
+        - content: '2'
+        - content: '3'
+        - content: '4'
+      -
+        - content: '4'
+        - content: '3'
+        - content: '2'
+        - content: '1'
+    output_batches:
+      -
+        - content_equals: 1
+        - content_equals: 2
+        - content_equals: 3
+        - content_equals: 4

--- a/config/test/deduplicate_by_batch.yaml
+++ b/config/test/deduplicate_by_batch.yaml
@@ -1,0 +1,39 @@
+pipeline:
+  processors:
+    - bloblang: |
+        meta batch_tag = if batch_index() == 0 {
+          nanoid(10)
+        }
+    - dedupe:
+        cache: local
+        key: ${! meta("batch_tag").from(0) + content() }
+
+cache_resources:
+  - label: local
+    memory:
+      default_ttl: 1m
+
+tests:
+  - name: de-duplicate by batches
+    input_batches:
+      -
+        - content: '1'
+        - content: '2'
+        - content: '3'
+        - content: '4'
+      -
+        - content: '4'
+        - content: '3'
+        - content: '2'
+        - content: '1'
+    output_batches:
+      -
+        - content_equals: 1
+        - content_equals: 2
+        - content_equals: 3
+        - content_equals: 4
+      -
+        - content_equals: 4
+        - content_equals: 3
+        - content_equals: 2
+        - content_equals: 1

--- a/config/test/deduplicate_by_batch.yaml
+++ b/config/test/deduplicate_by_batch.yaml
@@ -21,9 +21,16 @@ tests:
         - content: '2'
         - content: '3'
         - content: '4'
+        - content: '3'
+        - content: '3'
+        - content: '3'
       -
         - content: '4'
+        - content: '1'
+        - content: '1'
         - content: '3'
+        - content: '4'
+        - content: '4'
         - content: '2'
         - content: '1'
     output_batches:
@@ -34,6 +41,6 @@ tests:
         - content_equals: 4
       -
         - content_equals: 4
+        - content_equals: 1
         - content_equals: 3
         - content_equals: 2
-        - content_equals: 1

--- a/internal/cli/test/case.go
+++ b/internal/cli/test/case.go
@@ -68,7 +68,7 @@ type Case struct {
 	TargetProcessors string               `yaml:"target_processors"`
 	TargetMapping    string               `yaml:"target_mapping"`
 	Mocks            map[string]yaml.Node `yaml:"mocks"`
-	InputBatch       []InputPart          `yaml:"input_batch"` // Deprecated: use input_batches instead.
+	InputBatch       []InputPart          `yaml:"input_batch"`
 	InputBatches     [][]InputPart        `yaml:"input_batches"`
 	OutputBatches    [][]ConditionsMap    `yaml:"output_batches"`
 

--- a/internal/cli/test/case_test.go
+++ b/internal/cli/test/case_test.go
@@ -117,6 +117,22 @@ output_batches:
 `,
 		},
 		{
+			name: "positive 5",
+			conf: `
+name: positive 5
+input_batches:
+-
+  - content: foo
+-
+  - content: bar
+output_batches:
+-
+  - content_equals: "foo"
+-
+  - content_equals: "bar"
+`,
+		},
+		{
 			name: "negative 1",
 			conf: `
 name: negative 1

--- a/internal/cli/test/docs/docs.go
+++ b/internal/cli/test/docs/docs.go
@@ -82,6 +82,22 @@ It is also possible to target processors in a separate file by prefixing the tar
 			docs.FieldString("metadata", "A map of metadata key/values to add to the input message.").Map().Optional(),
 		),
 		docs.FieldObject(
+			"input_batches", "",
+		).ArrayOfArrays().Optional().WithChildren(
+			docs.FieldString("content", "The raw content of the input message.").HasDefault(""),
+			docs.FieldAnything(`json_content`, "Sets the raw content of the message to a JSON document matching the structure of the value.", map[string]interface{}{
+				"foo": "foo value",
+				"bar": []interface{}{"element1", 10},
+			},
+			).Optional(),
+			docs.FieldString(
+				`file_content`,
+				"Sets the raw content of the message by reading a file. The path of the file should be relative to the path of the test file.",
+				"./foo/bar.txt",
+			).Optional(),
+			docs.FieldString("metadata", "A map of metadata key/values to add to the input message.").Map().Optional(),
+		),
+		docs.FieldObject(
 			"output_batches", "",
 		).ArrayOfArrays().Optional().WithChildren(
 			docs.FieldString("content", "The raw content of the input message.").HasDefault(""),

--- a/website/docs/configuration/unit_testing.md
+++ b/website/docs/configuration/unit_testing.md
@@ -425,6 +425,58 @@ A map of metadata key/values to add to the input message.
 
 Type: map of `string`  
 
+### `tests[].input_batches`
+
+Sorry! This field is missing documentation.
+
+
+Type: `object`  
+
+### `tests[].input_batches[][].content`
+
+The raw content of the input message.
+
+
+Type: `string`  
+Default: `""`  
+
+### `tests[].input_batches[][].json_content`
+
+Sets the raw content of the message to a JSON document matching the structure of the value.
+
+
+Type: `unknown`  
+
+```yml
+# Examples
+
+json_content:
+  bar:
+    - element1
+    - 10
+  foo: foo value
+```
+
+### `tests[].input_batches[][].file_content`
+
+Sets the raw content of the message by reading a file. The path of the file should be relative to the path of the test file.
+
+
+Type: `string`  
+
+```yml
+# Examples
+
+file_content: ./foo/bar.txt
+```
+
+### `tests[].input_batches[][].metadata`
+
+A map of metadata key/values to add to the input message.
+
+
+Type: map of `string`  
+
 ### `tests[].output_batches`
 
 Sorry! This field is missing documentation.


### PR DESCRIPTION
It is a try to implement suggested enhancement: Implement https://github.com/benthosdev/benthos/issues/1289

I try to make as little changes as needed so let me know if this implementation is ok or if it need some adjustments.

I added a test to validate context across batches (count). ~Ideally, I would have liked to be able to use dedup to show dedup across batch or not depending on some configuration but I haven't found how to register cache resources in a test environment. 
Otherwise, I test this similar logic manually from a config file and it worked.~ I added a simple dedup use case to validate why I needed this feature.