### PR TITLE
log: expose naming of message field via logrus

### DIFF
--- a/internal/log/docs.go
+++ b/internal/log/docs.go
@@ -18,6 +18,7 @@ func Spec() docs.FieldSpecs {
 		docs.FieldString("format", "Set the format of emitted logs.").HasOptions("json", "logfmt").HasDefault("logfmt"),
 		docs.FieldBool("add_timestamp", "Whether to include timestamps in logs.").HasDefault(false),
 		docs.FieldString("timestamp_name", "The name of the timestamp field added to logs when `add_timestamp` is set to `true` and the `format` is `json`.").HasDefault("time"),
+		docs.FieldString("message_name", "The name of the message field added to logs when the logger is invoked.").HasDefault("msg"),
 		docs.FieldString("static_fields", "A map of key/value pairs to add to each structured log.").Map().HasDefault(map[string]string{
 			"@service": "benthos",
 		}),

--- a/internal/log/logrus.go
+++ b/internal/log/logrus.go
@@ -14,6 +14,7 @@ type Config struct {
 	LogLevel      string            `json:"level" yaml:"level"`
 	Format        string            `json:"format" yaml:"format"`
 	AddTimeStamp  bool              `json:"add_timestamp" yaml:"add_timestamp"`
+	MessageName   string            `json:"message_name" yaml:"message_name"`
 	TimestampName string            `json:"timestamp_name" yaml:"timestamp_name"`
 	StaticFields  map[string]string `json:"static_fields" yaml:"static_fields"`
 	File          File              `json:"file" yaml:"file"`
@@ -33,6 +34,7 @@ func NewConfig() Config {
 		Format:        "logfmt",
 		AddTimeStamp:  false,
 		TimestampName: "time",
+		MessageName:   "msg",
 		StaticFields: map[string]string{
 			"@service": "benthos",
 		},
@@ -101,6 +103,7 @@ func NewV2(stream io.Writer, config Config) (Modular, error) {
 			DisableTimestamp: !config.AddTimeStamp,
 			FieldMap: logrus.FieldMap{
 				logrus.FieldKeyTime: config.TimestampName,
+				logrus.FieldKeyMsg:  config.MessageName,
 			},
 		})
 	case "logfmt":
@@ -110,6 +113,7 @@ func NewV2(stream io.Writer, config Config) (Modular, error) {
 			FullTimestamp:    config.AddTimeStamp,
 			FieldMap: logrus.FieldMap{
 				logrus.FieldKeyTime: config.TimestampName,
+				logrus.FieldKeyMsg:  config.MessageName,
 			},
 		})
 	default:

--- a/website/docs/components/logger/about.md
+++ b/website/docs/components/logger/about.md
@@ -83,6 +83,14 @@ The name of the timestamp field added to logs when `add_timestamp` is set to `tr
 Type: `string`  
 Default: `"time"`  
 
+### `message_name`
+
+The name of the message field added to logs when the logger is invoked.
+
+
+Type: `string`  
+Default: `"msg"`  
+
 ### `static_fields`
 
 A map of key/value pairs to add to each structured log.


### PR DESCRIPTION
hey there! just piggy backing on top of d5da5fd40fce575c4bd6ed9b6a2511a729acb76c , we saw that the logger `message` field changed to `msg` with logrus. this just adds configuration for that field, so that tooling can optionally make it whatever it wants!

let me know if this is stepping on toes, just trying to get back to the old behavior and follow the timestamp changes. :) 

thanks for the look!