### PR TITLE
add checkpoint_limit to redis_list input

### DIFF
--- a/internal/component/input/config_redis_list.go
+++ b/internal/component/input/config_redis_list.go
@@ -6,16 +6,18 @@ import (
 
 // RedisListConfig contains configuration fields for the RedisList input type.
 type RedisListConfig struct {
-	bredis.Config `json:",inline" yaml:",inline"`
-	Key           string `json:"key" yaml:"key"`
-	Timeout       string `json:"timeout" yaml:"timeout"`
+	bredis.Config   `json:",inline" yaml:",inline"`
+	Key             string `json:"key" yaml:"key"`
+	Timeout         string `json:"timeout" yaml:"timeout"`
+	CheckpointLimit int    `json:"checkpoint_limit" yaml:"checkpoint_limit"`
 }
 
 // NewRedisListConfig creates a new RedisListConfig with default values.
 func NewRedisListConfig() RedisListConfig {
 	return RedisListConfig{
-		Config:  bredis.NewConfig(),
-		Key:     "",
-		Timeout: "5s",
+		Config:          bredis.NewConfig(),
+		Key:             "",
+		Timeout:         "5s",
+		CheckpointLimit: 0,
 	}
 }

--- a/website/docs/components/inputs/redis_list.md
+++ b/website/docs/components/inputs/redis_list.md
@@ -55,6 +55,7 @@ input:
       client_certs: []
     key: ""
     timeout: 5s
+    checkpoint_limit: 0
 ```
 
 </TabItem>
@@ -268,5 +269,13 @@ The length of time to poll for new messages before reattempting.
 
 Type: `string`  
 Default: `"5s"`  
+
+### `checkpoint_limit`
+
+Sets a limit on the number of messages that can be in either a prefetched or in-processing state. Default value implies no limit. Notice that that there are caveats to imposing this limit. If you have a batch policy at the output level, then messages won't be acked until the batch is flushed. If you don't allow the input to consume enough messages to trigger the batch, then it will stall.
+
+
+Type: `int`  
+Default: `0`  
 
 


### PR DESCRIPTION
# Changes

* Adds a `checkpoint_limit` to the `redis_list`. This sets a limit on the combined number of messages that are either in a prefetched or in-processing state. Has been tested using the setup described in https://github.com/benthosdev/benthos/discussions/1451. As this is quite a specific use-case, I've gone ahead with a default of `0`, which implies no limit.

Notice I have gone with the name `checkpoint_limit` as discussed in #1469. We can change this if needed (I leave this decision to you). I have also gone ahead and added a disclaimer in the description, so that people do not run into a stalling setup (hopefully it is clear from the description).

Closes #1469 