### PR TITLE
Change `INSERT` operation back to previous v3 behaviour on azure table storage

### DIFF
--- a/internal/impl/azure/output_table_storage.go
+++ b/internal/impl/azure/output_table_storage.go
@@ -293,18 +293,12 @@ func (a *azureTableStorageWriter) addToBatch(batch []aztables.TransactionAction,
 	}
 	var err error
 	switch strings.ToUpper(insertType) {
-	case "ADD":
+	case "INSERT":
 		batch, err = appendFunc(batch, aztables.TransactionTypeAdd, entity)
-	case "INSERT", "INSERT_MERGE", "INSERTMERGE":
+	case "INSERT_MERGE":
 		batch, err = appendFunc(batch, aztables.TransactionTypeInsertMerge, entity)
-	case "INSERT_REPLACE", "INSERTREPLACE":
+	case "INSERT_REPLACE":
 		batch, err = appendFunc(batch, aztables.TransactionTypeInsertReplace, entity)
-	case "UPDATE", "UPDATE_MERGE", "UPDATEMERGE":
-		batch, err = appendFunc(batch, aztables.TransactionTypeUpdateMerge, entity)
-	case "UPDATE_REPLACE", "UPDATEREPLACE":
-		batch, err = appendFunc(batch, aztables.TransactionTypeUpdateReplace, entity)
-	case "DELETE":
-		batch, err = appendFunc(batch, aztables.TransactionTypeDelete, entity)
 	default:
 		return batch, fmt.Errorf("invalid insert type")
 	}


### PR DESCRIPTION
Changing the `INSERT` operation back to the previous behaviour and making it again compliant to the docs.

https://www.benthos.dev/docs/components/outputs/azure_table_storage#insert_type

The INSERT should fail if the partition key and row key already exist, INSERT_MERGE should merge the values, and INSERT_REPLACE completely replace the entire row.

I've also removed the other operations (UPDATE and DELETE) since the field is called `insert_type` and there's no doc about them. I can add them back if you think they might be helpful for any use case.

CC: @davidandradeduarte 