### PR TITLE
Add method to parse url encoded data

### DIFF
--- a/internal/impl/urlencoded/bloblang.go
+++ b/internal/impl/urlencoded/bloblang.go
@@ -1,0 +1,29 @@
+package urlencoded
+
+import (
+	"fmt"
+	"net/url"
+
+	"github.com/benthosdev/benthos/v4/internal/bloblang/query"
+	"github.com/benthosdev/benthos/v4/public/bloblang"
+)
+
+func init() {
+	if err := bloblang.RegisterMethodV2("parse_url_encoded",
+		bloblang.NewPluginSpec().
+			Category(query.MethodCategoryParsing).
+			Description(`Attempts to parse a string as url-encoded data and returns a structured result.`),
+		func(args *bloblang.ParsedParams) (bloblang.Method, error) {
+			return bloblang.BytesMethod(func(data []byte) (interface{}, error) {
+				values, err := url.ParseQuery(string(data))
+
+				if err != nil {
+					return nil, fmt.Errorf("failed to parse value as url-encoded data: %w", err)
+				}
+
+				return toMap(values), nil
+			}), nil
+		}); err != nil {
+		panic(err)
+	}
+}

--- a/internal/impl/urlencoded/bloblang_test.go
+++ b/internal/impl/urlencoded/bloblang_test.go
@@ -1,0 +1,65 @@
+package urlencoded_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/benthosdev/benthos/v4/internal/bloblang/query"
+	_ "github.com/benthosdev/benthos/v4/internal/impl/urlencoded"
+)
+
+func TestParseUrlencoded(t *testing.T) {
+	testCases := []struct {
+		name   string
+		method string
+		target interface{}
+		args   []interface{}
+		exp    interface{}
+	}{
+		{
+			name:   "simple parsing",
+			method: "parse_url_encoded",
+			target: "username=example",
+			args:   []interface{}{},
+			exp:    map[string]interface{}{"username": "example"},
+		},
+		{
+			name:   "parsing multiple values under the same key",
+			method: "parse_url_encoded",
+			target: "usernames=userA&usernames=userB",
+			args:   []interface{}{},
+			exp:    map[string]interface{}{"usernames": []string{"userA", "userB"}},
+		},
+		{
+			name:   "decodes data correctly",
+			method: "parse_url_encoded",
+			target: "email=example%40email.com",
+			args:   []interface{}{},
+			exp:    map[string]interface{}{"email": "example@email.com"},
+		},
+	}
+
+	for _, test := range testCases {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			targetClone := query.IClone(test.target)
+			argsClone := query.IClone(test.args).([]interface{})
+
+			fn, err := query.InitMethodHelper(test.method, query.NewLiteralFunction("", targetClone), argsClone...)
+			require.NoError(t, err)
+
+			res, err := fn.Exec(query.FunctionContext{
+				Maps:     map[string]query.Function{},
+				Index:    0,
+				MsgBatch: nil,
+			})
+			require.NoError(t, err)
+
+			assert.Equal(t, test.exp, res)
+			assert.Equal(t, test.target, targetClone)
+			assert.Equal(t, test.args, argsClone)
+		})
+	}
+}

--- a/internal/impl/urlencoded/package.go
+++ b/internal/impl/urlencoded/package.go
@@ -1,0 +1,17 @@
+package urlencoded
+
+import "net/url"
+
+func toMap(values url.Values) map[string]interface{} {
+	root := make(map[string]interface{})
+
+	for k, v := range values {
+		if len(v) == 1 {
+			root[k] = v[0]
+		} else {
+			root[k] = v
+		}
+	}
+
+	return root
+}

--- a/public/components/pure/extended/package.go
+++ b/public/components/pure/extended/package.go
@@ -12,5 +12,6 @@ import (
 	// Import pure but larger packages.
 	_ "github.com/benthosdev/benthos/v4/internal/impl/lang"
 	_ "github.com/benthosdev/benthos/v4/internal/impl/msgpack"
+	_ "github.com/benthosdev/benthos/v4/internal/impl/urlencoded"
 	_ "github.com/benthosdev/benthos/v4/internal/impl/xml"
 )

--- a/website/docs/guides/bloblang/methods.md
+++ b/website/docs/guides/bloblang/methods.md
@@ -2179,6 +2179,10 @@ root = content().parse_parquet()
 root = content().parse_parquet(byte_array_as_string: true)
 ```
 
+### `parse_url_encoded`
+
+Attempts to parse a string as url-encoded data and returns a structured result.
+
 ### `parse_xml`
 
 


### PR DESCRIPTION
Adds method `parse_url_encoded` to bloblang strings so it can transform form url encoded data to something benthos can work with.

Example:
```
pipeline:
  processors:
    - bloblang: |
        root = content().parse_url_encoded()
```