### PR TITLE
add priority config to gcp_bigquery_select input

### DIFF
--- a/website/docs/components/inputs/gcp_bigquery_select.md
+++ b/website/docs/components/inputs/gcp_bigquery_select.md
@@ -32,6 +32,7 @@ input:
     columns: []
     where: ""
     job_labels: {}
+    priority: ""
     args_mapping: ""
     prefix: ""
     suffix: ""
@@ -121,6 +122,14 @@ A list of labels to add to the query job.
 
 Type: `object`  
 Default: `{}`  
+
+### `priority`
+
+The priority with which to schedule the query.
+
+
+Type: `string`  
+Default: `""`  
 
 ### `args_mapping`
 


### PR DESCRIPTION
Closes  #1311

This change adds a query `priority` config field to the `gcp_bigquery_select` that can be set to either "interactive" or "batch".