### PR TITLE
add errcheck ignore rule for (*service.BatchError).Failed

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -13,6 +13,7 @@ linters-settings:
   errcheck:
     exclude-functions:
       - (*github.com/benthosdev/benthos/v4/internal/batch.Error).Failed
+      - (*github.com/benthosdev/benthos/v4/public/service.BatchError).Failed
   gocritic:
     enabled-tags:
       - diagnostic


### PR DESCRIPTION
The `errcheck` linter that is part of golangci-lint currently complains that the error returned from `(*service.BatchError).Failed` is not checked. This is a false positive since Failed is not causing an application error. It's a chainable api that is returning the enriched error back.