### PR TITLE
Fix a panic in the Redis processor

### DIFF
--- a/website/docs/components/processors/redis.md
+++ b/website/docs/components/processors/redis.md
@@ -330,7 +330,6 @@ A [Bloblang mapping](/docs/guides/bloblang/about) which should evaluate to an ar
 
 
 Type: `string`  
-Default: `""`  
 Requires version 4.3.0 or newer  
 
 ```yml


### PR DESCRIPTION
Ensure that the Redis processor has the args_mapping field. Fixes #1371.

It now outputs the following:

```
ERRO Config lint error                             @service=benthos lint="./tmp/config_redis_cache.yaml: line 7: field args_mapping is required"
ERRO Shutting down due to linter errors, to prevent shutdown run Benthos with --chilled  @service=benthos
```