### PR TITLE
fix(cue): avoid cycles in higher-order components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ All notable changes to this project will be documented in this file.
 - The `amqp_1` input and output should no longer spam logs with timeout errors during graceful termination.
 - Fixed a potential crash when the `contains` bloblang method was used to compare complex types.
 - Fixed an issue where the `kafka_franz` input or output wouldn't use TLS connections without custom certificate configuration.
+- Fixed structural cycle in the CUE representation of the `retry` output.
 
 ### Changed
 

--- a/cmd/tools/benthos_docs_gen/cue_test.go
+++ b/cmd/tools/benthos_docs_gen/cue_test.go
@@ -27,6 +27,7 @@ func TestCUEGenerate(t *testing.T) {
 
 	ctx := cuecontext.New()
 	schemaV := ctx.CompileBytes(source)
+	require.NoError(t, schemaV.Validate())
 
 	v := ctx.CompileString(inputCue, cue.Scope(schemaV))
 	require.NoError(t, v.Validate())


### PR DESCRIPTION
Higher-order components such as the `retry` output can cause structural cycles within CUE's type system. To break these cycles, we need to declare their child component fields as optional.

Additionally, the test I had initially written was not detecting issues in the generated CUE schema. This has now been fixed and I was able to get it to fail, as expected, on the structural cycle error before fixing it in this PR. 