### PR TITLE
Add `tracing_id` function

### DIFF
--- a/internal/bloblang/query/functions.go
+++ b/internal/bloblang/query/functions.go
@@ -250,6 +250,22 @@ var _ = registerSimpleFunction(
 
 //------------------------------------------------------------------------------
 
+var _ = registerSimpleFunction(
+	NewFunctionSpec(
+		FunctionCategoryMessage, "tracing_id",
+		"Provides the message trace id. The returned value will be zeroed if the message does not contain a span.",
+		NewExampleSpec("",
+			`meta trace_id = tracing_id()`,
+		),
+	).Experimental(),
+	func(fCtx FunctionContext) (any, error) {
+		traceID := tracing.GetTraceID(fCtx.MsgBatch.Get(fCtx.Index))
+		return traceID, nil
+	},
+)
+
+//------------------------------------------------------------------------------
+
 var _ = registerFunction(
 	NewFunctionSpec(
 		FunctionCategoryGeneral, "count",

--- a/internal/tracing/otel.go
+++ b/internal/tracing/otel.go
@@ -34,6 +34,14 @@ func GetActiveSpan(p *message.Part) *Span {
 	return otelSpan(ctx, t)
 }
 
+// GetTraceID returns the traceID from a span attached to a message part. Returns a zeroed traceID if the part
+// doesn't have a span attached.
+func GetTraceID(p *message.Part) string {
+	ctx := message.GetContext(p)
+	span := trace.SpanFromContext(ctx)
+	return span.SpanContext().TraceID().String()
+}
+
 // WithChildSpan takes a message, extracts a span, creates a new child span,
 // and returns a new message with that span embedded. The original message is
 // unchanged.

--- a/website/docs/guides/bloblang/functions.md
+++ b/website/docs/guides/bloblang/functions.md
@@ -351,6 +351,20 @@ The key parameter is optional and if omitted the entire metadata contents are re
 root.all_metadata = root_meta()
 ```
 
+### `tracing_id`
+
+:::caution EXPERIMENTAL
+This function is experimental and therefore breaking changes could be made to it outside of major version releases.
+:::
+Provides the message trace id. The returned value will be zeroed if the message does not contain a span.
+
+#### Examples
+
+
+```coffee
+meta trace_id = tracing_id()
+```
+
 ### `tracing_span`
 
 :::caution EXPERIMENTAL


### PR DESCRIPTION
We need to log the messages' `trace_id` so that we can see the traces directly on Grafana Tempo from Grafana Loki logs.

I added a `tracing_id` func and we can use it like this:

```yml
  processors:
  - log:
      level: INFO
      message: "message"
      fields:
        payload: ${! content() }
        metadata: ${! meta() }
        traceID: ${! tracing_id() }
```
