### PR TITLE
Fix schema registry encode's field "avro_raw_json"

### DIFF
--- a/internal/impl/confluent/processor_schema_registry_decode.go
+++ b/internal/impl/confluent/processor_schema_registry_decode.go
@@ -33,7 +33,7 @@ Currently only Avro schemas are supported.
 
 ### Avro JSON Format
 
-This processor creates documents formatted as [Avro JSON]((https://avro.apache.org/docs/current/specification/_print/#json-encoding) when decoding Avro schemas. In this format the value of a union is encoded in JSON as follows:
+This processor creates documents formatted as [Avro JSON](https://avro.apache.org/docs/current/specification/_print/#json-encoding) when decoding Avro schemas. In this format the value of a union is encoded in JSON as follows:
 
 - if its type is ` + "`null`, then it is encoded as a JSON `null`" + `;
 - otherwise it is encoded as a JSON object with one name/value pair whose name is the type's name and whose value is the recursively encoded value. For Avro's named types (record, fixed or enum) the user-specified name is used, for other types the type name is used.

--- a/internal/impl/confluent/processor_schema_registry_decode.go
+++ b/internal/impl/confluent/processor_schema_registry_decode.go
@@ -33,7 +33,7 @@ Currently only Avro schemas are supported.
 
 ### Avro JSON Format
 
-This processor creates documents formatted as [Avro JSON](https://avro.apache.org/docs/current/spec.html#json_encoding) when decoding Avro schemas. In this format the value of a union is encoded in JSON as follows:
+This processor creates documents formatted as [Avro JSON]((https://avro.apache.org/docs/current/specification/_print/#json-encoding) when decoding Avro schemas. In this format the value of a union is encoded in JSON as follows:
 
 - if its type is ` + "`null`, then it is encoded as a JSON `null`" + `;
 - otherwise it is encoded as a JSON object with one name/value pair whose name is the type's name and whose value is the recursively encoded value. For Avro's named types (record, fixed or enum) the user-specified name is used, for other types the type name is used.

--- a/internal/impl/confluent/processor_schema_registry_decode_test.go
+++ b/internal/impl/confluent/processor_schema_registry_decode_test.go
@@ -218,8 +218,8 @@ func TestSchemaRegistryDecodeAvro(t *testing.T) {
 		},
 		{
 			name:   "successful message with logical raw json",
-			input:  "\x00\x00\x00\x00\x04\x02\x90\xaf\xce!\x02\x80\x80揪\x97\t\x00\x02\x02!",
-			output: `{"int_time_millis":{"int.time-millis":35245000},"long_time_micros":{"long.time-micros":20192000000000},"long_timestamp_micros":null,"pos_0_33333333":{"bytes.decimal":"!"}}`,
+			input:  "\x00\x00\x00\x00\x04\x02\x90\xaf\xce!\x02\x80\x80揪\x97\t\x02\x80\x80\xde\xf2\xdf\xff\xdf\xdc\x01\x02\x02!",
+			output: `{"int_time_millis":{"int.time-millis":35245000},"long_time_micros":{"long.time-micros":20192000000000},"long_timestamp_micros":{"long.timestamp-micros":62135596800000000},"pos_0_33333333":{"bytes.decimal":"!"}}`,
 		},
 		{
 			name:        "non-empty magic byte",

--- a/internal/impl/confluent/processor_schema_registry_decode_test.go
+++ b/internal/impl/confluent/processor_schema_registry_decode_test.go
@@ -96,7 +96,7 @@ const testSchema = `{
 			"type":	"record",
 			"name": "address",
 			"fields": [
-				{ "name": "City", "type": "string" },
+				{ "name": "City", "type": ["null", "string"], "default": null },
 				{ "name": "State", "type": "string" }
 			]
 		}],"default":null},
@@ -198,18 +198,28 @@ func TestSchemaRegistryDecodeAvro(t *testing.T) {
 	}{
 		{
 			name:   "successful message",
-			input:  "\x00\x00\x00\x00\x03\x06foo\x02\x06foo\x06bar\x02\x0edancing",
-			output: `{"Address":{"my.namespace.com.address":{"City":"foo","State":"bar"}},"MaybeHobby":{"string":"dancing"},"Name":"foo"}`,
+			input:  "\x00\x00\x00\x00\x03\x06foo\x02\x02\x06foo\x06bar\x02\x0edancing",
+			output: `{"Address":{"my.namespace.com.address":{"City":{"string":"foo"},"State":"bar"}},"MaybeHobby":{"string":"dancing"},"Name":"foo"}`,
 		},
 		{
 			name:   "successful message with null hobby",
-			input:  "\x00\x00\x00\x00\x03\x06foo\x02\x06foo\x06bar\x00",
-			output: `{"Address":{"my.namespace.com.address":{"City":"foo","State":"bar"}},"MaybeHobby":null,"Name":"foo"}`,
+			input:  "\x00\x00\x00\x00\x03\x06foo\x02\x02\x06foo\x06bar\x00",
+			output: `{"Address":{"my.namespace.com.address":{"City":{"string":"foo"},"State":"bar"}},"MaybeHobby":null,"Name":"foo"}`,
 		},
 		{
-			name:   "successful message with logical types",
+			name:   "successful message no address and null hobby",
+			input:  "\x00\x00\x00\x00\x03\x06foo\x00\x00",
+			output: `{"Name":"foo","MaybeHobby":null,"Address": null}`,
+		},
+		{
+			name:   "successful message with logical types avro json",
 			input:  "\x00\x00\x00\x00\x04\x02\x90\xaf\xce!\x02\x80\x80揪\x97\t\x02\x80\x80\xde\xf2\xdf\xff\xdf\xdc\x01\x02\x02!",
 			output: `{"int_time_millis":{"int.time-millis":35245000},"long_time_micros":{"long.time-micros":20192000000000},"long_timestamp_micros":{"long.timestamp-micros":62135596800000000},"pos_0_33333333":{"bytes.decimal":"!"}}`,
+		},
+		{
+			name:   "successful message with logical raw json",
+			input:  "\x00\x00\x00\x00\x04\x02\x90\xaf\xce!\x02\x80\x80揪\x97\t\x00\x02\x02!",
+			output: `{"int_time_millis":{"int.time-millis":35245000},"long_time_micros":{"long.time-micros":20192000000000},"long_timestamp_micros":null,"pos_0_33333333":{"bytes.decimal":"!"}}`,
 		},
 		{
 			name:        "non-empty magic byte",

--- a/internal/impl/confluent/processor_schema_registry_decode_test.go
+++ b/internal/impl/confluent/processor_schema_registry_decode_test.go
@@ -217,7 +217,7 @@ func TestSchemaRegistryDecodeAvro(t *testing.T) {
 			output: `{"int_time_millis":{"int.time-millis":35245000},"long_time_micros":{"long.time-micros":20192000000000},"long_timestamp_micros":{"long.timestamp-micros":62135596800000000},"pos_0_33333333":{"bytes.decimal":"!"}}`,
 		},
 		{
-			name:   "successful message with logical raw json",
+			name:   "successful message with logical types raw json",
 			input:  "\x00\x00\x00\x00\x04\x02\x90\xaf\xce!\x02\x80\x80揪\x97\t\x02\x80\x80\xde\xf2\xdf\xff\xdf\xdc\x01\x02\x02!",
 			output: `{"int_time_millis":{"int.time-millis":35245000},"long_time_micros":{"long.time-micros":20192000000000},"long_timestamp_micros":{"long.timestamp-micros":62135596800000000},"pos_0_33333333":{"bytes.decimal":"!"}}`,
 		},

--- a/internal/impl/confluent/processor_schema_registry_encode.go
+++ b/internal/impl/confluent/processor_schema_registry_encode.go
@@ -353,9 +353,7 @@ func (s *schemaRegistryEncoder) getLatestEncoder(subject string) (schemaEncoder,
 		return nil, 0, err
 	}
 
-	s.logger.Infof("codec 1 is: %#v", codec)
-
-	s.logger.Infof("codec 2 is: %v", codec)
+	s.logger.Tracef("codec is: %#v", codec)
 
 	return func(m *service.Message) error {
 		var datum interface{}
@@ -372,7 +370,7 @@ func (s *schemaRegistryEncoder) getLatestEncoder(subject string) (schemaEncoder,
 			return err
 		}
 
-		s.logger.Infof("datum is: %#v", datum)
+		s.logger.Tracef("datum is: %#v", datum)
 
 		binary, err := codec.BinaryFromNative(nil, datum)
 		if err != nil {

--- a/internal/impl/confluent/processor_schema_registry_encode.go
+++ b/internal/impl/confluent/processor_schema_registry_encode.go
@@ -353,6 +353,10 @@ func (s *schemaRegistryEncoder) getLatestEncoder(subject string) (schemaEncoder,
 		return nil, 0, err
 	}
 
+	s.logger.Infof("codec 1 is: %#v", codec)
+
+	s.logger.Infof("codec 2 is: %v", codec)
+
 	return func(m *service.Message) error {
 		var datum interface{}
 		if s.avroRawJSON {
@@ -367,6 +371,8 @@ func (s *schemaRegistryEncoder) getLatestEncoder(subject string) (schemaEncoder,
 		} else if datum, err = m.AsStructured(); err != nil {
 			return err
 		}
+
+		s.logger.Infof("datum is: %#v", datum)
 
 		binary, err := codec.BinaryFromNative(nil, datum)
 		if err != nil {

--- a/internal/impl/confluent/processor_schema_registry_encode.go
+++ b/internal/impl/confluent/processor_schema_registry_encode.go
@@ -35,7 +35,7 @@ Currently only Avro schemas are supported.
 
 ### Avro JSON Format
 
-By default this processor expects documents formatted as [Avro JSON](https://avro.apache.org/docs/current/spec.html#json_encoding) when encoding Avro schemas. In this format the value of a union is encoded in JSON as follows:
+By default this processor expects documents formatted as [Avro JSON](https://avro.apache.org/docs/current/specification/_print/#json-encoding) when encoding Avro schemas. In this format the value of a union is encoded in JSON as follows:
 
 - if its type is ` + "`null`, then it is encoded as a JSON `null`" + `;
 - otherwise it is encoded as a JSON object with one name/value pair whose name is the type's name and whose value is the recursively encoded value. For Avro's named types (record, fixed or enum) the user-specified name is used, for other types the type name is used.
@@ -57,7 +57,7 @@ However, it is possible to instead consume documents in raw JSON format (that ma
 			Example("60s").
 			Example("1h")).
 		Field(service.NewBoolField("avro_raw_json").
-			Description("Whether messages encoded in Avro format should be parsed as raw JSON documents rather than [Avro JSON](https://avro.apache.org/docs/current/specification/_print/#json-encoding). If true the the schema returned from the subject should be parsed as [standard json](https://pkg.go.dev/github.com/linkedin/goavro/v2#NewCodecForStandardJSON) instead of as (normal avro json)[https://pkg.go.dev/github.com/linkedin/goavro/v2#NewCodec]").
+			Description("Whether messages encoded in Avro format should be parsed as raw JSON documents rather than [Avro JSON](https://avro.apache.org/docs/current/specification/_print/#json-encoding). If true the the schema returned from the subject should be parsed as [standard json](https://pkg.go.dev/github.com/linkedin/goavro/v2#NewCodecForStandardJSON) instead of as [normal avro json](https://pkg.go.dev/github.com/linkedin/goavro/v2#NewCodec)").
 			Advanced().Default(false).Version("3.59.0")).
 		Field(service.NewTLSField("tls")).
 		Version("3.58.0")

--- a/internal/impl/confluent/processor_schema_registry_encode.go
+++ b/internal/impl/confluent/processor_schema_registry_encode.go
@@ -348,7 +348,7 @@ func (s *schemaRegistryEncoder) getLatestEncoder(subject string) (schemaEncoder,
 	}
 
 	var codec *goavro.Codec
-	if codec, err = goavro.NewCodecForStandardJSON(resPayload.Schema); err != nil {
+	if codec, err = goavro.NewCodec(resPayload.Schema); err != nil {
 		s.logger.Errorf("failed to parse response for schema subject '%v': %v", subject, err)
 		return nil, 0, err
 	}

--- a/internal/impl/confluent/processor_schema_registry_encode.go
+++ b/internal/impl/confluent/processor_schema_registry_encode.go
@@ -46,7 +46,12 @@ For example, the union schema ` + "`[\"null\",\"string\",\"Foo\"]`, where `Foo`"
 - the string ` + "`\"a\"` as `{\"string\": \"a\"}`" + `; and
 - a ` + "`Foo` instance as `{\"Foo\": {...}}`, where `{...}` indicates the JSON encoding of a `Foo`" + ` instance.
 
-However, it is possible to instead consume documents in raw JSON format (that match the schema) by setting the field ` + "[`avro_raw_json`](#avro_raw_json) to `true`" + `.`).
+
+
+However, it is possible to instead consume documents in [standard/raw JSON format](https://pkg.go.dev/github.com/linkedin/goavro/v2#NewCodecForStandardJSON) by setting the field ` + "[`avro_raw_json`](#avro_raw_json) to `true`" + `.
+
+Important! There is an outstanding issue in the [avro serializing library](https://github.com/linkedin/goavro) that benthos uses in that it [doesn't encode logical types correctly](https://github.com/linkedin/goavro/issues/252). It's still possible to encode logical types that are in-line with the spec if ` + "`avro_raw_json` is set to true" + `, but when decoded they will still be the verbose format that goavro uses.
+`).
 		Field(service.NewStringField("url").Description("The base URL of the schema registry service.")).
 		Field(service.NewInterpolatedStringField("subject").Description("The schema subject to derive schemas from.").
 			Example("foo").
@@ -57,7 +62,7 @@ However, it is possible to instead consume documents in raw JSON format (that ma
 			Example("60s").
 			Example("1h")).
 		Field(service.NewBoolField("avro_raw_json").
-			Description("Whether messages encoded in Avro format should be parsed as raw JSON documents rather than [Avro JSON](https://avro.apache.org/docs/current/specification/_print/#json-encoding). If true the the schema returned from the subject should be parsed as [standard json](https://pkg.go.dev/github.com/linkedin/goavro/v2#NewCodecForStandardJSON) instead of as [normal avro json](https://pkg.go.dev/github.com/linkedin/goavro/v2#NewCodec)").
+			Description("Whether messages encoded in Avro format should be parsed as raw JSON documents rather than [Avro JSON](https://avro.apache.org/docs/current/specification/_print/#json-encoding). If true the the schema returned from the subject should be parsed as [standard json](https://pkg.go.dev/github.com/linkedin/goavro/v2#NewCodecForStandardJSON) instead of as [normal avro json](https://pkg.go.dev/github.com/linkedin/goavro/v2#NewCodec). There is a [comment in goavro](https://github.com/linkedin/goavro/blob/5ec5a5ee7ec82e16e6e2b438d610e1cab2588393/union.go#L224-L249), the [underlining library](https://github.com/linkedin/goavro) used to encode schemas, that explains in more detail the diffrence between the two.").
 			Advanced().Default(false).Version("3.59.0")).
 		Field(service.NewTLSField("tls")).
 		Version("3.58.0")

--- a/internal/impl/confluent/processor_schema_registry_encode_test.go
+++ b/internal/impl/confluent/processor_schema_registry_encode_test.go
@@ -363,8 +363,8 @@ func TestSchemaRegistryEncodeAvroRawJSONLogicalTypes(t *testing.T) {
 	}{
 		{
 			name:   "successful message with logical types raw json",
-			input:  `{"int_time_millis":35245000,"long_time_micros":20192000000000,"long_timestamp_micros":null,"pos_0_33333333":"!"}`,
-			output: "\x00\x00\x00\x00\x04\x02\x90\xaf\xce!\x02\x80\x80揪\x97\t\x00\x02\x02!",
+			input:  `{"int_time_millis":35245000,"long_time_micros":20192000000000,"long_timestamp_micros":62135596800000000,"pos_0_33333333":"!"}`,
+			output: "\x00\x00\x00\x00\x04\x02\x90\xaf\xce!\x02\x80\x80揪\x97\t\x02\x80\x80\xde\xf2\xdf\xff\xdf\xdc\x01\x02\x02!",
 		},
 		{
 			name:        "message doesnt match schema codec",
@@ -373,7 +373,7 @@ func TestSchemaRegistryEncodeAvroRawJSONLogicalTypes(t *testing.T) {
 		},
 		{
 			name:        "message doesnt match schema",
-			input:       `{"int_time_millis":"35245000","long_time_micros":20192000000000,"long_timestamp_micros":null,"pos_0_33333333":"!"}`,
+			input:       `{"int_time_millis":"35245000","long_time_micros":20192000000000,"long_timestamp_micros":62135596800000000,"pos_0_33333333":"!"}`,
 			errContains: "could not decode any json data in input",
 		},
 	}

--- a/internal/impl/confluent/processor_schema_registry_encode_test.go
+++ b/internal/impl/confluent/processor_schema_registry_encode_test.go
@@ -123,12 +123,17 @@ func TestSchemaRegistryEncodeAvroRawJSON(t *testing.T) {
 		{
 			name:   "successful message",
 			input:  `{"Address":{"City":"foo","State":"bar"},"Name":"foo","MaybeHobby":"dancing"}`,
-			output: "\x00\x00\x00\x00\x03\x06foo\x02\x06foo\x06bar\x02\x0edancing",
+			output: "\x00\x00\x00\x00\x03\x06foo\x02\x02\x06foo\x06bar\x02\x0edancing",
 		},
 		{
 			name:   "successful message null hobby",
 			input:  `{"Address":{"City":"foo","State":"bar"},"Name":"foo","MaybeHobby":null}`,
-			output: "\x00\x00\x00\x00\x03\x06foo\x02\x06foo\x06bar\x00",
+			output: "\x00\x00\x00\x00\x03\x06foo\x02\x02\x06foo\x06bar\x00",
+		},
+		{
+			name:   "successful message no address and null hobby",
+			input:  `{"Name":"foo","MaybeHobby":null}`,
+			output: "\x00\x00\x00\x00\x03\x06foo\x00\x00",
 		},
 		{
 			name:        "message doesnt match schema",
@@ -199,18 +204,177 @@ func TestSchemaRegistryEncodeAvro(t *testing.T) {
 	}{
 		{
 			name:   "successful message",
-			input:  `{"Address":{"my.namespace.com.address":{"City":"foo","State":"bar"}},"Name":"foo","MaybeHobby":{"string":"dancing"}}`,
-			output: "\x00\x00\x00\x00\x03\x06foo\x02\x06foo\x06bar\x02\x0edancing",
+			input:  `{"Address":{"my.namespace.com.address":{"City":{"string":"foo"},"State":"bar"}},"Name":"foo","MaybeHobby":{"string":"dancing"}}`,
+			output: "\x00\x00\x00\x00\x03\x06foo\x02\x02\x06foo\x06bar\x02\x0edancing",
 		},
 		{
 			name:   "successful message null hobby",
-			input:  `{"Address":{"my.namespace.com.address":{"City":"foo","State":"bar"}},"Name":"foo","MaybeHobby":null}`,
-			output: "\x00\x00\x00\x00\x03\x06foo\x02\x06foo\x06bar\x00",
+			input:  `{"Address":{"my.namespace.com.address":{"City":{"string":"foo"},"State":"bar"}},"Name":"foo","MaybeHobby":null}`,
+			output: "\x00\x00\x00\x00\x03\x06foo\x02\x02\x06foo\x06bar\x00",
+		},
+		{
+			name:   "successful message no address and null hobby",
+			input:  `{"Name":"foo","MaybeHobby":null}`,
+			output: "\x00\x00\x00\x00\x03\x06foo\x00\x00",
 		},
 		{
 			name:        "message doesnt match schema",
 			input:       `{"Address":{"my.namespace.com.address":"not this","Name":"foo"}}`,
 			errContains: "cannot decode textual union: cannot decode textual record",
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			outBatches, err := encoder.ProcessBatch(
+				context.Background(),
+				service.MessageBatch{service.NewMessage([]byte(test.input))},
+			)
+			require.NoError(t, err)
+			require.Len(t, outBatches, 1)
+			require.Len(t, outBatches[0], 1)
+
+			err = outBatches[0][0].GetError()
+			if test.errContains != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), test.errContains)
+			} else {
+				require.NoError(t, err)
+
+				b, err := outBatches[0][0].AsBytes()
+				require.NoError(t, err)
+				assert.Equal(t, test.output, string(b))
+			}
+		})
+	}
+
+	require.NoError(t, encoder.Close(context.Background()))
+	encoder.cacheMut.Lock()
+	assert.Len(t, encoder.schemas, 0)
+	encoder.cacheMut.Unlock()
+}
+
+func TestSchemaRegistryEncodeAvroLogicalTypes(t *testing.T) {
+	fooFirst, err := json.Marshal(struct {
+		Schema string `json:"schema"`
+		ID     int    `json:"id"`
+	}{
+		Schema: testSchemaLogicalTypes,
+		ID:     4,
+	})
+	require.NoError(t, err)
+
+	urlStr := runSchemaRegistryServer(t, func(path string) ([]byte, error) {
+		if path == "/subjects/foo/versions/latest" {
+			return fooFirst, nil
+		}
+		return nil, errors.New("nope")
+	})
+
+	subj, err := service.NewInterpolatedString("foo")
+	require.NoError(t, err)
+
+	encoder, err := newSchemaRegistryEncoder(urlStr, nil, subj, false, time.Minute*10, time.Minute, nil)
+	require.NoError(t, err)
+
+	tests := []struct {
+		name        string
+		input       string
+		output      string
+		errContains string
+	}{
+		{
+			name:   "successful message with logical types avro json",
+			input:  `{"int_time_millis":{"int.time-millis":35245000},"long_time_micros":{"long.time-micros":20192000000000},"long_timestamp_micros":{"long.timestamp-micros":62135596800000000},"pos_0_33333333":{"bytes.decimal":"!"}}`,
+			output: "\x00\x00\x00\x00\x04\x02\x90\xaf\xce!\x02\x80\x80揪\x97\t\x02\x80\x80\xde\xf2\xdf\xff\xdf\xdc\x01\x02\x02!",
+		},
+		{
+			name:        "message doesnt match schema codec",
+			input:       `{"int_time_millis":35245000,"long_time_micros":20192000000000,"long_timestamp_micros":null,"pos_0_33333333":"!"}`,
+			errContains: "cannot decode textual union: expected:",
+		},
+		{
+			name:        "message doesnt match schema",
+			input:       `{"int_time_millis":{"long.time-millis":35245000},"long_time_micros":{"long.time-micros":20192000000000},"long_timestamp_micros":{"long.timestamp-micros":62135596800000000},"pos_0_33333333":{"bytes.decimal":"!"}}`,
+			errContains: "cannot decode textual union: cannot decode textual map: cannot determine codec:",
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			outBatches, err := encoder.ProcessBatch(
+				context.Background(),
+				service.MessageBatch{service.NewMessage([]byte(test.input))},
+			)
+			require.NoError(t, err)
+			require.Len(t, outBatches, 1)
+			require.Len(t, outBatches[0], 1)
+
+			err = outBatches[0][0].GetError()
+			if test.errContains != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), test.errContains)
+			} else {
+				require.NoError(t, err)
+
+				b, err := outBatches[0][0].AsBytes()
+				require.NoError(t, err)
+				assert.Equal(t, test.output, string(b))
+			}
+		})
+	}
+
+	require.NoError(t, encoder.Close(context.Background()))
+	encoder.cacheMut.Lock()
+	assert.Len(t, encoder.schemas, 0)
+	encoder.cacheMut.Unlock()
+}
+
+func TestSchemaRegistryEncodeAvroRawJSONLogicalTypes(t *testing.T) {
+	fooFirst, err := json.Marshal(struct {
+		Schema string `json:"schema"`
+		ID     int    `json:"id"`
+	}{
+		Schema: testSchemaLogicalTypes,
+		ID:     4,
+	})
+	require.NoError(t, err)
+
+	urlStr := runSchemaRegistryServer(t, func(path string) ([]byte, error) {
+		if path == "/subjects/foo/versions/latest" {
+			return fooFirst, nil
+		}
+		return nil, errors.New("nope")
+	})
+
+	subj, err := service.NewInterpolatedString("foo")
+	require.NoError(t, err)
+
+	encoder, err := newSchemaRegistryEncoder(urlStr, nil, subj, true, time.Minute*10, time.Minute, nil)
+	require.NoError(t, err)
+
+	tests := []struct {
+		name        string
+		input       string
+		output      string
+		errContains string
+	}{
+		{
+			name:   "successful message with logical types raw json",
+			input:  `{"int_time_millis":35245000,"long_time_micros":20192000000000,"long_timestamp_micros":null,"pos_0_33333333":"!"}`,
+			output: "\x00\x00\x00\x00\x04\x02\x90\xaf\xce!\x02\x80\x80揪\x97\t\x00\x02\x02!",
+		},
+		{
+			name:        "message doesnt match schema codec",
+			input:       `{"int_time_millis":{"int.time-millis":35245000},"long_time_micros":{"long.time-micros":20192000000000},"long_timestamp_micros":{"long.timestamp-micros":62135596800000000},"pos_0_33333333":{"bytes.decimal":"!"}}`,
+			errContains: "could not decode any json data in input",
+		},
+		{
+			name:        "message doesnt match schema",
+			input:       `{"int_time_millis":"35245000","long_time_micros":20192000000000,"long_timestamp_micros":null,"pos_0_33333333":"!"}`,
+			errContains: "could not decode any json data in input",
 		},
 	}
 

--- a/internal/impl/confluent/processor_schema_registry_encode_test.go
+++ b/internal/impl/confluent/processor_schema_registry_encode_test.go
@@ -210,7 +210,7 @@ func TestSchemaRegistryEncodeAvro(t *testing.T) {
 		{
 			name:        "message doesnt match schema",
 			input:       `{"Address":{"my.namespace.com.address":"not this","Name":"foo"}}`,
-			errContains: "schema does not specify default value",
+			errContains: "cannot decode textual union: cannot decode textual record",
 		},
 	}
 

--- a/website/docs/components/processors/schema_registry_decode.md
+++ b/website/docs/components/processors/schema_registry_decode.md
@@ -60,7 +60,7 @@ Currently only Avro schemas are supported.
 
 ### Avro JSON Format
 
-This processor creates documents formatted as [Avro JSON](https://avro.apache.org/docs/current/spec.html#json_encoding) when decoding Avro schemas. In this format the value of a union is encoded in JSON as follows:
+This processor creates documents formatted as [Avro JSON]((https://avro.apache.org/docs/current/specification/_print/#json-encoding) when decoding Avro schemas. In this format the value of a union is encoded in JSON as follows:
 
 - if its type is `null`, then it is encoded as a JSON `null`;
 - otherwise it is encoded as a JSON object with one name/value pair whose name is the type's name and whose value is the recursively encoded value. For Avro's named types (record, fixed or enum) the user-specified name is used, for other types the type name is used.

--- a/website/docs/components/processors/schema_registry_decode.md
+++ b/website/docs/components/processors/schema_registry_decode.md
@@ -60,7 +60,7 @@ Currently only Avro schemas are supported.
 
 ### Avro JSON Format
 
-This processor creates documents formatted as [Avro JSON]((https://avro.apache.org/docs/current/specification/_print/#json-encoding) when decoding Avro schemas. In this format the value of a union is encoded in JSON as follows:
+This processor creates documents formatted as [Avro JSON](https://avro.apache.org/docs/current/specification/_print/#json-encoding) when decoding Avro schemas. In this format the value of a union is encoded in JSON as follows:
 
 - if its type is `null`, then it is encoded as a JSON `null`;
 - otherwise it is encoded as a JSON object with one name/value pair whose name is the type's name and whose value is the recursively encoded value. For Avro's named types (record, fixed or enum) the user-specified name is used, for other types the type name is used.

--- a/website/docs/components/processors/schema_registry_encode.md
+++ b/website/docs/components/processors/schema_registry_encode.md
@@ -80,7 +80,12 @@ For example, the union schema `["null","string","Foo"]`, where `Foo` is a record
 - the string `"a"` as `{"string": "a"}`; and
 - a `Foo` instance as `{"Foo": {...}}`, where `{...}` indicates the JSON encoding of a `Foo` instance.
 
-However, it is possible to instead consume documents in raw JSON format (that match the schema) by setting the field [`avro_raw_json`](#avro_raw_json) to `true`.
+
+
+However, it is possible to instead consume documents in [standard/raw JSON format](https://pkg.go.dev/github.com/linkedin/goavro/v2#NewCodecForStandardJSON) by setting the field [`avro_raw_json`](#avro_raw_json) to `true`.
+
+Important! There is an outstanding issue in the [avro serializing library](https://github.com/linkedin/goavro) that benthos uses in that it [doesn't encode logical types correctly](https://github.com/linkedin/goavro/issues/252). It's still possible to encode logical types that are in-line with the spec if `avro_raw_json` is set to true, but when decoded they will still be the verbose format that goavro uses.
+
 
 ## Fields
 
@@ -125,7 +130,7 @@ refresh_period: 1h
 
 ### `avro_raw_json`
 
-Whether messages encoded in Avro format should be parsed as raw JSON documents rather than [Avro JSON](https://avro.apache.org/docs/current/specification/_print/#json-encoding). If true the the schema returned from the subject should be parsed as [standard json](https://pkg.go.dev/github.com/linkedin/goavro/v2#NewCodecForStandardJSON) instead of as [normal avro json](https://pkg.go.dev/github.com/linkedin/goavro/v2#NewCodec)
+Whether messages encoded in Avro format should be parsed as raw JSON documents rather than [Avro JSON](https://avro.apache.org/docs/current/specification/_print/#json-encoding). If true the the schema returned from the subject should be parsed as [standard json](https://pkg.go.dev/github.com/linkedin/goavro/v2#NewCodecForStandardJSON) instead of as [normal avro json](https://pkg.go.dev/github.com/linkedin/goavro/v2#NewCodec). There is a [comment in goavro](https://github.com/linkedin/goavro/blob/5ec5a5ee7ec82e16e6e2b438d610e1cab2588393/union.go#L224-L249), the [underlining library](https://github.com/linkedin/goavro) used to encode schemas, that explains in more detail the diffrence between the two.
 
 
 Type: `bool`  

--- a/website/docs/components/processors/schema_registry_encode.md
+++ b/website/docs/components/processors/schema_registry_encode.md
@@ -69,7 +69,7 @@ Currently only Avro schemas are supported.
 
 ### Avro JSON Format
 
-By default this processor expects documents formatted as [Avro JSON](https://avro.apache.org/docs/current/spec.html#json_encoding) when encoding Avro schemas. In this format the value of a union is encoded in JSON as follows:
+By default this processor expects documents formatted as [Avro JSON](https://avro.apache.org/docs/current/specification/_print/#json-encoding) when encoding Avro schemas. In this format the value of a union is encoded in JSON as follows:
 
 - if its type is `null`, then it is encoded as a JSON `null`;
 - otherwise it is encoded as a JSON object with one name/value pair whose name is the type's name and whose value is the recursively encoded value. For Avro's named types (record, fixed or enum) the user-specified name is used, for other types the type name is used.
@@ -125,7 +125,7 @@ refresh_period: 1h
 
 ### `avro_raw_json`
 
-Whether messages encoded in Avro format should be parsed as raw JSON documents rather than [Avro JSON](https://avro.apache.org/docs/current/spec.html#json_encoding).
+Whether messages encoded in Avro format should be parsed as raw JSON documents rather than [Avro JSON](https://avro.apache.org/docs/current/specification/_print/#json-encoding). If true the the schema returned from the subject should be parsed as [standard json](https://pkg.go.dev/github.com/linkedin/goavro/v2#NewCodecForStandardJSON) instead of as [normal avro json](https://pkg.go.dev/github.com/linkedin/goavro/v2#NewCodec)
 
 
 Type: `bool`  


### PR DESCRIPTION
### Manual test description

If the schema is:
```
{
  "type": "record",
  "name": "heartbeat_v3",
  "namespace": "outbox_events",
  "fields": [
      {
          "name": "heartbeat",
          "type": [
              "null",
              "int"
          ],
          "default": null
      }
  ]
}
```

When the benthos config is:
```
schema_registry_encode:
  url: ${SCHEMA_REGISTRY_ENDPOINT}
  subject: ${! meta("EventName")}
  avro_raw_json: false
```

If the input is:
```
'{"heartbeat": {"int": 1}}'
```

The logs show a success:
<img width="1733" alt="Screen Shot 2022-08-10 at 5 35 41 AM" src="https://user-images.githubusercontent.com/6489651/183903713-23214996-a210-4076-8934-4628927a8e1b.png">

If the input is:
```
'{"heartbeat": 1}'
```

The logs show a failure:
<img width="1741" alt="Screen Shot 2022-08-10 at 5 35 53 AM" src="https://user-images.githubusercontent.com/6489651/183903782-12ee41b7-7242-4d0a-abc7-4267d90f03f5.png">


When the benthos config is:
```
schema_registry_encode:
  url: ${SCHEMA_REGISTRY_ENDPOINT}
  subject: ${! meta("EventName")}
  avro_raw_json: true
```

If the input is:
```
'{"heartbeat": {"int": 1}}'
```

The logs show a failure:
<img width="1735" alt="Screen Shot 2022-08-10 at 5 36 48 AM" src="https://user-images.githubusercontent.com/6489651/183903913-60ff948d-2757-49f1-afe0-b0c476834aae.png">

If the input is:
```
'{"heartbeat": 1}'
```

The logs show  a success:
<img width="1746" alt="Screen Shot 2022-08-10 at 5 37 13 AM" src="https://user-images.githubusercontent.com/6489651/183903983-75f6f49c-d2d3-4214-a037-b2a682faa087.png">

### Thoughts on default value

So this PR does keep `avro_raw_json` defaulted to false.

Though this PR doesn't change the default value of `avro_raw_json` (it is already false), it does changes the default codec mechanism from [`NewCodecForStandardJSON`](https://pkg.go.dev/github.com/linkedin/goavro/v2#NewCodecForStandardJSON) to [`NewCodec`](https://pkg.go.dev/github.com/linkedin/goavro/v2#NewCodec), so previously though we stated the default mechanism was avro json the code was expecting standard json.
So there is an argument to change `avro_raw_json` to default to `true`, as this is a breaking change given that the code now expects you to have your json formatted differently when `avro_raw_json` is false.
The argument to set the default to `true` is bolstered by the fact that most new time avro users will expect to be able to pass normal json, and there are some slight differences in standard json and the spec: https://avro.apache.org/docs/current/specification/_print/#json-encoding

But I think this will cause more confusion in the long run as:
1. The standard java implementation of avro doesn't support raw json
People have been asking avro to support normal json for as far back as 2014
https://issues.apache.org/jira/browse/AVRO-1582
And as recently in 2021:
https://issues.apache.org/jira/browse/AVRO-3210
But from the responses you can tell that avro maintainers are open to supporting raw json but in no rush.
So many users, I assume most are coming from java, will be caught off guard by defaulting to raw json.

2. No matter how the avro is encdoded (whether `avro_raw_json` is true or false), it is always decoded to avro json.
For example if your input to avro encoder is this:
```
`{"Address":{"City":"foo","State":"bar"},"Name":"foo","MaybeHobby":"dancing"}`
```
then after you decode the binary data your output is this:
```
{"Address":{"my.namespace.com.address":{"City":"foo","State":"bar"}},"MaybeHobby":{"string":"dancing"},"Name":"foo"}
```
Given this, I think it would be unnatural for the kafka producers to be handling a different json format than the kafka consumers by default.

3. Changing the default value to `true` does mess anyone up who didn't set the value of `avro_raw_json` and kept the default of false, thinking they are using avro json this whole time.
For example they may not have used any union types, they upgrade benthos to latest version, and then at a much later date they go to add an avro json value that involves a union, and then they are unexpectedly given an error because the default value of `avro_raw_json` has switched to true and wants raw json. So I would argue that whether we keep the value as `false` or set it to `true`, we are creating a breaking change. And `avro_raw_json` defaulting to `false` will cause less confusion in the long run.