### PR TITLE
Remove some heavy dependencies from public/service

### DIFF
--- a/internal/component/input/config_gcp_pubsub.go
+++ b/internal/component/input/config_gcp_pubsub.go
@@ -1,9 +1,5 @@
 package input
 
-import (
-	"cloud.google.com/go/pubsub"
-)
-
 // GCPPubSubConfig contains configuration values for the input type.
 type GCPPubSubConfig struct {
 	ProjectID              string `json:"project" yaml:"project"`
@@ -18,8 +14,8 @@ func NewGCPPubSubConfig() GCPPubSubConfig {
 	return GCPPubSubConfig{
 		ProjectID:              "",
 		SubscriptionID:         "",
-		MaxOutstandingMessages: pubsub.DefaultReceiveSettings.MaxOutstandingMessages,
-		MaxOutstandingBytes:    pubsub.DefaultReceiveSettings.MaxOutstandingBytes,
+		MaxOutstandingMessages: 1000, // pubsub.DefaultReceiveSettings.MaxOutstandingMessages
+		MaxOutstandingBytes:    1e9,  // pubsub.DefaultReceiveSettings.MaxOutstandingBytes (1G)
 		Sync:                   false,
 	}
 }

--- a/internal/component/output/config_gcp_cloud_storage.go
+++ b/internal/component/output/config_gcp_cloud_storage.go
@@ -1,8 +1,6 @@
 package output
 
 import (
-	"google.golang.org/api/googleapi"
-
 	"github.com/benthosdev/benthos/v4/internal/batch/policy/batchconfig"
 )
 
@@ -40,7 +38,7 @@ func NewGCPCloudStorageConfig() GCPCloudStorageConfig {
 		Path:            `${!count("files")}-${!timestamp_unix_nano()}.txt`,
 		ContentType:     "application/octet-stream",
 		ContentEncoding: "",
-		ChunkSize:       googleapi.DefaultUploadChunkSize,
+		ChunkSize:       16 * 1024 * 1024, // googleapi.DefaultUploadChunkSize
 		MaxInFlight:     64,
 		Batching:        batchconfig.NewConfig(),
 		CollisionMode:   GCPCloudStorageOverwriteCollisionMode,

--- a/internal/component/processor/config_protobuf.go
+++ b/internal/component/processor/config_protobuf.go
@@ -1,9 +1,5 @@
 package processor
 
-// nolint:staticcheck // Ignore SA1019 deprecation warning until we can switch to "google.golang.org/protobuf/types/dynamicpb"
-
-// nolint:staticcheck // Ignore SA1019 deprecation warning until we can switch to "google.golang.org/protobuf/types/dynamicpb"
-
 // ProtobufConfig contains configuration fields for the Protobuf processor.
 type ProtobufConfig struct {
 	Operator    string   `json:"operator" yaml:"operator"`


### PR DESCRIPTION
Related to #1332.

While I don't expect these values to change much in the future, it might be nicer to separate configs into pure and non-pure packages.

Given a hello world `main.go` which only imports `"github.com/benthosdev/benthos/v4/public/service"` and `"github.com/benthosdev/benthos/v4/public/components/pure"`, I noticed that there are a bunch of heavy Google dependencies that are being pulled in. Here's the diff in dependencies after this change:

```diff
diff --git a/go.mod b/go.mod
index 7571134..4eac6f8 100644
--- a/go.mod
+++ b/go.mod
@@ -5,10 +5,6 @@ go 1.18
 require github.com/benthosdev/benthos/v4 v4.4.1

 require (
-	cloud.google.com/go v0.100.2 // indirect
-	cloud.google.com/go/compute v1.5.0 // indirect
-	cloud.google.com/go/iam v0.1.0 // indirect
-	cloud.google.com/go/pubsub v1.17.1 // indirect
 	cuelang.org/go v0.4.2 // indirect
 	github.com/Azure/go-amqp v0.17.0 // indirect
 	github.com/Jeffail/gabs/v2 v2.6.1 // indirect
@@ -28,11 +24,8 @@ require (
 	github.com/gocql/gocql v0.0.0-20211222173705-d73e6b1002a7 // indirect
 	github.com/gofrs/uuid v4.2.0+incompatible // indirect
 	github.com/golang-jwt/jwt v3.2.2+incompatible // indirect
-	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/golang/snappy v0.0.4 // indirect
-	github.com/google/go-cmp v0.5.7 // indirect
-	github.com/googleapis/gax-go/v2 v2.2.0 // indirect
 	github.com/gorilla/css v1.0.0 // indirect
 	github.com/gorilla/handlers v1.5.1 // indirect
 	github.com/gorilla/mux v1.8.0 // indirect
@@ -76,7 +69,6 @@ require (
 	github.com/youmark/pkcs8 v0.0.0-20201027041543-1326539a0a0a // indirect
 	go.mongodb.org/mongo-driver v1.8.2 // indirect
 	go.nanomsg.org/mangos/v3 v3.3.0 // indirect
-	go.opencensus.io v0.23.0 // indirect
 	go.opentelemetry.io/otel v1.6.2 // indirect
 	go.opentelemetry.io/otel/trace v1.6.2 // indirect
 	golang.org/x/crypto v0.0.0-20220315160706-3147a52a75dd // indirect
@@ -86,12 +78,12 @@ require (
 	golang.org/x/sys v0.0.0-20220412211240-33da011f77ad // indirect
 	golang.org/x/text v0.3.7 // indirect
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
-	google.golang.org/api v0.74.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/genproto v0.0.0-20220405205423-9d709892a2bf // indirect
-	google.golang.org/grpc v1.45.0 // indirect
 	google.golang.org/protobuf v1.28.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/natefinch/lumberjack.v2 v2.0.0 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 )
+
+replace github.com/benthosdev/benthos/v4 => /Users/mihaitodor/Projects/jeffail/benthos
diff --git a/go.sum b/go.sum
index c1d693c..740889f 100644
--- a/go.sum
+++ b/go.sum
@@ -48,7 +48,6 @@ cloud.google.com/go/datastore v1.1.0/go.mod h1:umbIZjpQpHh4hmRpGhH4tLFup+FVzqBi1
 cloud.google.com/go/firestore v1.1.0/go.mod h1:ulACoGHTpvq5r8rxGJ4ddJZBZqakUQqClKRT5SZwBmk=
 cloud.google.com/go/iam v0.1.0 h1:W2vbGCrE3Z7J/x3WXLxxGl9LMSB2uhsAA7Ss/6u/qRY=
 cloud.google.com/go/iam v0.1.0/go.mod h1:vcUNEa0pEm0qRVpmWepWaFMIAI8/hjB9mO8rNCJtF6c=
-cloud.google.com/go/kms v1.0.0 h1:YkIeqPXqTAlwXk3Z2/WG0d6h1tqJQjU354WftjEoP9E=
 cloud.google.com/go/kms v1.0.0/go.mod h1:nhUehi+w7zht2XrUfvTRNpxrfayBHqP4lu2NSywui/0=
 cloud.google.com/go/pubsub v1.0.1/go.mod h1:R0Gpsv3s54REJCy4fxDixWD93lHJMoZTyQ2kNxGRt3I=
 cloud.google.com/go/pubsub v1.1.0/go.mod h1:EwwdRX2sKPjnvnqCa270oGRyludottCI76h+R3AArQw=
@@ -239,8 +238,6 @@ github.com/aymerick/douceur v0.2.0/go.mod h1:wlT5vV2O3h55X9m7iVYN0TBM0NH/MmbLnd3
 github.com/beefsack/go-rate v0.0.0-20220214233405-116f4ca011a0/go.mod h1:6YNgTHLutezwnBvyneBbwvB8C82y3dcoOj5EQJIdGXA=
 github.com/benhoyt/goawk v1.17.1 h1:ritTxg1s3NRIq25RmCgxPnlt2gtbMKCg0qvmYWo9heE=
 github.com/benhoyt/goawk v1.17.1/go.mod h1:UKzPyqDh9O7HZ/ftnU33MYlAP2rPbXdwQ+OVlEOPsjM=
-github.com/benthosdev/benthos/v4 v4.4.1 h1:MHRPitSIrhRhV70L2lZvNx5avFP58h7pJRcq1ySNnzc=
-github.com/benthosdev/benthos/v4 v4.4.1/go.mod h1:a92cmLoza8zioBiqW3NZdqvl2yWWFXcbWqGeS32Ch84=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
```