### PR TITLE
Add Jaeger tracer default tags

### DIFF
--- a/internal/impl/jaeger/tracer_jaeger_test.go
+++ b/internal/impl/jaeger/tracer_jaeger_test.go
@@ -1,10 +1,18 @@
 package jaeger
 
 import (
+	"context"
 	"testing"
 
+	"github.com/benthosdev/benthos/v4/internal/cli"
+	"github.com/benthosdev/benthos/v4/internal/component/tracer"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/exporters/jaeger"
+	tracesdk "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+	semconv "go.opentelemetry.io/otel/semconv/v1.7.0"
 )
 
 func TestGetAgentOps(t *testing.T) {
@@ -37,5 +45,78 @@ func TestGetAgentOps(t *testing.T) {
 			assert.Len(t, opts, len(testCase.want))
 			assert.NoError(t, err)
 		})
+	}
+}
+
+func TestNewJaeger(t *testing.T) {
+	exporter := tracetest.NewInMemoryExporter()
+	exporterInitFn = func(_ jaeger.EndpointOption) (tracesdk.SpanExporter, error) {
+		return exporter, nil
+	}
+
+	dummyVersion := "v1.0"
+
+	// Naughty global value reassignment
+	origCliVersion := cli.Version
+	cli.Version = dummyVersion
+	defer func() { cli.Version = origCliVersion }()
+
+	tests := []struct {
+		Name           string
+		ServiceName    string
+		ServiceVersion string
+		Tags           map[string]string
+	}{
+		{
+			Name:           "no tags",
+			ServiceName:    "benthos",
+			ServiceVersion: dummyVersion,
+		},
+		{
+			Name:           "tags can overwrite service name and version",
+			ServiceName:    "foobar",
+			ServiceVersion: "6.6.6",
+			Tags: map[string]string{
+				string(semconv.ServiceNameKey):    "foobar",
+				string(semconv.ServiceVersionKey): "6.6.6",
+			},
+		},
+		{
+			Name: "supports extra arbitrary tags",
+			Tags: map[string]string{
+				"foo": "bar",
+			},
+		},
+	}
+
+	for _, test := range tests {
+		exporter.Reset()
+
+		cfg := tracer.NewConfig()
+		cfg.Jaeger.Tags = test.Tags
+
+		jaegerProvider, err := NewJaeger(cfg, nil)
+		require.NoError(t, err, test.Name)
+
+		// Add a span and flush it
+		_, span := jaegerProvider.Tracer("testProvider").Start(context.Background(), "testSpan")
+		span.AddEvent("testEvent")
+		span.End()
+		jaegerProvider.(*tracesdk.TracerProvider).ForceFlush(context.Background())
+
+		snapshots := exporter.GetSpans().Snapshots()
+		require.Len(t, snapshots, 1, test.Name)
+		resource := snapshots[0].Resource()
+		require.NotNil(t, resource, test.Name)
+		attrs := resource.Attributes()
+
+		if len(test.Tags) != 1 {
+			require.Len(t, attrs, 2, test.Name)
+			require.Equal(t, semconv.ServiceNameKey.String(test.ServiceName), attrs[0], test.Name)
+			require.Equal(t, semconv.ServiceVersionKey.String(test.ServiceVersion), attrs[1], test.Name)
+		} else {
+			require.Len(t, attrs, 3, test.Name)
+			require.Equal(t, attribute.Key("foo").String("bar"), attrs[0], test.Name)
+		}
 	}
 }


### PR DESCRIPTION
Inspired from this blog article: http://www.inanzzz.com/index.php/post/4qes/implementing-opentelemetry-and-jaeger-tracing-in-golang-http-api

This code adds 2 default tags to the Jaeger tracer: `service.name` and `service.version` (which can still be overridden via the `jaeger.tags` configuration field.