### PR TITLE
add endpoint to serve pprof goroutine profile

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -197,6 +197,10 @@ func New(
 			pprof.Index,
 		)
 		t.RegisterEndpoint(
+			"/debug/pprof/goroutine", "DEBUG: Responds with a pprof-formatted goroutine profile.",
+			pprof.Index,
+		)
+		t.RegisterEndpoint(
 			"/debug/pprof/block", "DEBUG: Responds with a pprof-formatted block profile.",
 			pprof.Index,
 		)


### PR DESCRIPTION
Registers an endpoint at `/debug/pprof/goroutine` to serve the goroutine profile.