### PR TITLE
Fix bugs in tracing config and in http server input metadata

### DIFF
--- a/internal/impl/io/input_http_server.go
+++ b/internal/impl/io/input_http_server.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"mime"
 	"mime/multipart"
+	"net"
 	"net/http"
 	"net/textproto"
 	"strconv"
@@ -291,7 +292,13 @@ func (h *httpServerInput) extractMessageFromRequest(r *http.Request) (message.Ba
 		p.MetaSet("http_server_user_agent", r.UserAgent())
 		p.MetaSet("http_server_request_path", r.URL.Path)
 		p.MetaSet("http_server_verb", r.Method)
-		p.MetaSet("http_server_remote_ip", strings.Split(r.RemoteAddr, ":")[0])
+
+		host, _, err := net.SplitHostPort(r.RemoteAddr)
+		if err != nil {
+			return fmt.Errorf("failed to extract host from request remote addr: %s", err)
+		}
+		p.MetaSet("http_server_remote_ip", host)
+
 		if r.TLS != nil {
 			var tlsVersion string
 			switch r.TLS.Version {

--- a/internal/impl/otlp/tracer_otlp.go
+++ b/internal/impl/otlp/tracer_otlp.go
@@ -91,7 +91,7 @@ func collectors(conf *service.ParsedConfig, name string) ([]collector, error) {
 	if err != nil {
 		return nil, err
 	}
-	collectors := make([]collector, len(list))
+	collectors := make([]collector, 0, len(list))
 	for _, pc := range list {
 		u, err := pc.FieldString("url")
 		if err != nil {


### PR DESCRIPTION
- For the `http_server` input, using `strings.Split(r.RemoteAddr, ":")[0]` will fail to extract the IP if `RemoteAddr` ends up being something like `"[::1]:53947"`.
- Avoid creating empty tracing collector. This fixes #1399.