### PR TITLE
feat: add lint to require labels on components

### DIFF
--- a/internal/cli/test/command.go
+++ b/internal/cli/test/command.go
@@ -90,7 +90,7 @@ func GetTestTargets(targetPaths []string, testSuffix string) (map[string]Definit
 func lintTarget(path, testSuffix string) ([]string, error) {
 	confPath, _ := GetPathPair(path, testSuffix)
 	dummyConf := config.New()
-	lints, err := config.ReadFileLinted(confPath, false, &dummyConf)
+	lints, err := config.ReadFileLinted(confPath, &config.LintOptions{}, &dummyConf)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/config/lint.go
+++ b/internal/config/lint.go
@@ -11,9 +11,15 @@ import (
 	"github.com/benthosdev/benthos/v4/internal/docs"
 )
 
+// LintOptions specifies the linters that will be enabled.
+type LintOptions struct {
+	RejectDeprecated bool
+	RequireLabels    bool
+}
+
 // ReadFileLinted will attempt to read a configuration file path into a
 // structure. Returns an array of lint messages or an error.
-func ReadFileLinted(path string, rejectDeprecated bool, config *Type) ([]string, error) {
+func ReadFileLinted(path string, opts *LintOptions, config *Type) ([]string, error) {
 	configBytes, lints, err := ReadFileEnvSwap(path)
 	if err != nil {
 		return nil, err
@@ -24,7 +30,8 @@ func ReadFileLinted(path string, rejectDeprecated bool, config *Type) ([]string,
 	}
 
 	lintCtx := docs.NewLintContext()
-	lintCtx.RejectDeprecated = rejectDeprecated
+	lintCtx.RejectDeprecated = opts.RejectDeprecated
+	lintCtx.RequireLabels = opts.RequireLabels
 	newLints, err := LintBytes(lintCtx, configBytes)
 	if err != nil {
 		return nil, err

--- a/internal/docs/field.go
+++ b/internal/docs/field.go
@@ -563,6 +563,9 @@ type LintContext struct {
 
 	// Reject any deprecated components or fields as linting errors.
 	RejectDeprecated bool
+
+	// Require labels for components.
+	RequireLabels bool
 }
 
 // NewLintContext creates a new linting context.
@@ -572,6 +575,7 @@ func NewLintContext() LintContext {
 		DocsProvider:     DeprecatedProvider,
 		BloblangEnv:      bloblang.GlobalEnvironment().Deactivated(),
 		RejectDeprecated: false,
+		RequireLabels:    false,
 	}
 }
 

--- a/internal/docs/yaml_test.go
+++ b/internal/docs/yaml_test.go
@@ -632,6 +632,7 @@ func TestYAMLComponentLinting(t *testing.T) {
 		inputType        docs.Type
 		inputConf        string
 		rejectDeprecated bool
+		requireLabels    bool
 
 		res []docs.Lint
 	}
@@ -681,6 +682,17 @@ testlintfooinput:
 			rejectDeprecated: true,
 			res: []docs.Lint{
 				docs.NewLintError(4, "field foo6 is deprecated"),
+			},
+		},
+		{
+			name:      "require label",
+			inputType: docs.TypeInput,
+			inputConf: `
+testlintbarinput:
+  bar1: hello world`,
+			requireLabels: true,
+			res: []docs.Lint{
+				docs.NewLintError(2, "label is required for testlintbarinput"),
 			},
 		},
 		{
@@ -921,6 +933,7 @@ testlintfooinput:
 		t.Run(test.name, func(t *testing.T) {
 			lintCtx := docs.NewLintContext()
 			lintCtx.RejectDeprecated = test.rejectDeprecated
+			lintCtx.RequireLabels = test.requireLabels
 			lintCtx.DocsProvider = prov
 
 			var node yaml.Node

--- a/internal/serverless/lambda/lambda.go
+++ b/internal/serverless/lambda/lambda.go
@@ -57,7 +57,7 @@ func Run() {
 		// Iterate default config paths
 		for _, path := range defaultPaths {
 			if _, err := os.Stat(path); err == nil {
-				if _, err = config.ReadFileLinted(path, false, &conf); err != nil {
+				if _, err = config.ReadFileLinted(path, &config.LintOptions{}, &conf); err != nil {
 					fmt.Fprintf(os.Stderr, "Configuration file read error: %v\n", err)
 					os.Exit(1)
 				}

--- a/internal/stream/manager/from_directory.go
+++ b/internal/stream/manager/from_directory.go
@@ -58,7 +58,7 @@ func LoadStreamConfigsFromDirectory(replaceEnvVars bool, dir string) (map[string
 		}
 
 		conf := config.New()
-		if _, readerr := config.ReadFileLinted(path, false, &conf); readerr != nil {
+		if _, readerr := config.ReadFileLinted(path, &config.LintOptions{}, &conf); readerr != nil {
 			// TODO: Read and report linting errors.
 			return readerr
 		}


### PR DESCRIPTION
This change adds a new lint option that checks that all relevant components have labels.

## Why

Labelled components will have stable metric names that can improve discoverability and prevent clobbering past time series.

Currently, an unlabelled processor has the following time series:

```
processor_batch_sent{label="",path="root.pipeline.processors.0"} 9
```

This is problematic because, if the config changes, then the processor at `root.pipeline.processors.0` can change to something else entirely and disrupt the time-series.

Labelling it will result in:

```
processor_batch_sent{label="format_msg",path="root.pipeline.processors.0"} 9
```

This is better because it can tolerate changes to the structure of the config if users query the metric by the `label` label in their dashboards.

## Example

Given:

```yaml
input:
  broker:
    inputs:
      - generate:
          mapping: |
            root = {
              "id": uuid_v4(),
              "msg": "hello world"
            }
    batching:
      count: 5

pipeline:
  processors:
    - label: format_msg
      bloblang: |
        root = this
        root.msg = this.msg.uppercase()

output:
  drop: {}
```

Output:

```
❯ ./target/bin/benthos lint --labels ./scratch/sample.yml
./scratch/sample.yml: line 4: label is required for generate
./scratch/sample.yml: line 2: label is required for broker
./scratch/sample.yml: line 21: label is required for drop
```