### PR TITLE
feat: implement header propagation for the kafka input

### DIFF
--- a/internal/impl/io/input_http_server.go
+++ b/internal/impl/io/input_http_server.go
@@ -330,12 +330,9 @@ func (h *httpServerInput) extractMessageFromRequest(r *http.Request) (message.Ba
 	})
 
 	textMapGeneric := map[string]interface{}{}
-	// Go normalises headers changing the way they are capitalised, here we are converting from normalised headers to
-	// a TextMap format which is case-sensitive. To ensure propagation still happens we need to convert the headers to
-	// lowercase as that is the format expected by the OTEL libraries.
 	for k, vals := range r.Header {
 		for _, v := range vals {
-			textMapGeneric[strings.ToLower(k)] = v
+			textMapGeneric[k] = v
 		}
 	}
 

--- a/internal/tracing/otel.go
+++ b/internal/tracing/otel.go
@@ -2,6 +2,7 @@ package tracing
 
 import (
 	"context"
+	"strings"
 
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/propagation"
@@ -159,7 +160,7 @@ func InitSpansFromParentTextMap(prov trace.TracerProvider, operationName string,
 	c := propagation.MapCarrier{}
 	for k, v := range textMapGeneric {
 		if vStr, ok := v.(string); ok {
-			c[k] = vStr
+			c[strings.ToLower(k)] = vStr
 		}
 	}
 

--- a/internal/tracing/otel_test.go
+++ b/internal/tracing/otel_test.go
@@ -1,0 +1,39 @@
+package tracing
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/propagation"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/benthosdev/benthos/v4/internal/message"
+)
+
+func TestInitSpansFromParentTextMap(t *testing.T) {
+	t.Run("it will update the context for each message in the batch", func(t *testing.T) {
+		textMap := map[string]interface{}{
+			"traceparent": "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01",
+		}
+
+		msgOne := message.NewPart([]byte("hello"))
+		msgTwo := message.NewPart([]byte("world"))
+
+		batch := message.Batch([]*message.Part{msgOne, msgTwo})
+
+		otel.SetTextMapPropagator(propagation.NewCompositeTextMapPropagator(propagation.TraceContext{}))
+		tp := trace.NewNoopTracerProvider()
+
+		err := InitSpansFromParentTextMap(tp, "test", textMap, batch)
+		assert.Nil(t, err)
+
+		spanOne := trace.SpanFromContext(batch[0].GetContext())
+		assert.Equal(t, "4bf92f3577b34da6a3ce929d0e0e4736", spanOne.SpanContext().TraceID().String())
+		assert.Equal(t, "00f067aa0ba902b7", spanOne.SpanContext().SpanID().String())
+
+		spanTwo := trace.SpanFromContext(batch[1].GetContext())
+		assert.Equal(t, "4bf92f3577b34da6a3ce929d0e0e4736", spanTwo.SpanContext().TraceID().String())
+		assert.Equal(t, "00f067aa0ba902b7", spanTwo.SpanContext().SpanID().String())
+	})
+}

--- a/website/docs/components/tracers/about.md
+++ b/website/docs/components/tracers/about.md
@@ -10,6 +10,8 @@ When a tracer is configured all messages will be allocated a root span during in
 Some inputs, such as `http_server` and `http_client`, are capable of extracting a root span from the source of the message (HTTP headers). This is
 a work in progress and should eventually expand so that all inputs have a way of doing so.
 
+Other inputs, such as `kafka` can be configured to extract a root span by using the `extract_tracing_map` field.
+
 A tracer config section looks like this:
 
 ```yaml


### PR DESCRIPTION
This PR allows propagation of parent spans when using the `kafka` input. For this we are using the `traceparent` header that can be attached to a Kafka message.

Example: 
![image](https://user-images.githubusercontent.com/507871/185650670-31dba609-11c4-4b9a-a2cf-f7cf660d661d.png)
