### PR TITLE
fix: Jaeger Tracer ignoring the agent host and port

### DIFF
--- a/internal/impl/jaeger/tracer_jaeger_test.go
+++ b/internal/impl/jaeger/tracer_jaeger_test.go
@@ -1,0 +1,41 @@
+package jaeger
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/otel/exporters/jaeger"
+)
+
+func TestGetAgentOps(t *testing.T) {
+	tests := []struct {
+		name         string
+		agentAddress string
+		want         []jaeger.AgentEndpointOption
+	}{
+		{
+			name:         "address with port",
+			agentAddress: "localhost:5775",
+			want: []jaeger.AgentEndpointOption{
+				jaeger.WithAgentHost("localhost"),
+				jaeger.WithAgentPort("5775"),
+			},
+		},
+		{
+			name:         "address without port",
+			agentAddress: "jaeger",
+			want: []jaeger.AgentEndpointOption{
+				jaeger.WithAgentHost("jaeger"),
+			},
+		},
+	}
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			opts, err := getAgentOpts(testCase.agentAddress)
+
+			// We can't check for equality because they are functions, so we just check that the length is the same
+			assert.Len(t, opts, len(testCase.want))
+			assert.NoError(t, err)
+		})
+	}
+}


### PR DESCRIPTION
`url.Parse` fails silently when parsing URLs without a schema (http for example). In this case it was always setting the agent host and port to empty. Because Jaeger was using the default it worked if your agent was hosted at `localhost` and `6831` but it didn't when it wasn't (like when running in Docker). 

I've updated the way the agent address is parsed and it now works.

Fixes #1314