### PR TITLE
Add description to parquet_encode processor schema field

### DIFF
--- a/internal/impl/parquet/processor_encode.go
+++ b/internal/impl/parquet/processor_encode.go
@@ -82,7 +82,7 @@ func parquetSchemaConfig() *service.ConfigField {
 				"name": "bar",
 				"type": "BYTE_ARRAY",
 			},
-		}),
+		}).Description("Parquet schema."),
 	)
 }
 

--- a/website/docs/components/processors/parquet_encode.md
+++ b/website/docs/components/processors/parquet_encode.md
@@ -108,7 +108,7 @@ Default: `false`
 
 ### `schema[].fields`
 
-A list of child fields.
+Parquet schema.
 
 
 Type: `array`  


### PR DESCRIPTION
Maybe this should be something like "Parquet schema mapping"?