### PR TITLE
Add support for WaitTimeSeconds in SQS input

### DIFF
--- a/internal/component/input/config_aws_sqs.go
+++ b/internal/component/input/config_aws_sqs.go
@@ -8,6 +8,7 @@ import (
 type AWSSQSConfig struct {
 	sess.Config         `json:",inline" yaml:",inline"`
 	URL                 string `json:"url" yaml:"url"`
+	WaitTimeSeconds     int    `json:"wait_time_seconds" yaml:"wait_time_seconds"`
 	DeleteMessage       bool   `json:"delete_message" yaml:"delete_message"`
 	ResetVisibility     bool   `json:"reset_visibility" yaml:"reset_visibility"`
 	MaxNumberOfMessages int    `json:"max_number_of_messages" yaml:"max_number_of_messages"`
@@ -18,6 +19,7 @@ func NewAWSSQSConfig() AWSSQSConfig {
 	return AWSSQSConfig{
 		Config:              sess.NewConfig(),
 		URL:                 "",
+		WaitTimeSeconds:     0,
 		DeleteMessage:       true,
 		ResetVisibility:     true,
 		MaxNumberOfMessages: 10,

--- a/internal/impl/aws/input_sqs.go
+++ b/internal/impl/aws/input_sqs.go
@@ -61,6 +61,7 @@ You can access these metadata fields using
 			docs.FieldBool("delete_message", "Whether to delete the consumed message once it is acked. Disabling allows you to handle the deletion using a different mechanism.").Advanced(),
 			docs.FieldBool("reset_visibility", "Whether to set the visibility timeout of the consumed message to zero once it is nacked. Disabling honors the preset visibility timeout specified for the queue.").AtVersion("3.58.0").Advanced(),
 			docs.FieldInt("max_number_of_messages", "The maximum number of messages to return on one poll. Valid values: 1 to 10.").Advanced(),
+			docs.FieldInt("wait_time_seconds", "Whether to set the wait time. Enabling this activates long-polling. Valid values: 0 to 20.").Advanced(),
 		).WithChildren(sess.FieldSpecs()...).ChildDefaultAndTypesFromStruct(input.NewAWSSQSConfig()),
 		Categories: []string{
 			"Services",
@@ -223,6 +224,7 @@ func (a *awsSQSReader) readLoop(wg *sync.WaitGroup) {
 		res, err := a.sqs.ReceiveMessageWithContext(ctx, &sqs.ReceiveMessageInput{
 			QueueUrl:              aws.String(a.conf.URL),
 			MaxNumberOfMessages:   aws.Int64(int64(a.conf.MaxNumberOfMessages)),
+			WaitTimeSeconds:       aws.Int64(int64(a.conf.WaitTimeSeconds)),
 			AttributeNames:        []*string{aws.String("All")},
 			MessageAttributeNames: []*string{aws.String("All")},
 		})


### PR DESCRIPTION
This parameter allows to enable long-polling and reduce costs.