### PR TITLE
Add "content_type" field to gcs cache

### DIFF
--- a/internal/impl/gcp/cache_cloud_storage.go
+++ b/internal/impl/gcp/cache_cloud_storage.go
@@ -17,7 +17,7 @@ func gcpCloudStorageCacheConfig() *service.ConfigSpec {
 		Field(service.NewStringField("bucket").
 			Description("The Google Cloud Storage bucket to store items in.")).
 		Field(service.NewStringField("content_type").
-			Description("Optional field to explicitly set the Content-Type.").Default("").Optional())
+			Description("Optional field to explicitly set the Content-Type.").Optional())
 
 	return spec
 }


### PR DESCRIPTION
This is something we actively use, since the official Google Cloud Storage library is kind of flaky when automatically inferring the Content-Type.
The "content_type" field should be optional to still use the automatic inferring of the library if so desired.