### PR TITLE
feat: make batch type configurable on cassandra output

### DIFF
--- a/internal/component/output/config_cassandra.go
+++ b/internal/component/output/config_cassandra.go
@@ -24,6 +24,7 @@ type CassandraConfig struct {
 	ArgsMapping              string                `json:"args_mapping" yaml:"args_mapping"`
 	Consistency              string                `json:"consistency" yaml:"consistency"`
 	Timeout                  string                `json:"timeout" yaml:"timeout"`
+	LoggedBatch              bool                  `json:"logged_batch" yaml:"logged_batch"`
 	// TODO: V4 Remove this and replace with explicit values.
 	retries.Config `json:",inline" yaml:",inline"`
 	MaxInFlight    int                `json:"max_in_flight" yaml:"max_in_flight"`
@@ -54,5 +55,6 @@ func NewCassandraConfig() CassandraConfig {
 		Config:                   rConf,
 		MaxInFlight:              64,
 		Batching:                 batchconfig.NewConfig(),
+		LoggedBatch:              true,
 	}
 }

--- a/internal/impl/cassandra/output.go
+++ b/internal/impl/cassandra/output.go
@@ -115,6 +115,10 @@ output:
 			).HasOptions(
 				"ANY", "ONE", "TWO", "THREE", "QUORUM", "ALL", "LOCAL_QUORUM", "EACH_QUORUM", "LOCAL_ONE",
 			).Advanced(),
+			docs.FieldBool(
+				"logged_batch",
+				"If enabled the driver will perform a logged batch.",
+			).Advanced(),
 			docs.FieldInt("max_retries", "The maximum number of retries before giving up on a request.").Advanced(),
 			docs.FieldObject("backoff", "Control time intervals between retry attempts.").WithChildren(
 				docs.FieldString("initial_interval", "The initial period to wait between retry attempts."),
@@ -255,7 +259,11 @@ func (c *cassandraWriter) writeRow(session *gocql.Session, msg message.Batch) er
 }
 
 func (c *cassandraWriter) writeBatch(session *gocql.Session, msg message.Batch) error {
-	batch := session.NewBatch(gocql.LoggedBatch)
+	batchType := gocql.UnloggedBatch
+	if c.conf.LoggedBatch {
+		batchType = gocql.LoggedBatch
+	}
+	batch := session.NewBatch(batchType)
 
 	if err := msg.Iter(func(i int, p *message.Part) error {
 		values, err := c.mapArgs(msg, i)

--- a/website/docs/components/outputs/cassandra.md
+++ b/website/docs/components/outputs/cassandra.md
@@ -69,6 +69,7 @@ output:
     query: ""
     args_mapping: ""
     consistency: QUORUM
+    logged_batch: true
     max_retries: 3
     backoff:
       initial_interval: 1s
@@ -367,6 +368,14 @@ The consistency level to use.
 Type: `string`  
 Default: `"QUORUM"`  
 Options: `ANY`, `ONE`, `TWO`, `THREE`, `QUORUM`, `ALL`, `LOCAL_QUORUM`, `EACH_QUORUM`, `LOCAL_ONE`.
+
+### `logged_batch`
+
+If enabled the driver will perform a logged batch.
+
+
+Type: `bool`  
+Default: `true`  
 
 ### `max_retries`
 


### PR DESCRIPTION
Hi!

The version 4.9.0 changed the default behavior of the cassandra output to insert logged batches of data instead of unlogged batches. However, [AWS keyspaces](https://docs.aws.amazon.com/keyspaces/latest/devguide/functional-differences.html#functional-differences.batch) and [Azure CosmoDB](https://learn.microsoft.com/en-us/azure/cosmos-db/cassandra/cassandra-support#cql-commands) don't support logged batches. 

This PR makes the batch type configurable by adding a new boolean field `logged_batch` that is true by default.
