### PR TITLE
Support for queue declare auto-delete bit in AMQP 0-9-1 input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ All notable changes to this project will be documented in this file.
 - New `parse_parquet` bloblang method.
 - CLI flag `--prefix-stream-endpoints` added for disabling streams mode API prefixing.
 - Field `timestamp_name` added to the logger config.
+- AMQP 0-9-1 input now supports setting the `auto-delete` bit during queue declaration.
 
 ## 4.3.0 - 2022-06-23
 

--- a/internal/component/input/config_amqp_0_9.go
+++ b/internal/component/input/config_amqp_0_9.go
@@ -8,8 +8,9 @@ import (
 // queue needs to be declared and bound to an exchange, as well as any fields
 // specifying how to accomplish that.
 type AMQP09QueueDeclareConfig struct {
-	Enabled bool `json:"enabled" yaml:"enabled"`
-	Durable bool `json:"durable" yaml:"durable"`
+	Enabled    bool `json:"enabled" yaml:"enabled"`
+	Durable    bool `json:"durable" yaml:"durable"`
+	AutoDelete bool `json:"auto_delete" yaml:"auto_delete"`
 }
 
 // AMQP09BindingConfig contains fields describing a queue binding to be
@@ -39,8 +40,9 @@ func NewAMQP09Config() AMQP09Config {
 		URLs:  []string{},
 		Queue: "",
 		QueueDeclare: AMQP09QueueDeclareConfig{
-			Enabled: false,
-			Durable: true,
+			Enabled:    false,
+			Durable:    true,
+			AutoDelete: false,
 		},
 		ConsumerTag:        "",
 		AutoAck:            false,

--- a/internal/impl/amqp09/input.go
+++ b/internal/impl/amqp09/input.go
@@ -85,6 +85,7 @@ then the declaration passively verifies that they match the target fields.`,
 			).WithChildren(
 				docs.FieldBool("enabled", "Whether to enable queue declaration.").HasDefault(false),
 				docs.FieldBool("durable", "Whether the declared queue is durable.").HasDefault(true),
+				docs.FieldBool("auto_delete", "Whether the declared queue will auto-delete.").HasDefault(false),
 			).Advanced(),
 			docs.FieldObject("bindings_declare",
 				"Allows you to passively declare bindings for the target queue.",
@@ -192,12 +193,12 @@ func (a *amqp09Reader) ConnectWithContext(ctx context.Context) (err error) {
 
 	if a.conf.QueueDeclare.Enabled {
 		if _, err = amqpChan.QueueDeclare(
-			a.conf.Queue,                // name of the queue
-			a.conf.QueueDeclare.Durable, // durable
-			false,                       // delete when unused
-			false,                       // exclusive
-			false,                       // noWait
-			nil,                         // arguments
+			a.conf.Queue,                   // name of the queue
+			a.conf.QueueDeclare.Durable,    // durable
+			a.conf.QueueDeclare.AutoDelete, // delete when unused
+			false,                          // exclusive
+			false,                          // noWait
+			nil,                            // arguments
 		); err != nil {
 			return fmt.Errorf("queue Declare: %s", err)
 		}

--- a/internal/impl/amqp09/integration_test.go
+++ b/internal/impl/amqp09/integration_test.go
@@ -1,7 +1,9 @@
 package amqp09
 
 import (
+	"encoding/json"
 	"fmt"
+	"net/http"
 	"testing"
 	"time"
 
@@ -13,31 +15,49 @@ import (
 	"github.com/benthosdev/benthos/v4/internal/integration"
 )
 
-func TestIntegrationAMQP09(t *testing.T) {
-	integration.CheckSkip(t)
-	t.Parallel()
+func doSetupAndAssertions(setQueueDeclareAutoDelete bool, t *testing.T) {
+	assertQueueStateFromRabbitMQManagementAPI := func(resource *dockertest.Resource) {
+		require.NotNil(t, resource)
 
-	pool, err := dockertest.NewPool("")
-	require.NoError(t, err)
-
-	pool.MaxWait = time.Second * 30
-
-	resource, err := pool.Run("rabbitmq", "latest", nil)
-	require.NoError(t, err)
-	t.Cleanup(func() {
-		assert.NoError(t, pool.Purge(resource))
-	})
-
-	_ = resource.Expire(900)
-	require.NoError(t, pool.Retry(func() error {
-		client, err := amqp.Dial(fmt.Sprintf("amqp://guest:guest@localhost:%v/", resource.GetPort("5672/tcp")))
-		if err == nil {
-			client.Close()
+		type Queue struct {
+			AutoDelete bool `json:"auto_delete"`
 		}
-		return err
-	}))
 
-	template := `
+		client := &http.Client{
+			Timeout: time.Second * 5,
+		}
+
+		url := fmt.Sprintf("http://localhost:%v/api/queues", resource.GetPort("15672/tcp"))
+
+		req, err := http.NewRequest("GET", url, http.NoBody)
+		require.NoError(t, err)
+
+		req.SetBasicAuth("guest", "guest")
+		resp, err := client.Do(req)
+		require.NoError(t, err)
+
+		queues := make([]Queue, 0)
+		err = json.NewDecoder(resp.Body).Decode(&queues)
+		require.NoError(t, err)
+
+		if !setQueueDeclareAutoDelete {
+			// declared queues should remain when auto-delete is not set
+			assert.Contains(t, queues, Queue{AutoDelete: false})
+		} else {
+			// declared queues should be cleaned up when auto-delete is not set
+			assert.NotContains(t, queues, Queue{AutoDelete: true})
+		}
+	}
+
+	getTemplate := func() string {
+		// by completely omitting this item we can exercise the default setting
+		queueDeclareAutoDeleteFragment := ""
+		if setQueueDeclareAutoDelete {
+			queueDeclareAutoDeleteFragment = "\n      auto_delete: true"
+		}
+
+		return fmt.Sprintf(
+			`
 output:
   amqp_0_9:
     urls:
@@ -64,11 +84,37 @@ input:
     queue: queue-$ID
     queue_declare:
       durable: true
-      enabled: true
+      enabled: true%s
     bindings_declare:
       - exchange: exchange-$ID
         key: benthos-key
-`
+`,
+			queueDeclareAutoDeleteFragment,
+		)
+	}
+
+	integration.CheckSkip(t)
+	t.Parallel()
+
+	pool, err := dockertest.NewPool("")
+	require.NoError(t, err)
+
+	pool.MaxWait = time.Second * 30
+
+	resource, err := pool.Run("rabbitmq", "management", nil)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		assert.NoError(t, pool.Purge(resource))
+	})
+
+	_ = resource.Expire(900)
+	require.NoError(t, pool.Retry(func() error {
+		client, err := amqp.Dial(fmt.Sprintf("amqp://guest:guest@localhost:%v/", resource.GetPort("5672/tcp")))
+		if err == nil {
+			_ = client.Close()
+		}
+		return err
+	}))
 
 	suite := integration.StreamTests(
 		integration.StreamTestOpenClose(),
@@ -77,14 +123,41 @@ input:
 		integration.StreamTestSendBatch(10),
 		integration.StreamTestStreamSequential(1000),
 		integration.StreamTestStreamParallel(1000),
-		integration.StreamTestStreamParallelLossy(1000),
-		integration.StreamTestStreamParallelLossyThroughReconnect(1000),
 	)
-	suite.Run(
-		t, template,
-		integration.StreamTestOptSleepAfterInput(500*time.Millisecond),
-		integration.StreamTestOptSleepAfterOutput(500*time.Millisecond),
+
+	// we can't run these tests when auto-delete is not set because the disconnect / reconnect cycle cleans up the queues under test
+	if !setQueueDeclareAutoDelete {
+		suite = append(
+			suite,
+			integration.StreamTests(
+				integration.StreamTestStreamParallelLossy(1000),
+				integration.StreamTestStreamParallelLossyThroughReconnect(1000),
+			)...,
+		)
+	}
+
+	streamTestOptFuncs := []integration.StreamTestOptFunc{
+		integration.StreamTestOptSleepAfterInput(500 * time.Millisecond),
+		integration.StreamTestOptSleepAfterOutput(500 * time.Millisecond),
 		integration.StreamTestOptPort(resource.GetPort("5672/tcp")),
 		integration.StreamTestOptVarOne("false"),
+	}
+
+	suite.Run(
+		t,
+		getTemplate(),
+		streamTestOptFuncs...,
 	)
+
+	t.Cleanup(func() {
+		assertQueueStateFromRabbitMQManagementAPI(resource)
+	})
+}
+
+func TestIntegrationAMQP09WithoutQueueDeclareAutoDelete(t *testing.T) {
+	doSetupAndAssertions(false, t)
+}
+
+func TestIntegrationAMQP09WithQueueDeclareAutoDelete(t *testing.T) {
+	doSetupAndAssertions(true, t)
 }

--- a/website/docs/components/inputs/amqp_0_9.md
+++ b/website/docs/components/inputs/amqp_0_9.md
@@ -51,6 +51,7 @@ input:
     queue_declare:
       enabled: false
       durable: true
+      auto_delete: false
     bindings_declare: []
     consumer_tag: ""
     auto_ack: false
@@ -156,6 +157,14 @@ Whether the declared queue is durable.
 
 Type: `bool`  
 Default: `true`  
+
+### `queue_declare.auto_delete`
+
+Whether the declared queue will auto-delete.
+
+
+Type: `bool`  
+Default: `false`  
 
 ### `bindings_declare`
 


### PR DESCRIPTION
**Context**

This PR addresses https://github.com/benthosdev/benthos/issues/1315.

**In this PR**

- Add `auto_delete` as an option for queue declaration in AMQP 0-9-1 inputs
- Extend integration test for AMQP 0-9-1 input to cover `auto_delete` omitted and `auto_delete` set

I ran the tests, linter and formatter and also ran the integration tests (just for AMQP 0-9-1 input) and it all seemed fine.

I was able to see the changed doco when I ran the website locally.