### PR TITLE
Fix InfluxDB Key/Value Mismatches

### DIFF
--- a/internal/impl/influxdb/metrics_influxdb_types.go
+++ b/internal/impl/influxdb/metrics_influxdb_types.go
@@ -62,10 +62,12 @@ func encodeInfluxDBName(name string, tagNames, tagValues []string) string {
 			tags[v] = tagValues[k]
 		}
 
-		sort.Strings(tagNames)
+		tagSort := make([]string, len(tagNames))
+		copy(tagSort, tagNames)
+		sort.Strings(tagSort)
 
 		// name,tag1=value1,tag2=value\ 3
-		for _, v := range tagNames {
+		for _, v := range tagSort {
 			b.WriteString(tagEncodingSeparator)
 			b.WriteString(escape.String(v))
 			b.WriteString("=")


### PR DESCRIPTION
Sort tags from copy in order to retain correct order of original tagNames to stop tagName/tagValue mismatches.

#1430 