### PR TITLE
Add remote ip and TLS information to http_server meta

### DIFF
--- a/internal/impl/io/input_http_server.go
+++ b/internal/impl/io/input_http_server.go
@@ -82,12 +82,18 @@ This input adds the following metadata fields to each message:
 - http_server_user_agent
 - http_server_request_path
 - http_server_verb
+- http_server_remote_ip
 - All headers (only first values are taken)
 - All query parameters
 - All path parameters
 - All cookies
 ` + "```" + `
-
+If HTTPS is enabled, the following fields are added as well:
+` + "``` text" + `
+- http_server_tls_version
+- http_server_tls_subject
+- http_server_tls_cipher_suite
+` + "```" + `
 You can access these metadata fields using [function interpolation](/docs/configuration/interpolation#metadata).`,
 		Config: docs.FieldComponent().WithChildren(
 			docs.FieldString("address", "An alternative address to host from. If left empty the service wide address is used."),

--- a/internal/impl/io/input_http_server_test.go
+++ b/internal/impl/io/input_http_server_test.go
@@ -348,6 +348,7 @@ func TestHTTPServerMetadata(t *testing.T) {
 	assert.Equal(t, dummyPath, part.MetaGet("http_server_request_path"))
 	assert.Equal(t, "POST", part.MetaGet("http_server_verb"))
 	assert.Regexp(t, "^Go-http-client/", part.MetaGet("http_server_user_agent"))
+	assert.Equal(t, "127.0.0.1", part.MetaGet("http_server_remote_ip"))
 	// Make sure query params are set in the metadata
 	assert.Contains(t, "bar", part.MetaGet("foo"))
 }

--- a/website/docs/components/inputs/http_server.md
+++ b/website/docs/components/inputs/http_server.md
@@ -115,16 +115,12 @@ This input adds the following metadata fields to each message:
 - All path parameters
 - All cookies
 ```
-
-If server is configured to work with HTTPS, the following fields added:
-
+If HTTPS is enabled, the following fields are added as well:
 ``` text
 - http_server_tls_version
 - http_server_tls_subject
 - http_server_tls_cipher_suite
 ```
-
-
 You can access these metadata fields using [function interpolation](/docs/configuration/interpolation#metadata).
 
 ## Fields

--- a/website/docs/components/inputs/http_server.md
+++ b/website/docs/components/inputs/http_server.md
@@ -109,11 +109,21 @@ This input adds the following metadata fields to each message:
 - http_server_user_agent
 - http_server_request_path
 - http_server_verb
+- http_server_remote_ip
 - All headers (only first values are taken)
 - All query parameters
 - All path parameters
 - All cookies
 ```
+
+If server is configured to work with HTTPS, the following fields added:
+
+``` text
+- http_server_tls_version
+- http_server_tls_subject
+- http_server_tls_cipher_suite
+```
+
 
 You can access these metadata fields using [function interpolation](/docs/configuration/interpolation#metadata).
 


### PR DESCRIPTION
This fixes #1052

I couldn't come up with the solution how to test TLS fields population, so I just tested it locally (using self-signed certificate made with mkcert).