### PR TITLE
Add ability to authenticate with the schema registry with basic auth credentials

### DIFF
--- a/internal/impl/confluent/processor_schema_registry_decode.go
+++ b/internal/impl/confluent/processor_schema_registry_decode.go
@@ -108,7 +108,7 @@ func newSchemaRegistryDecoderFromConfig(conf *service.ParsedConfig, logger *serv
 	return newSchemaRegistryDecoder(urlStr, usernameStr, passwordStr, tlsConf, avroRawJSON, logger)
 }
 
-func newSchemaRegistryDecoder(urlStr string, usernameStr string, passwordStr string, tlsConf *tls.Config, avroRawJSON bool, logger *service.Logger) (*schemaRegistryDecoder, error) {
+func newSchemaRegistryDecoder(urlStr, usernameStr, passwordStr string, tlsConf *tls.Config, avroRawJSON bool, logger *service.Logger) (*schemaRegistryDecoder, error) {
 	u, err := url.Parse(urlStr)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse url: %w", err)

--- a/internal/impl/confluent/processor_schema_registry_decode.go
+++ b/internal/impl/confluent/processor_schema_registry_decode.go
@@ -130,7 +130,7 @@ func newSchemaRegistryDecoder(urlStr string, basicAuthEnabledBool bool, username
 	}
 
 	var token string
-	if basicAuthEnabledBool == true {
+	if basicAuthEnabledBool {
 		token = base64.StdEncoding.EncodeToString([]byte(usernameStr + ":" + passwordStr))
 	}
 

--- a/internal/impl/confluent/processor_schema_registry_decode_test.go
+++ b/internal/impl/confluent/processor_schema_registry_decode_test.go
@@ -43,8 +43,10 @@ url: http://example.com/v1
 			name: "url with basic auth",
 			config: `
 url: http://example.com/v1
-username: user
-password: pass
+basic_auth:
+  enabled: true
+  username: user
+  password: pass
 `,
 			expectedBaseURL:        "http://example.com/v1",
 			expectedBasicAuthToken: "dXNlcjpwYXNz",
@@ -200,7 +202,7 @@ func TestSchemaRegistryDecodeAvro(t *testing.T) {
 		return nil, nil
 	})
 
-	decoder, err := newSchemaRegistryDecoder(urlStr, "", "", nil, false, nil)
+	decoder, err := newSchemaRegistryDecoder(urlStr, false, "", "", nil, false, nil)
 	require.NoError(t, err)
 
 	tests := []struct {
@@ -303,7 +305,7 @@ func TestSchemaRegistryDecodeAvroRawJson(t *testing.T) {
 		return nil, nil
 	})
 
-	decoder, err := newSchemaRegistryDecoder(urlStr, "", "", nil, true, nil)
+	decoder, err := newSchemaRegistryDecoder(urlStr, false, "", "", nil, true, nil)
 	require.NoError(t, err)
 
 	tests := []struct {
@@ -381,7 +383,7 @@ func TestSchemaRegistryDecodeClearExpired(t *testing.T) {
 		return nil, fmt.Errorf("nope")
 	})
 
-	decoder, err := newSchemaRegistryDecoder(urlStr, "", "", nil, false, nil)
+	decoder, err := newSchemaRegistryDecoder(urlStr, false, "", "", nil, false, nil)
 	require.NoError(t, err)
 	require.NoError(t, decoder.Close(context.Background()))
 

--- a/internal/impl/confluent/processor_schema_registry_decode_test.go
+++ b/internal/impl/confluent/processor_schema_registry_decode_test.go
@@ -18,10 +18,11 @@ import (
 
 func TestSchemaRegistryDecoderConfigParse(t *testing.T) {
 	configTests := []struct {
-		name            string
-		config          string
-		errContains     string
-		expectedBaseURL string
+		name                   string
+		config                 string
+		errContains            string
+		expectedBaseURL        string
+		expectedBasicAuthToken string
 	}{
 		{
 			name: "bad url",
@@ -35,7 +36,18 @@ url: huh#%#@$u*not////::example.com
 			config: `
 url: http://example.com/v1
 `,
-			expectedBaseURL: "http://example.com/v1",
+			expectedBaseURL:        "http://example.com/v1",
+			expectedBasicAuthToken: "",
+		},
+		{
+			name: "url with basic auth",
+			config: `
+url: http://example.com/v1
+username: user
+password: pass
+`,
+			expectedBaseURL:        "http://example.com/v1",
+			expectedBasicAuthToken: "dXNlcjpwYXNz",
 		},
 	}
 
@@ -50,6 +62,7 @@ url: http://example.com/v1
 
 			if e != nil {
 				assert.Equal(t, test.expectedBaseURL, e.schemaRegistryBaseURL.String())
+				assert.Equal(t, test.expectedBasicAuthToken, e.schemaRegistryBasicAuthToken)
 			}
 
 			if err == nil {
@@ -187,7 +200,7 @@ func TestSchemaRegistryDecodeAvro(t *testing.T) {
 		return nil, nil
 	})
 
-	decoder, err := newSchemaRegistryDecoder(urlStr, nil, false, nil)
+	decoder, err := newSchemaRegistryDecoder(urlStr, "", "", nil, false, nil)
 	require.NoError(t, err)
 
 	tests := []struct {
@@ -290,7 +303,7 @@ func TestSchemaRegistryDecodeAvroRawJson(t *testing.T) {
 		return nil, nil
 	})
 
-	decoder, err := newSchemaRegistryDecoder(urlStr, nil, true, nil)
+	decoder, err := newSchemaRegistryDecoder(urlStr, "", "", nil, true, nil)
 	require.NoError(t, err)
 
 	tests := []struct {
@@ -368,7 +381,7 @@ func TestSchemaRegistryDecodeClearExpired(t *testing.T) {
 		return nil, fmt.Errorf("nope")
 	})
 
-	decoder, err := newSchemaRegistryDecoder(urlStr, nil, false, nil)
+	decoder, err := newSchemaRegistryDecoder(urlStr, "", "", nil, false, nil)
 	require.NoError(t, err)
 	require.NoError(t, decoder.Close(context.Background()))
 

--- a/internal/impl/confluent/processor_schema_registry_encode.go
+++ b/internal/impl/confluent/processor_schema_registry_encode.go
@@ -175,7 +175,7 @@ func newSchemaRegistryEncoder(
 	}
 
 	var token string
-	if basicAuthEnabledBool == true {
+	if basicAuthEnabledBool {
 		token = base64.StdEncoding.EncodeToString([]byte(usernameStr + ":" + passwordStr))
 	}
 

--- a/internal/impl/confluent/processor_schema_registry_encode.go
+++ b/internal/impl/confluent/processor_schema_registry_encode.go
@@ -144,8 +144,8 @@ func newSchemaRegistryEncoderFromConfig(conf *service.ParsedConfig, logger *serv
 }
 
 func newSchemaRegistryEncoder(
-	urlStr string,
-	usernameStr string,
+	urlStr,
+	usernameStr,
 	passwordStr string,
 	tlsConf *tls.Config,
 	subject *service.InterpolatedString,

--- a/internal/impl/confluent/processor_schema_registry_encode_test.go
+++ b/internal/impl/confluent/processor_schema_registry_encode_test.go
@@ -17,10 +17,11 @@ import (
 
 func TestSchemaRegistryEncoderConfigParse(t *testing.T) {
 	configTests := []struct {
-		name            string
-		config          string
-		errContains     string
-		expectedBaseURL string
+		name                   string
+		config                 string
+		errContains            string
+		expectedBaseURL        string
+		expectedBasicAuthToken string
 	}{
 		{
 			name: "bad url",
@@ -44,7 +45,8 @@ subject: ${! bad interpolation }
 url: http://example.com
 subject: foo
 `,
-			expectedBaseURL: "http://example.com",
+			expectedBaseURL:        "http://example.com",
+			expectedBasicAuthToken: "",
 		},
 		{
 			name: "bad period",
@@ -61,7 +63,19 @@ refresh_period: not a duration
 url: http://example.com/v1
 subject: foo
 `,
-			expectedBaseURL: "http://example.com/v1",
+			expectedBaseURL:        "http://example.com/v1",
+			expectedBasicAuthToken: "",
+		},
+		{
+			name: "url with basic auth",
+			config: `
+url: http://example.com/v1
+username: user
+password: pass
+subject: foo
+`,
+			expectedBaseURL:        "http://example.com/v1",
+			expectedBasicAuthToken: "dXNlcjpwYXNz",
 		},
 	}
 
@@ -76,6 +90,7 @@ subject: foo
 
 			if e != nil {
 				assert.Equal(t, test.expectedBaseURL, e.schemaRegistryBaseURL.String())
+				assert.Equal(t, test.expectedBasicAuthToken, e.schemaRegistryBasicAuthToken)
 			}
 
 			if err == nil {
@@ -111,7 +126,7 @@ func TestSchemaRegistryEncodeAvro(t *testing.T) {
 	subj, err := service.NewInterpolatedString("foo")
 	require.NoError(t, err)
 
-	encoder, err := newSchemaRegistryEncoder(urlStr, nil, subj, false, time.Minute*10, time.Minute, nil)
+	encoder, err := newSchemaRegistryEncoder(urlStr, "", "", nil, subj, false, time.Minute*10, time.Minute, nil)
 	require.NoError(t, err)
 
 	tests := []struct {
@@ -193,7 +208,7 @@ func TestSchemaRegistryEncodeAvroRawJSON(t *testing.T) {
 	subj, err := service.NewInterpolatedString("foo")
 	require.NoError(t, err)
 
-	encoder, err := newSchemaRegistryEncoder(urlStr, nil, subj, true, time.Minute*10, time.Minute, nil)
+	encoder, err := newSchemaRegistryEncoder(urlStr, "", "", nil, subj, true, time.Minute*10, time.Minute, nil)
 	require.NoError(t, err)
 
 	tests := []struct {
@@ -275,7 +290,7 @@ func TestSchemaRegistryEncodeAvroLogicalTypes(t *testing.T) {
 	subj, err := service.NewInterpolatedString("foo")
 	require.NoError(t, err)
 
-	encoder, err := newSchemaRegistryEncoder(urlStr, nil, subj, false, time.Minute*10, time.Minute, nil)
+	encoder, err := newSchemaRegistryEncoder(urlStr, "", "", nil, subj, false, time.Minute*10, time.Minute, nil)
 	require.NoError(t, err)
 
 	tests := []struct {
@@ -352,7 +367,7 @@ func TestSchemaRegistryEncodeAvroRawJSONLogicalTypes(t *testing.T) {
 	subj, err := service.NewInterpolatedString("foo")
 	require.NoError(t, err)
 
-	encoder, err := newSchemaRegistryEncoder(urlStr, nil, subj, true, time.Minute*10, time.Minute, nil)
+	encoder, err := newSchemaRegistryEncoder(urlStr, "", "", nil, subj, true, time.Minute*10, time.Minute, nil)
 	require.NoError(t, err)
 
 	tests := []struct {
@@ -417,7 +432,7 @@ func TestSchemaRegistryEncodeClearExpired(t *testing.T) {
 	subj, err := service.NewInterpolatedString("foo")
 	require.NoError(t, err)
 
-	encoder, err := newSchemaRegistryEncoder(urlStr, nil, subj, false, time.Minute*10, time.Minute, nil)
+	encoder, err := newSchemaRegistryEncoder(urlStr, "", "", nil, subj, false, time.Minute*10, time.Minute, nil)
 	require.NoError(t, err)
 	require.NoError(t, encoder.Close(context.Background()))
 
@@ -478,7 +493,7 @@ func TestSchemaRegistryEncodeRefresh(t *testing.T) {
 	subj, err := service.NewInterpolatedString("foo")
 	require.NoError(t, err)
 
-	encoder, err := newSchemaRegistryEncoder(urlStr, nil, subj, false, time.Minute*10, time.Minute, nil)
+	encoder, err := newSchemaRegistryEncoder(urlStr, "", "", nil, subj, false, time.Minute*10, time.Minute, nil)
 	require.NoError(t, err)
 	require.NoError(t, encoder.Close(context.Background()))
 

--- a/internal/impl/confluent/processor_schema_registry_encode_test.go
+++ b/internal/impl/confluent/processor_schema_registry_encode_test.go
@@ -70,8 +70,10 @@ subject: foo
 			name: "url with basic auth",
 			config: `
 url: http://example.com/v1
-username: user
-password: pass
+basic_auth:
+  enabled: true
+  username: user
+  password: pass
 subject: foo
 `,
 			expectedBaseURL:        "http://example.com/v1",
@@ -126,7 +128,7 @@ func TestSchemaRegistryEncodeAvro(t *testing.T) {
 	subj, err := service.NewInterpolatedString("foo")
 	require.NoError(t, err)
 
-	encoder, err := newSchemaRegistryEncoder(urlStr, "", "", nil, subj, false, time.Minute*10, time.Minute, nil)
+	encoder, err := newSchemaRegistryEncoder(urlStr, false, "", "", nil, subj, false, time.Minute*10, time.Minute, nil)
 	require.NoError(t, err)
 
 	tests := []struct {
@@ -208,7 +210,7 @@ func TestSchemaRegistryEncodeAvroRawJSON(t *testing.T) {
 	subj, err := service.NewInterpolatedString("foo")
 	require.NoError(t, err)
 
-	encoder, err := newSchemaRegistryEncoder(urlStr, "", "", nil, subj, true, time.Minute*10, time.Minute, nil)
+	encoder, err := newSchemaRegistryEncoder(urlStr, false, "", "", nil, subj, true, time.Minute*10, time.Minute, nil)
 	require.NoError(t, err)
 
 	tests := []struct {
@@ -290,7 +292,7 @@ func TestSchemaRegistryEncodeAvroLogicalTypes(t *testing.T) {
 	subj, err := service.NewInterpolatedString("foo")
 	require.NoError(t, err)
 
-	encoder, err := newSchemaRegistryEncoder(urlStr, "", "", nil, subj, false, time.Minute*10, time.Minute, nil)
+	encoder, err := newSchemaRegistryEncoder(urlStr, false, "", "", nil, subj, false, time.Minute*10, time.Minute, nil)
 	require.NoError(t, err)
 
 	tests := []struct {
@@ -367,7 +369,7 @@ func TestSchemaRegistryEncodeAvroRawJSONLogicalTypes(t *testing.T) {
 	subj, err := service.NewInterpolatedString("foo")
 	require.NoError(t, err)
 
-	encoder, err := newSchemaRegistryEncoder(urlStr, "", "", nil, subj, true, time.Minute*10, time.Minute, nil)
+	encoder, err := newSchemaRegistryEncoder(urlStr, false, "", "", nil, subj, true, time.Minute*10, time.Minute, nil)
 	require.NoError(t, err)
 
 	tests := []struct {
@@ -432,7 +434,7 @@ func TestSchemaRegistryEncodeClearExpired(t *testing.T) {
 	subj, err := service.NewInterpolatedString("foo")
 	require.NoError(t, err)
 
-	encoder, err := newSchemaRegistryEncoder(urlStr, "", "", nil, subj, false, time.Minute*10, time.Minute, nil)
+	encoder, err := newSchemaRegistryEncoder(urlStr, false, "", "", nil, subj, false, time.Minute*10, time.Minute, nil)
 	require.NoError(t, err)
 	require.NoError(t, encoder.Close(context.Background()))
 
@@ -493,7 +495,7 @@ func TestSchemaRegistryEncodeRefresh(t *testing.T) {
 	subj, err := service.NewInterpolatedString("foo")
 	require.NoError(t, err)
 
-	encoder, err := newSchemaRegistryEncoder(urlStr, "", "", nil, subj, false, time.Minute*10, time.Minute, nil)
+	encoder, err := newSchemaRegistryEncoder(urlStr, false, "", "", nil, subj, false, time.Minute*10, time.Minute, nil)
 	require.NoError(t, err)
 	require.NoError(t, encoder.Close(context.Background()))
 

--- a/website/docs/components/processors/schema_registry_decode.md
+++ b/website/docs/components/processors/schema_registry_decode.md
@@ -33,6 +33,8 @@ Automatically decodes and validates messages with schemas from a Confluent Schem
 label: ""
 schema_registry_decode:
   url: ""
+  username: ""
+  password: ""
 ```
 
 </TabItem>
@@ -44,6 +46,8 @@ label: ""
 schema_registry_decode:
   avro_raw_json: false
   url: ""
+  username: ""
+  password: ""
   tls:
     skip_cert_verify: false
     enable_renegotiation: false
@@ -90,6 +94,22 @@ The base URL of the schema registry service.
 
 
 Type: `string`  
+
+### `username`
+
+The basic auth username for the schema registry service.
+
+
+Type: `string`  
+Default: `""`  
+
+### `password`
+
+The basic auth password for the schema registry service.
+
+
+Type: `string`  
+Default: `""`  
 
 ### `tls`
 

--- a/website/docs/components/processors/schema_registry_decode.md
+++ b/website/docs/components/processors/schema_registry_decode.md
@@ -33,8 +33,6 @@ Automatically decodes and validates messages with schemas from a Confluent Schem
 label: ""
 schema_registry_decode:
   url: ""
-  username: ""
-  password: ""
 ```
 
 </TabItem>
@@ -46,8 +44,10 @@ label: ""
 schema_registry_decode:
   avro_raw_json: false
   url: ""
-  username: ""
-  password: ""
+  basic_auth:
+    enabled: false
+    username: ""
+    password: ""
   tls:
     skip_cert_verify: false
     enable_renegotiation: false
@@ -59,24 +59,7 @@ schema_registry_decode:
 </TabItem>
 </Tabs>
 
-Decodes messages automatically from a schema stored within a [Confluent Schema Registry service](https://docs.confluent.io/platform/current/schema-registry/index.html) by extracting a schema ID from the message and obtaining the associated schema from the registry. If a message fails to match against the schema then it will remain unchanged and the error can be caught using error handling methods outlined [here](/docs/configuration/error_handling).
-
-Currently only Avro schemas are supported.
-
-### Avro JSON Format
-
-This processor creates documents formatted as [Avro JSON](https://avro.apache.org/docs/current/specification/_print/#json-encoding) when decoding with Avro schemas. In this format the value of a union is encoded in JSON as follows:
-
-- if its type is `null`, then it is encoded as a JSON `null`;
-- otherwise it is encoded as a JSON object with one name/value pair whose name is the type's name and whose value is the recursively encoded value. For Avro's named types (record, fixed or enum) the user-specified name is used, for other types the type name is used.
-
-For example, the union schema `["null","string","Foo"]`, where `Foo` is a record name, would encode:
-
-- `null` as `null`;
-- the string `"a"` as `{"string": "a"}`; and
-- a `Foo` instance as `{"Foo": {...}}`, where `{...}` indicates the JSON encoding of a `Foo` instance.
-
-However, it is possible to instead create documents in [standard/raw JSON format](https://pkg.go.dev/github.com/linkedin/goavro/v2#NewCodecForStandardJSONFull) by setting the field [`avro_raw_json`](#avro_raw_json) to `true`.
+Enable basic authentication
 
 ## Fields
 
@@ -95,17 +78,32 @@ The base URL of the schema registry service.
 
 Type: `string`  
 
-### `username`
+### `basic_auth`
 
-The basic auth username for the schema registry service.
+Allows you to specify basic authentication.
+
+
+Type: `object`  
+
+### `basic_auth.enabled`
+
+Whether to use basic authentication in requests.
+
+
+Type: `bool`  
+Default: `false`  
+
+### `basic_auth.username`
+
+Username required to authenticate.
 
 
 Type: `string`  
 Default: `""`  
 
-### `password`
+### `basic_auth.password`
 
-The basic auth password for the schema registry service.
+Password required to authenticate.
 
 
 Type: `string`  

--- a/website/docs/components/processors/schema_registry_encode.md
+++ b/website/docs/components/processors/schema_registry_encode.md
@@ -35,8 +35,6 @@ Introduced in version 3.58.0.
 label: ""
 schema_registry_encode:
   url: ""
-  username: ""
-  password: ""
   subject: ""
   refresh_period: 10m
 ```
@@ -49,8 +47,10 @@ schema_registry_encode:
 label: ""
 schema_registry_encode:
   url: ""
-  username: ""
-  password: ""
+  basic_auth:
+    enabled: false
+    username: ""
+    password: ""
   subject: ""
   refresh_period: 10m
   avro_raw_json: false
@@ -65,31 +65,7 @@ schema_registry_encode:
 </TabItem>
 </Tabs>
 
-Encodes messages automatically from schemas obtains from a [Confluent Schema Registry service](https://docs.confluent.io/platform/current/schema-registry/index.html) by polling the service for the latest schema version for target subjects.
-
-If a message fails to encode under the schema then it will remain unchanged and the error can be caught using error handling methods outlined [here](/docs/configuration/error_handling).
-
-Currently only Avro schemas are supported.
-
-### Avro JSON Format
-
-By default this processor expects documents formatted as [Avro JSON](https://avro.apache.org/docs/current/specification/_print/#json-encoding) when encoding with Avro schemas. In this format the value of a union is encoded in JSON as follows:
-
-- if its type is `null`, then it is encoded as a JSON `null`;
-- otherwise it is encoded as a JSON object with one name/value pair whose name is the type's name and whose value is the recursively encoded value. For Avro's named types (record, fixed or enum) the user-specified name is used, for other types the type name is used.
-
-For example, the union schema `["null","string","Foo"]`, where `Foo` is a record name, would encode:
-
-- `null` as `null`;
-- the string `"a"` as `{"string": "a"}`; and
-- a `Foo` instance as `{"Foo": {...}}`, where `{...}` indicates the JSON encoding of a `Foo` instance.
-
-However, it is possible to instead consume documents in [standard/raw JSON format](https://pkg.go.dev/github.com/linkedin/goavro/v2#NewCodecForStandardJSONFull) by setting the field [`avro_raw_json`](#avro_raw_json) to `true`.
-
-### Known Issues
-
-Important! There is an outstanding issue in the [avro serializing library](https://github.com/linkedin/goavro) that benthos uses which means it [doesn't encode logical types correctly](https://github.com/linkedin/goavro/issues/252). It's still possible to encode logical types that are in-line with the spec if `avro_raw_json` is set to true, though now of course non-logical types will not be in-line with the spec.
-
+Enable basic authentication
 
 ## Fields
 
@@ -100,17 +76,32 @@ The base URL of the schema registry service.
 
 Type: `string`  
 
-### `username`
+### `basic_auth`
 
-The basic auth username for the schema registry service.
+Allows you to specify basic authentication.
+
+
+Type: `object`  
+
+### `basic_auth.enabled`
+
+Whether to use basic authentication in requests.
+
+
+Type: `bool`  
+Default: `false`  
+
+### `basic_auth.username`
+
+Username required to authenticate.
 
 
 Type: `string`  
 Default: `""`  
 
-### `password`
+### `basic_auth.password`
 
-The basic auth password for the schema registry service.
+Password required to authenticate.
 
 
 Type: `string`  

--- a/website/docs/components/processors/schema_registry_encode.md
+++ b/website/docs/components/processors/schema_registry_encode.md
@@ -35,6 +35,8 @@ Introduced in version 3.58.0.
 label: ""
 schema_registry_encode:
   url: ""
+  username: ""
+  password: ""
   subject: ""
   refresh_period: 10m
 ```
@@ -47,6 +49,8 @@ schema_registry_encode:
 label: ""
 schema_registry_encode:
   url: ""
+  username: ""
+  password: ""
   subject: ""
   refresh_period: 10m
   avro_raw_json: false
@@ -95,6 +99,22 @@ The base URL of the schema registry service.
 
 
 Type: `string`  
+
+### `username`
+
+The basic auth username for the schema registry service.
+
+
+Type: `string`  
+Default: `""`  
+
+### `password`
+
+The basic auth password for the schema registry service.
+
+
+Type: `string`  
+Default: `""`  
 
 ### `subject`
 


### PR DESCRIPTION
This addresses https://github.com/benthosdev/benthos/issues/1425.

One question I had was how we best validate for the username and password to go together in their config. If we are setting username, then we should expect a password as well as vice versa.