### PR TITLE
Fix healthcheck bug

### DIFF
--- a/internal/stream/type.go
+++ b/internal/stream/type.go
@@ -52,7 +52,7 @@ func New(conf Config, mgr bundle.NewManagement, opts ...func(*Type)) (*Type, err
 			w.WriteHeader(http.StatusServiceUnavailable)
 			_, _ = w.Write([]byte("input not connected\n"))
 		}
-		if !t.outputLayer.Connected() {
+		if !t.outputLayer.Connected() && connected {
 			connected = false
 			w.WriteHeader(http.StatusServiceUnavailable)
 			_, _ = w.Write([]byte("output not connected\n"))


### PR DESCRIPTION
Don't write the header and message twice if both input and output aren't connected.

With the current code, the following will pop up in the logs:
```
2022/06/21 23:10:14 http: superfluous response.WriteHeader call from github.com/benthosdev/benthos/v4/internal/stream.New.func2 (type.go:57)
```