### PR TITLE
feat: allow delaying shutdown of benthos process

### DIFF
--- a/internal/config/schema.go
+++ b/internal/config/schema.go
@@ -19,6 +19,7 @@ type Type struct {
 	Logger                 log.Config     `json:"logger" yaml:"logger"`
 	Metrics                metrics.Config `json:"metrics" yaml:"metrics"`
 	Tracer                 tracer.Config  `json:"tracer" yaml:"tracer"`
+	SystemCloseDelay       string         `json:"shutdown_delay" yaml:"shutdown_delay"`
 	SystemCloseTimeout     string         `json:"shutdown_timeout" yaml:"shutdown_timeout"`
 	Tests                  []interface{}  `json:"tests,omitempty" yaml:"tests,omitempty"`
 }
@@ -32,6 +33,7 @@ func New() Type {
 		Logger:             log.NewConfig(),
 		Metrics:            metrics.NewConfig(),
 		Tracer:             tracer.NewConfig(),
+		SystemCloseDelay:   "",
 		SystemCloseTimeout: "20s",
 		Tests:              nil,
 	}
@@ -43,6 +45,7 @@ var observabilityFields = docs.FieldSpecs{
 	docs.FieldObject("logger", "Describes how operational logs should be emitted.").WithChildren(log.Spec()...),
 	docs.FieldMetrics("metrics", "A mechanism for exporting metrics.").Optional(),
 	docs.FieldTracer("tracer", "A mechanism for exporting traces.").Optional(),
+	docs.FieldString("shutdown_delay", "A period of time to wait for metrics and traces to be pulled or pushed from the process.").HasDefault("0s"),
 	docs.FieldString("shutdown_timeout", "The maximum period of time to wait for a clean shutdown. If this time is exceeded Benthos will forcefully close.").HasDefault("20s"),
 }
 

--- a/website/docs/configuration/about.md
+++ b/website/docs/configuration/about.md
@@ -282,11 +282,12 @@ You can check the output of the above command to see if certain sections are mis
 ## Shutting down
 
 Under normal operating conditions, the Benthos process will shut down when there are no more messages produced by inputs and the final message has been processed. The shutdown procedure can also be initiated by sending the process a interrupt (`SIGINT`) or termination (`SIGTERM`) signal. There are two top-level configuration options that control the shutdown behaviour: `shutdown_timeout` and `shutdown_delay`.
+
 ### Shutdown delay
 
-The `shutdown_delay` option can be used to delay the start of the shutdown procedure. This is useful for pipelines that will process a finite number of messages and terminate but need a short grace period to have their metrics and traces scraped. While the shutdown delay is in effect, the HTTP metrics endpoint continues to be available for scraping and any active tracers are free to flush remaining traces.
+The `shutdown_delay` option can be used to delay the start of the shutdown procedure. This is useful for pipelines that need a short grace period to have their metrics and traces scraped. While the shutdown delay is in effect, the HTTP metrics endpoint continues to be available for scraping and any active tracers are free to flush remaining traces.
 
-It is important to note the shutdown delay is only applied when a pipeline no longer has messages to process. It will not be applied if the process is being terminated using an OS signal or if an error occurs that initiates process termination.
+The shutdown delay can be interrupted by sending the Benthos process a second OS interrupt or termination signal.
 
 ### Shutdown timeout
 

--- a/website/docs/configuration/about.md
+++ b/website/docs/configuration/about.md
@@ -279,6 +279,21 @@ benthos -c ./your-config.yaml echo
 
 You can check the output of the above command to see if certain sections are missing or fields are incorrect, which allows you to pinpoint typos in the config.
 
+## Shutting down
+
+Under normal operating conditions, the Benthos process will shut down when there are no more messages produced by inputs and the final message has been processed. The shutdown procedure can also be initiated by sending the process a interrupt (`SIGINT`) or termination (`SIGTERM`) signal. There are two top-level configuration options that control the shutdown behaviour: `shutdown_timeout` and `shutdown_delay`.
+### Shutdown delay
+
+The `shutdown_delay` option can be used to delay the start of the shutdown procedure. This is useful for pipelines that will process a finite number of messages and terminate but need a short grace period to have their metrics and traces scraped. While the shutdown delay is in effect, the HTTP metrics endpoint continues to be available for scraping and any active tracers are free to flush remaining traces.
+
+It is important to note the shutdown delay is only applied when a pipeline no longer has messages to process. It will not be applied if the process is being terminated using an OS signal or if an error occurs that initiates process termination.
+
+### Shutdown timeout
+
+The `shutdown_timeout` option sets a hard deadline for Benthos process to gracefully terminate. If this duration is exceeded then the process is forcefully terminated and any messages that were in-flight will be dropped.
+
+This option takes effect after the `shutdown_delay` duration has passed if that is enabled.
+
 [processors]: /docs/components/processors/about
 [config-interp]: /docs/configuration/interpolation
 [config.testing]: /docs/configuration/unit_testing


### PR DESCRIPTION
This change adds a top-level `shutdown_delay` config option that sets an optional shutdown delay duration. This option can be used to delay the start of the shutdown procedure. This is useful for pipelines that need a short grace period to have their metrics and traces scraped. While the shutdown delay is in effect, the HTTP metrics endpoint continues to be available for scraping and any active tracers are free to flush remaining traces.

The shutdown delay can be interrupted by sending the Benthos process a second OS interrupt or termination signal.

**Why not use a [Prometheus Pushgateway](https://prometheus.io/docs/practices/pushing/) instead?**

Push gateways are designed to be a workaround for systems that cannot be scraped, either because they don't expose metrics data over an endpoint or they are behind a firewall that prevents scrapers from accessing metrics endpoints. Additionally, deploying a Pushgateway instance increases operational burden and adds a single point of failure in the chain (one more thing to keep alive). According to the official Prometheus docs, Pushgateway is only recommended for such limited use cases and the preference should be to have service metrics scraped from an endpoint.

For users that share these views, they will tend to delay the termination of there short-lived pipelines and batch jobs using certain hacks. For example in Benthos this can setup can be used to create a synthetic delay:

```yaml

input:
  sequence:
      # The input that has a finite amount of data
    - gcp_bigquery_select: {}
    - generate:
        mapping: "root = {}"
        interval: 30s
        # the count is 2 since it'll fire immediately the first time
        # and then wait one interval
        count: 2
      processors:
        - bloblang: root = deleted()
```

This is a cumbersome solution that convolutes an otherwise simple pipeline configuration compared to:

```yaml
shutdown_delay: 30s

input:
  gcp_bigquery_select: {}
```

---

Sample config:

```yaml
shutdown_delay: 5s

input:
  generate:
    mapping: |-
      root = { "id": uuid_v4(), "message": "Hello, World!" }
    count: 5
    interval: 1s

output:
  drop: {}

```

Sample output:

```
INFO Running main config from specified file       @service=benthos path=scratch/sample.yml
INFO Launching a benthos instance, use CTRL+C to close  @service=benthos
INFO Listening for HTTP requests at: http://0.0.0.0:4195  @service=benthos
INFO Dropping messages.                            @service=benthos label="" path=root.output
INFO Pipeline has terminated. Shutting down the service  @service=benthos
INFO Shutdown delay is in effect for 5s            @service=benthos
```