### PR TITLE
Fix Elasticsearch output action field

### DIFF
--- a/internal/impl/elasticsearch/output.go
+++ b/internal/impl/elasticsearch/output.go
@@ -58,7 +58,7 @@ false for connections to succeed.`),
 		Config: docs.FieldComponent().WithChildren(
 			docs.FieldString("urls", "A list of URLs to connect to. If an item of the list contains commas it will be expanded into multiple URLs.", []string{"http://localhost:9200"}).Array(),
 			docs.FieldString("index", "The index to place messages.").IsInterpolated(),
-			docs.FieldString("action", "The action to take on the document.").IsInterpolated().HasOptions("create", "index", "update", "upsert", "delete").Advanced(),
+			docs.FieldString("action", "The action to take on the document. This field must resolve to one of the following action types: `create`, `index`, `update`, `upsert` or `delete`.").IsInterpolated().Advanced(),
 			docs.FieldString("pipeline", "An optional pipeline id to preprocess incoming documents.").IsInterpolated().Advanced(),
 			docs.FieldString("id", "The ID for indexed messages. Interpolation should be used in order to create a unique ID for each message.").IsInterpolated(),
 			docs.FieldString("type", "The document mapping type. This field is required for versions of elasticsearch earlier than 6.0.0, but are invalid for versions 7.0.0 or later.").Optional().IsInterpolated(),

--- a/website/docs/components/outputs/elasticsearch.md
+++ b/website/docs/components/outputs/elasticsearch.md
@@ -151,13 +151,12 @@ Default: `""`
 
 ### `action`
 
-The action to take on the document.
+The action to take on the document. This field must resolve to one of the following action types: `create`, `index`, `update`, `upsert` or `delete`.
 This field supports [interpolation functions](/docs/configuration/interpolation#bloblang-queries).
 
 
 Type: `string`  
 Default: `"index"`  
-Options: `create`, `index`, `update`, `upsert`, `delete`.
 
 ### `pipeline`
 


### PR DESCRIPTION
We can't lint the value of this field if it gets resolved at runtime from an interpolated bloblang expression.