### PR TITLE
fix: OTEL propagation for the HTTP server input

### DIFF
--- a/internal/impl/io/input_http_server.go
+++ b/internal/impl/io/input_http_server.go
@@ -331,9 +331,12 @@ func (h *httpServerInput) extractMessageFromRequest(r *http.Request) (message.Ba
 	})
 
 	textMapGeneric := map[string]interface{}{}
+	// Go normalises headers changing the way they are capitalised, here we are converting from normalised headers to
+	// a TextMap format which is case-sensitive. To ensure propagation still happens we need to convert the headers to
+	// lowercase as that is the format expected by the OTEL libraries.
 	for k, vals := range r.Header {
 		for _, v := range vals {
-			textMapGeneric[k] = v
+			textMapGeneric[strings.ToLower(k)] = v
 		}
 	}
 


### PR DESCRIPTION
At the moment when an HTTP request is made to Benthos on the HTTP input with a `traceparent` header the propagation is not happening because Go normalises headers and changes the case (uppercase first). The headers are then converted to a `TextMap` carrier which is case-sensitive so when extraction happens no values are found since the OTEL libraries are looking for `traceparent` in lowercase.

This PR ensures the headers are lowercased before passed to the extractor for the HTTP input where we deal with headers.

Propagation now works as expected and spans are being linked.