### PR TITLE
fix: call os.Exit only if there was an issue

### DIFF
--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -222,7 +222,8 @@ Either run Benthos as a stream processor or choose a command:
 				_ = cli.ShowAppHelp(c)
 				os.Exit(1)
 			}
-			os.Exit(cmdService(
+
+			code := cmdService(
 				c.String("config"),
 				c.StringSlice("resources"),
 				c.StringSlice("set"),
@@ -232,7 +233,12 @@ Either run Benthos as a stream processor or choose a command:
 				false,
 				false,
 				nil,
-			))
+			)
+
+			if code != 0 {
+				os.Exit(code)
+			}
+
 			return nil
 		},
 		Commands: []*cli.Command{


### PR DESCRIPTION
In our custom Benthos build, we would like to execute some code _after_ the pipeline terminates. Currently this isn't possible because `internal/cli.Run` is calling `os.Exit` at the end of its execution. We're fine with it calling `os.Exit` when there is an issue or `cmdService` comes back with non-zero code but otherwise we'd like it to yield back to our code. Ideally, if Benthos is being run as part of a larger Go program then we could avoid `os.Exit` calls entirely though it's a bit of heavy-handed change for our present use case (happy to explore this though).

Given this pipeline:

```yaml
input:
  generate:
    count: 1
    mapping: |
      root = {"msg": "hello world"}

output:
  fallback:
    - http_client:
        url: "https://bad.example.com/api"
    - file:
        path: ./failed.cron
        codec: "all-bytes"
      processors:
        - bloblang: root = ""
```

and this program:

```go
package main

import (
	"context"
	"errors"
	"log"
	"os"
	"path"

	"github.com/benthosdev/benthos/v4/public/service"

	_ "github.com/benthosdev/benthos/v4/public/components/all"
)

func main() {
	service.RunCLI(context.Background())

	// Currently, the program does not reach this point.

	wd, err := os.Getwd()
	if err != nil {
		log.Fatalf("failed to get working directory path: %s", wd)
		return
	}

	cronFailFilename := path.Join(wd, "failed.cron")
	_, err = os.Stat(cronFailFilename)
	cronFailed := !errors.Is(err, os.ErrNotExist)
	if cronFailed {
		log.Fatalf("cron job failed: found %s file", cronFailFilename)
		return
	}
}
```