### PR TITLE
Add missing link to Processors About page

### DIFF
--- a/website/docs/components/processors/about.md
+++ b/website/docs/components/processors/about.md
@@ -89,3 +89,4 @@ You can read more about batching [in this document][batching].
 [processor.split]: /docs/components/processors/split
 [processor.dedupe]: /docs/components/processors/dedupe
 [processor.for_each]: /docs/components/processors/for_each
+[metrics.about]: /docs/components/metrics/about


### PR DESCRIPTION
I see the default for [`onBrokenLinks`](https://docusaurus.io/docs/api/docusaurus-config#onBrokenLinks) is `throw` and the default for [`onBrokenMarkdownLinks`](https://docusaurus.io/docs/api/docusaurus-config#onBrokenMarkdownLinks) is `warn`, but, somehow, it's not showing me any warning or anything when I try to build the site with `yarn build`... Or maybe I'm missing something. Frontend dev 🤯 