### PR TITLE
add jetstream metadata

### DIFF
--- a/internal/impl/nats/input_jetstream.go
+++ b/internal/impl/nats/input_jetstream.go
@@ -5,6 +5,7 @@ import (
 	"crypto/tls"
 	"errors"
 	"fmt"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -372,6 +373,17 @@ func (j *jetStreamReader) Close(ctx context.Context) error {
 func convertMessage(m *nats.Msg) (*service.Message, service.AckFunc, error) {
 	msg := service.NewMessage(m.Data)
 	msg.MetaSet("nats_subject", m.Subject)
+
+	metadata, err := m.Metadata()
+	if err == nil {
+		msg.MetaSet("nats_sequence_stream", strconv.Itoa(int(metadata.Sequence.Stream)))
+		msg.MetaSet("nats_sequence_consumer", strconv.Itoa(int(metadata.Sequence.Consumer)))
+		msg.MetaSet("nats_num_delivered", strconv.Itoa(int(metadata.NumDelivered)))
+		msg.MetaSet("nats_num_pending", strconv.Itoa(int(metadata.NumPending)))
+		msg.MetaSet("nats_domain", metadata.Domain)
+		msg.MetaSet("nats_timestamp", strconv.Itoa(int(metadata.Timestamp.UnixNano())))
+	}
+
 	for k := range m.Header {
 		v := m.Header.Get(k)
 		if v != "" {


### PR DESCRIPTION
This solves https://github.com/benthosdev/benthos/issues/1486

NATS Jetstream is different from normal NATS in that metadata like timestamp and sequence is not send as part of headers, but in the reply subject. The NATS client library has convenient methods to extract this information, which after this PR is added to the message and made available to processors

This is tested locally and it works. I didn't know how to add unit tests and documentation, but happy to do so if you think is relevant