### PR TITLE
Refactor dispatchMessages to remove the need for mutex

### DIFF
--- a/internal/pipeline/processor.go
+++ b/internal/pipeline/processor.go
@@ -98,7 +98,7 @@ func (p *Processor) dispatchMessages(ctx context.Context, msgs []message.Batch, 
 
 		var newPending = make([]message.Batch, len(pending))
 
-		for i, _ := range pending {
+		for i := range pending {
 			transac := message.NewTransactionFunc(pending[i].ShallowCopy(), func(ctx context.Context, err error) error {
 				if err != nil {
 					newPending[i] = pending[i]

--- a/internal/pipeline/processor.go
+++ b/internal/pipeline/processor.go
@@ -96,16 +96,12 @@ func (p *Processor) dispatchMessages(ctx context.Context, msgs []message.Batch, 
 		wg := sync.WaitGroup{}
 		wg.Add(len(pending))
 
-		var newPending []message.Batch
-		var newPendingMut sync.Mutex
+		var newPending = make([]message.Batch, len(pending))
 
-		for _, b := range pending {
-			b := b
-			transac := message.NewTransactionFunc(b.ShallowCopy(), func(ctx context.Context, err error) error {
+		for i, _ := range pending {
+			transac := message.NewTransactionFunc(pending[i].ShallowCopy(), func(ctx context.Context, err error) error {
 				if err != nil {
-					newPendingMut.Lock()
-					newPending = append(newPending, b)
-					newPendingMut.Unlock()
+					newPending[i] = pending[i]
 				}
 				wg.Done()
 				return nil


### PR DESCRIPTION
Slight refactoring of dispatch messages to remove the need for the mutex and allocate the array for pending up front since we know the size in advance.