### PR TITLE
Convert YAML config to JSON for HandleList

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -49,6 +49,7 @@ require (
 	github.com/eclipse/paho.mqtt.golang v1.3.5
 	github.com/fatih/color v1.13.0
 	github.com/fsnotify/fsnotify v1.5.1
+	github.com/ghodss/yaml v1.0.0
 	github.com/go-redis/redis/v7 v7.4.1
 	github.com/go-sql-driver/mysql v1.6.0
 	github.com/go-stack/stack v1.8.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -413,6 +413,7 @@ github.com/fsnotify/fsnotify v1.5.1/go.mod h1:T3375wBYaZdLLcVNkcVbzGHY7f1l/uK5T5
 github.com/gabriel-vasile/mimetype v1.4.0 h1:Cn9dkdYsMIu56tGho+fqzh7XmvY2YyGU0FnbhiOsEro=
 github.com/gabriel-vasile/mimetype v1.4.0/go.mod h1:fA8fi6KUiG7MgQQ+mEWotXoEOvmxRtOJlERCzSmRvr8=
 github.com/gdamore/optopia v0.2.0/go.mod h1:YKYEwo5C1Pa617H7NlPcmQXl+vG6YnSSNB44n8dNL0Q=
+github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/go-fonts/dejavu v0.1.0/go.mod h1:4Wt4I4OU2Nq9asgDCteaAaWZOV24E+0/Pwo0gppep4g=
 github.com/go-fonts/latin-modern v0.2.0/go.mod h1:rQVLdDMK+mK1xscDwsqM5J8U2jrRa3T0ecnM9pNujks=

--- a/internal/impl/io/input_dynamic.go
+++ b/internal/impl/io/input_dynamic.go
@@ -5,8 +5,8 @@ import (
 	"path"
 	"sync"
 
-	"gopkg.in/yaml.v3"
 	yamlutil "github.com/ghodss/yaml"
+	"gopkg.in/yaml.v3"
 
 	"github.com/benthosdev/benthos/v4/internal/api"
 	"github.com/benthosdev/benthos/v4/internal/bundle"

--- a/internal/impl/io/input_dynamic.go
+++ b/internal/impl/io/input_dynamic.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 
 	"gopkg.in/yaml.v3"
+	yamlutil "github.com/ghodss/yaml"
 
 	"github.com/benthosdev/benthos/v4/internal/api"
 	"github.com/benthosdev/benthos/v4/internal/bundle"
@@ -75,6 +76,7 @@ func newDynamicInput(conf input.Config, mgr bundle.NewManagement) (input.Streame
 				sanitConf.RemoveTypeField = true
 				if err := docs.FieldInput("input", "").SanitiseYAML(&node, sanitConf); err == nil {
 					confBytes, _ = yaml.Marshal(node)
+					confBytes, _ = yamlutil.YAMLToJSON(confBytes)
 				}
 			}
 

--- a/internal/impl/io/input_dynamic_test.go
+++ b/internal/impl/io/input_dynamic_test.go
@@ -68,13 +68,7 @@ generate:
 	gMux.ServeHTTP(res, req)
 
 	assert.Equal(t, 200, res.Code)
-	assert.Equal(t, `label: ""
-generate:
-    mapping: root.source = "foo"
-    interval: 100ms
-    count: 0
-    batch_size: 1
-`, res.Body.String())
+	assert.Equal(t, `{"generate":{"batch_size":1,"count":0,"interval":"100ms","mapping":"root.source = \"foo\""},"label":""}`, res.Body.String())
 
 	i.TriggerStopConsuming()
 	require.NoError(t, i.WaitForClose(ctx))

--- a/internal/impl/io/output_dynamic.go
+++ b/internal/impl/io/output_dynamic.go
@@ -5,8 +5,8 @@ import (
 	"path"
 	"sync"
 
-	"gopkg.in/yaml.v3"
 	yamlutil "github.com/ghodss/yaml"
+	"gopkg.in/yaml.v3"
 
 	"github.com/benthosdev/benthos/v4/internal/api"
 	"github.com/benthosdev/benthos/v4/internal/bundle"

--- a/internal/impl/io/output_dynamic.go
+++ b/internal/impl/io/output_dynamic.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 
 	"gopkg.in/yaml.v3"
+	yamlutil "github.com/ghodss/yaml"
 
 	"github.com/benthosdev/benthos/v4/internal/api"
 	"github.com/benthosdev/benthos/v4/internal/bundle"
@@ -82,6 +83,7 @@ func newDynamicOutput(conf output.Config, mgr bundle.NewManagement) (output.Stre
 				sanitConf.RemoveTypeField = true
 				if err := docs.FieldOutput("output", "").SanitiseYAML(&node, sanitConf); err == nil {
 					confBytes, _ = yaml.Marshal(node)
+					confBytes, _ = yamlutil.YAMLToJSON(confBytes)
 				}
 			}
 

--- a/internal/impl/io/output_dynamic_test.go
+++ b/internal/impl/io/output_dynamic_test.go
@@ -71,9 +71,7 @@ func TestDynamicOutputAPI(t *testing.T) {
 	gMux.ServeHTTP(res, req)
 
 	assert.Equal(t, 200, res.Code)
-	assert.Equal(t, `label: ""
-drop: {}
-`, res.Body.String())
+	assert.Equal(t, `{"drop":{},"label":""}`, res.Body.String())
 
 	o.TriggerCloseNow()
 	require.NoError(t, o.WaitForClose(ctx))


### PR DESCRIPTION
The dynamic CRUD API is marshalling a YAML object into json.RawMessage object.   The HandleList endpoints are returning an internal server error because it cannot marshal the YAML into JSON.     This PR converts the YAML into valid JSON before it is returned to the caller.