### PR TITLE
Update docs to reference the mapping processor

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ input:
 
 pipeline:
   processors:
-    - bloblang: |
+    - mapping: |
         root.message = this
         root.meta.link_count = this.links.length()
         root.user.age = this.user.age.number()

--- a/cmd/tools/benthos_docs_gen/cue_test/expected.yml
+++ b/cmd/tools/benthos_docs_gen/cue_test/expected.yml
@@ -7,7 +7,7 @@ testCases:
     pipeline:
       processors:
         - label: sample_transform
-          bloblang: root = this.uppercase()
+          mapping: root = this.uppercase()
     output:
       switch:
         cases:

--- a/cmd/tools/benthos_docs_gen/cue_test/test.cue
+++ b/cmd/tools/benthos_docs_gen/cue_test/test.cue
@@ -7,7 +7,7 @@ testCases:
 
     pipeline: processors: [{
       label: "sample_transform"
-      bloblang: "root = this.uppercase()"
+      mapping: "root = this.uppercase()"
     }]
 
     output: #Guarded & {

--- a/config/test/deduplicate_by_batch.yaml
+++ b/config/test/deduplicate_by_batch.yaml
@@ -1,6 +1,6 @@
 pipeline:
   processors:
-    - bloblang: |
+    - mapping: |
         meta batch_tag = if batch_index() == 0 {
           nanoid(10)
         }

--- a/config/test/unit_test_example.yaml
+++ b/config/test/unit_test_example.yaml
@@ -6,7 +6,7 @@ input:
 
 pipeline:
   processors:
-    - bloblang: 'root = "%vend".format(content().uppercase().string())'
+    - mapping: 'root = "%vend".format(content().uppercase().string())'
 
 output:
   aws_s3:

--- a/internal/cli/test/docs/docs.go
+++ b/internal/cli/test/docs/docs.go
@@ -53,15 +53,15 @@ It is also possible to target processors in a separate file by prefixing the tar
 		).HasDefault(""),
 		docs.FieldAnything(
 			"mocks",
-			"An optional map of processors to mock. Keys should contain either a label or a JSON pointer of a processor that should be mocked. Values should contain a processor definition, which will replace the mocked processor. Most of the time you'll want to use a `bloblang` processor here, and use it to create a result that emulates the target processor.",
+			"An optional map of processors to mock. Keys should contain either a label or a JSON pointer of a processor that should be mocked. Values should contain a processor definition, which will replace the mocked processor. Most of the time you'll want to use a [`mapping` processor][processors.mapping] here, and use it to create a result that emulates the target processor.",
 			map[string]any{
 				"get_foobar_api": map[string]any{
-					"bloblang": "root = content().string() + \" this is some mock content\"",
+					"mapping": "root = content().string() + \" this is some mock content\"",
 				},
 			},
 			map[string]any{
 				"/pipeline/processors/1": map[string]any{
-					"bloblang": "root = content().string() + \" this is some mock content\"",
+					"mapping": "root = content().string() + \" this is some mock content\"",
 				},
 			},
 		).Map().Optional(),

--- a/internal/cli/test/docs/docs.md
+++ b/internal/cli/test/docs/docs.md
@@ -32,7 +32,7 @@ input:
 
 pipeline:
   processors:
-  - bloblang: '"%vend".format(content().uppercase().string())'
+  - mapping: '"%vend".format(content().uppercase().string())'
 
 output:
   aws_s3:
@@ -255,15 +255,15 @@ Sometimes you'll want to write tests for a series of processors, where one or mo
 ```yaml
 pipeline:
   processors:
-    - bloblang: 'root = "simon says: " + content()'
+    - mapping: 'root = "simon says: " + content()'
     - label: get_foobar_api
       http:
         url: http://example.com/foobar
         verb: GET
-    - bloblang: 'root = content().uppercase()'
+    - mapping: 'root = content().uppercase()'
 ```
 
-Rather than create a fake service for the `http` processor to interact with we can define a mock in our test definition that replaces it with a `bloblang` processor. Mocks are configured as a map of labels that identify a processor to replace and the config to replace it with:
+Rather than create a fake service for the `http` processor to interact with we can define a mock in our test definition that replaces it with a [`mapping` processor][processors.mapping]. Mocks are configured as a map of labels that identify a processor to replace and the config to replace it with:
 
 ```yaml
 tests:
@@ -271,14 +271,14 @@ tests:
     target_processors: '/pipeline/processors'
     mocks:
       get_foobar_api:
-        bloblang: 'root = content().string() + " this is some mock content"'
+        mapping: 'root = content().string() + " this is some mock content"'
     input_batch:
       - content: "hello world"
     output_batches:
       - - content_equals: "SIMON SAYS: HELLO WORLD THIS IS SOME MOCK CONTENT"
 ```
 
-With the above test definition the `http` processor will be swapped out for `bloblang: 'root = content().string() + " this is some mock content"'`. For the purposes of mocking it is recommended that you use a `bloblang` processor that simply mutates the message in a way that you would expect the mocked processor to.
+With the above test definition the `http` processor will be swapped out for `mapping: 'root = content().string() + " this is some mock content"'`. For the purposes of mocking it is recommended that you use a [`mapping` processor][processors.mapping] that simply mutates the message in a way that you would expect the mocked processor to.
 
 > Note: It's not currently possible to mock components that are imported as separate resource files (using `--resource`/`-r`). It is recommended that you mock these by maintaining separate definitions for test purposes (`-r "./test/*.yaml"`).
 
@@ -292,7 +292,7 @@ tests:
     target_processors: '/pipeline/processors'
     mocks:
       /pipeline/processors/1:
-        bloblang: 'root = content().string() + " this is some mock content"'
+        mapping: 'root = content().string() + " this is some mock content"'
     input_batch:
       - content: "hello world"
     output_batches:
@@ -308,3 +308,4 @@ The schema of a template file is as follows:
 [json-pointer]: https://tools.ietf.org/html/rfc6901
 [bloblang]: /docs/guides/bloblang/about
 [logger]: /docs/components/logger/about
+[processors.mapping]: /docs/components/processors/mapping

--- a/internal/impl/gcp/output_pubsub.go
+++ b/internal/impl/gcp/output_pubsub.go
@@ -39,7 +39,7 @@ If you are blocked by this issue then a work around is to delete either the spec
 `+"```yaml"+`
 pipeline:
   processors:
-    - bloblang: |
+    - mapping: |
         meta kafka_key = deleted()
 `+"```"+`
 
@@ -48,7 +48,7 @@ Or delete all keys with:
 `+"```yaml"+`
 pipeline:
   processors:
-    - bloblang: meta = deleted()
+    - mapping: meta = deleted()
 `+"```"+``),
 		Config: docs.FieldComponent().WithChildren(
 			docs.FieldString("project", "The project ID of the topic to publish to."),

--- a/internal/impl/pure/buffer_system_window.go
+++ b/internal/impl/pure/buffer_system_window.go
@@ -106,7 +106,7 @@ pipeline:
 
     # Reduce each batch to a single message by deleting indexes > 0, and
     # aggregate the car and passenger counts.
-    - bloblang: |
+    - mapping: |
         root = if batch_index() == 0 {
           {
             "traffic_light": this.traffic_light,

--- a/internal/impl/pure/cache_multilevel.go
+++ b/internal/impl/pure/cache_multilevel.go
@@ -26,7 +26,7 @@ pipeline:
               operator: get
               key: ${! json("key") }
           - catch:
-            - bloblang: 'root = {"err":error()}'
+            - mapping: 'root = {"err":error()}'
         result_map: 'root.result = this'
 
 cache_resources:

--- a/internal/impl/pure/input_broker.go
+++ b/internal/impl/pure/input_broker.go
@@ -39,7 +39,7 @@ input:
 
         # Optional list of input specific processing steps
         processors:
-          - bloblang: |
+          - mapping: |
               root.message = this
               root.meta.link_count = this.links.length()
               root.user.age = this.user.age.number()

--- a/internal/impl/pure/output_fallback.go
+++ b/internal/impl/pure/output_fallback.go
@@ -35,7 +35,7 @@ output:
         retries: 3
         retry_period: 1s
       processors:
-        - bloblang: 'root = "failed to send this message to foo: " + content()'
+        - mapping: 'root = "failed to send this message to foo: " + content()'
     - file:
         path: /usr/local/benthos/everything_failed.jsonl
 ` + "```" + `

--- a/internal/impl/pure/output_sync_response.go
+++ b/internal/impl/pure/output_sync_response.go
@@ -42,7 +42,7 @@ output:
           topic: foo_topic
       - sync_response: {}
         processors:
-          - bloblang: 'root = content().uppercase()'
+          - mapping: 'root = content().uppercase()'
 ` + "```" + `
 
 Using the above example and posting the message 'hello world' to the endpoint

--- a/internal/impl/pure/processor_jmespath.go
+++ b/internal/impl/pure/processor_jmespath.go
@@ -31,7 +31,7 @@ Executes a [JMESPath query](http://jmespath.org/) on JSON documents and replaces
 the message with the resulting document.`,
 		Description: `
 :::note Try out Bloblang
-For better performance and improved capabilities try out native Benthos mapping with the [bloblang processor](/docs/components/processors/bloblang).
+For better performance and improved capabilities try out native Benthos mapping with the [` + "`mapping`" + ` processor](/docs/components/processors/mapping).
 :::
 `,
 		Examples: []docs.AnnotatedExample{

--- a/internal/impl/pure/processor_jq.go
+++ b/internal/impl/pure/processor_jq.go
@@ -32,7 +32,7 @@ func init() {
 Transforms and filters messages using jq queries.`,
 		Description: `
 :::note Try out Bloblang
-For better performance and improved capabilities try out native Benthos mapping with the [bloblang processor](/docs/components/processors/bloblang).
+For better performance and improved capabilities try out native Benthos mapping with the [` + "`mapping`" + ` processor](/docs/components/processors/mapping).
 :::
 
 The provided query is executed on each message, targeting either the contents

--- a/internal/impl/pure/processor_jsonschema.go
+++ b/internal/impl/pure/processor_jsonschema.go
@@ -74,7 +74,7 @@ pipeline:
     - log:
         level: ERROR
         message: "Schema validation failed due to: ${!error()}"
-    - bloblang: 'root = deleted()' # Drop messages that fail
+    - mapping: 'root = deleted()' # Drop messages that fail
 ` + "```" + `
 
 If a payload being processed looked like:

--- a/internal/impl/pure/processor_resource.go
+++ b/internal/impl/pure/processor_resource.go
@@ -27,7 +27,7 @@ This processor allows you to reference the same configured processor resource in
 ` + "```yaml" + `
 pipeline:
   processors:
-    - bloblang: |
+    - mapping: |
         root.message = this
         root.meta.link_count = this.links.length()
         root.user.age = this.user.age.number()
@@ -42,7 +42,7 @@ pipeline:
 
 processor_resources:
   - label: foo_proc
-    bloblang: |
+    mapping: |
       root.message = this
       root.meta.link_count = this.links.length()
       root.user.age = this.user.age.number()

--- a/internal/template/docs.md
+++ b/internal/template/docs.md
@@ -67,7 +67,7 @@ input:
 
 pipeline:
   processors:
-    - bloblang: |
+    - mapping: |
         root.id = uuid_v4()
         root.foo = this.inner.foo
         root.body = this.outter
@@ -89,7 +89,7 @@ input:
 
 pipeline:
   processors:
-    - bloblang: |
+    - mapping: |
         root.id = uuid_v4()
         root.foo = this.inner.foo
         root.body = this.outter

--- a/website/cookbooks/discord_bot.md
+++ b/website/cookbooks/discord_bot.md
@@ -65,7 +65,7 @@ Writing messages to a Discord channel is pretty easy. You can feed the [`discord
 ```yaml
 pipeline:
   processors:
-    - bloblang: |
+    - mapping: |
         root = if !this.content.has_prefix("SHOUTS BACK") {
           "SHOUTS BACK BOT SAYS " + this.content.uppercase()
         } else {
@@ -90,10 +90,10 @@ pipeline:
     - switch:
         - check: this.type == 7
           processors:
-            - bloblang: 'root = "Welcome to the server <@%v>!".format(this.author.id)'
+            - mapping: 'root = "Welcome to the server <@%v>!".format(this.author.id)'
 
         - processors:
-            - bloblang: 'root = deleted()'
+            - mapping: 'root = deleted()'
 ```
 
 By changing our mapping out to this switch we can add specialised commands for different message types, and if none of the cases match then we don't respond. Technically, we can do all of this within a single Bloblang mapping by using a match expression, but having a switch processor would also allow us to add cases where we do cool things like hit other APIs, etc.
@@ -108,11 +108,11 @@ pipeline:
     - switch:
         - check: this.type == 7
           processors:
-            - bloblang: 'root = "Welcome to the server <@%v>!".format(this.author.id)'
+            - mapping: 'root = "Welcome to the server <@%v>!".format(this.author.id)'
 
         - check: this.content == "/joke"
           processors:
-            - bloblang: |
+            - mapping: |
                 let jokes = [
                   "What do you call a belt made of watches? A waist of time.",
                   "What does a clock do when it’s hungry? It goes back four seconds.",
@@ -122,7 +122,7 @@ pipeline:
 
         - check: this.content == "/roast"
           processors:
-            - bloblang: |
+            - mapping: |
                 let roasts = [
                   "If <@%v>'s brain was dynamite, there wouldn’t be enough to blow their hat off.",
                   "Someday you’ll go far <@%v>, and I really hope you stay there.",
@@ -131,7 +131,7 @@ pipeline:
                 root = $roasts.index(timestamp_unix_nano() % $roasts.length()).format(this.author.id)
 
         - processors:
-            - bloblang: 'root = deleted()'
+            - mapping: 'root = deleted()'
 ```
 
 Here we have two new commands. If someone posts a message "/joke" then we respond by selecting one of several exceptionally funny jokes from a static list in the mapping.
@@ -151,18 +151,18 @@ pipeline:
         # Other cases omitted for brevity
         - check: this.content == "/release"
           processors:
-            - bloblang: 'root = ""'
+            - mapping: 'root = ""'
             - try:
               - http:
                   url: https://api.github.com/repos/benthosdev/benthos/releases/latest
                   verb: GET
-              - bloblang: 'root = "The latest release of Benthos is %v: %v".format(this.tag_name, this.html_url)'
+              - mapping: 'root = "The latest release of Benthos is %v: %v".format(this.tag_name, this.html_url)'
 
     - catch:
       - log:
           fields_mapping: 'root.error = error()'
           message: "Failed to process message"
-      - bloblang: 'root = "Sorry, my circuits are all bent from twerking and I must have malfunctioned."'
+      - mapping: 'root = "Sorry, my circuits are all bent from twerking and I must have malfunctioned."'
 ```
 
 Here we've added a switch case that clears the contents of the message, hits the Github API to obtain the latest Benthos release as a JSON object, and finally maps the tag name and the URL of the release to a useful message.

--- a/website/cookbooks/enrichments.md
+++ b/website/cookbooks/enrichments.md
@@ -296,7 +296,7 @@ pipeline:
             fields_mapping: 'root.content = content().string()'
             message: "Enrichments failed due to: ${!error()}"
 
-    - bloblang: |
+    - mapping: |
         root = this
         root.tmp = deleted()
 
@@ -306,7 +306,7 @@ output:
     topic: comments_hydrated
 ```
 
-Since the contents of `tmp` won't be required downstream we remove it after our enrichments using a [`bloblang` processor][processor.bloblang].
+Since the contents of `tmp` won't be required downstream we remove it after our enrichments using a [`mapping` processor][processor.mapping].
 
 A [`catch`][processor.catch] processor was added at the end of the pipeline which catches documents that failed enrichment. You can replace the log event with a wide range of recovery actions such as sending to a dead-letter/retry queue, dropping the message entirely, etc. You can read more about error handling [in this article][error-handling].
 
@@ -317,7 +317,7 @@ A [`catch`][processor.catch] processor was added at the end of the pipeline whic
 [processor.catch]: /docs/components/processors/catch
 [processor.archive]: /docs/components/processors/archive
 [processor.unarchive]: /docs/components/processors/unarchive
-[processor.bloblang]: /docs/components/processors/bloblang
+[processor.mapping]: /docs/components/processors/mapping
 [processor.subprocess]: /docs/components/processors/subprocess
 [processor.lambda]: /docs/components/processors/aws_lambda
 [processor.http]: /docs/components/processors/http

--- a/website/cookbooks/filtering.md
+++ b/website/cookbooks/filtering.md
@@ -4,7 +4,7 @@ title: Filtering and Sampling
 description: Configure Benthos to conditionally drop messages.
 ---
 
-Events are like eyebrows, sometimes it's best to just get rid of them. Filtering events in Benthos is both easy and flexible, this cookbook demonstrates a few different types of filtering you can do. All of these examples make use of the [`bloblang` processor][processors.bloblang] but shouldn't require any prior knowledge.
+Events are like eyebrows, sometimes it's best to just get rid of them. Filtering events in Benthos is both easy and flexible, this cookbook demonstrates a few different types of filtering you can do. All of these examples make use of the [`mapping` processor][processors.mapping] but shouldn't require any prior knowledge.
 
 ## The Basic Filter
 
@@ -13,7 +13,7 @@ Dropping events with [Bloblang][guides.bloblang] is done by mapping the function
 ```yaml
 pipeline:
   processors:
-  - bloblang: root = deleted()
+  - mapping: root = deleted()
 ```
 
 But that's most likely not what you want. We can instead only delete an event under certain conditions with a [`match`][bloblang.match] or [`if`][bloblang.if] expression:
@@ -21,7 +21,7 @@ But that's most likely not what you want. We can instead only delete an event un
 ```yaml
 pipeline:
   processors:
-  - bloblang: |
+  - mapping: |
       root = if meta("topic").or("") == "foo" ||
         this.doc.type == "bar" ||
         this.doc.urls.contains("https://www.benthos.dev/").catch(false) {
@@ -44,7 +44,7 @@ Another type of filter we might want is a sampling filter, we can do that with a
 ```yaml
 pipeline:
   processors:
-  - bloblang: |
+  - mapping: |
       # Drop 50% of documents randomly
       root = if random_int() % 2 == 0 { deleted() }
 ```
@@ -54,14 +54,14 @@ We can also do this in a deterministic way by hashing events and filtering by th
 ```yaml
 pipeline:
   processors:
-  - bloblang: |
+  - mapping: |
       # Drop ~10% of documents deterministically (same docs filtered each run)
       root = if content().hash("xxhash64").slice(-8).number() % 10 == 0 {
          deleted()
       }
 ```
 
-[processors.bloblang]: /docs/components/processors/bloblang
+[processors.mapping]: /docs/components/processors/mapping
 [bloblang.match]: /docs/guides/bloblang/about#pattern-matching
 [bloblang.if]: /docs/guides/bloblang/about#conditional-mapping
 [guides.bloblang]: /docs/guides/bloblang/about

--- a/website/cookbooks/joining_streams.md
+++ b/website/cookbooks/joining_streams.md
@@ -78,7 +78,7 @@ input:
 pipeline:
   processors:
     # Reduce document into only fields we wish to cache.
-    - bloblang: 'article = article'
+    - mapping: 'article = article'
 
     # Store reduced articles into our cache.
     - cache:
@@ -204,11 +204,11 @@ pipeline:
             {} # Omitted
 
       # If we've reached this point then both processors succeeded.
-      - bloblang: 'meta output_topic = "comments_hydrated"'
+      - mapping: 'meta output_topic = "comments_hydrated"'
 
     - catch:
         # If we reach here then a processing stage failed.
-        - bloblang: |
+        - mapping: |
             meta output_topic = "comments_retry"
             meta last_attempted = timestamp_unix()
 

--- a/website/docs/components/about.md
+++ b/website/docs/components/about.md
@@ -24,7 +24,7 @@ buffer:
 
 pipeline:
   processors:
-  - bloblang: |
+  - mapping: |
       message = this
       meta.link_count = links.length()
 
@@ -77,7 +77,7 @@ pipeline:
         operator: add
         key: '${! json("id") }'
         value: "x"
-    - bloblang: root = if errored() { deleted() }
+    - mapping: root = if errored() { deleted() }
 
 rate_limit_resources:
   - label: foo_ratelimit

--- a/website/docs/components/buffers/system_window.md
+++ b/website/docs/components/buffers/system_window.md
@@ -106,7 +106,7 @@ pipeline:
 
     # Reduce each batch to a single message by deleting indexes > 0, and
     # aggregate the car and passenger counts.
-    - bloblang: |
+    - mapping: |
         root = if batch_index() == 0 {
           {
             "traffic_light": this.traffic_light,

--- a/website/docs/components/caches/about.md
+++ b/website/docs/components/caches/about.md
@@ -26,7 +26,7 @@ pipeline:
         operator: add
         key: '${! json("message.id") }'
         value: "storeme"
-    - bloblang: root = if errored() { deleted() }
+    - mapping: root = if errored() { deleted() }
 ```
 
 For the simple case where you wish to store messages in a cache as an output destination for your pipeline check out the [`cache` output][output.cache]. To see examples of more advanced uses of caches such as hydration and deduplication check out the [`cache` processor][processor.cache]. 

--- a/website/docs/components/caches/multilevel.md
+++ b/website/docs/components/caches/multilevel.md
@@ -42,7 +42,7 @@ pipeline:
               operator: get
               key: ${! json("key") }
           - catch:
-            - bloblang: 'root = {"err":error()}'
+            - mapping: 'root = {"err":error()}'
         result_map: 'root.result = this'
 
 cache_resources:

--- a/website/docs/components/inputs/about.md
+++ b/website/docs/components/inputs/about.md
@@ -18,7 +18,7 @@ input:
 
   # Optional list of processing steps
   processors:
-   - bloblang: |
+   - mapping: |
        root.document = this.without("links")
        root.link_count = this.links.length()
 ```

--- a/website/docs/components/inputs/broker.md
+++ b/website/docs/components/inputs/broker.md
@@ -77,7 +77,7 @@ input:
 
         # Optional list of input specific processing steps
         processors:
-          - bloblang: |
+          - mapping: |
               root.message = this
               root.meta.link_count = this.links.length()
               root.user.age = this.user.age.number()

--- a/website/docs/components/metrics/about.md
+++ b/website/docs/components/metrics/about.md
@@ -105,7 +105,7 @@ input:
 
 pipeline:
   processors:
-    - bloblang: |
+    - mapping: |
         root.message = this
         root.meta.link_count = this.links.length()
         root.user.age = this.user.age.number()

--- a/website/docs/components/outputs/about.md
+++ b/website/docs/components/outputs/about.md
@@ -17,7 +17,7 @@ output:
 
   # Optional list of processing steps
   processors:
-    - bloblang: '{"message":this,"meta":{"link_count":this.links.length()}}'
+    - mapping: '{"message":this,"meta":{"link_count":this.links.length()}}'
 ```
 
 ## Back Pressure
@@ -90,7 +90,7 @@ output:
             url: tcp://localhost:6379
             stream: everything_else
           processors:
-            - bloblang: |
+            - mapping: |
                 root = this
                 root.type = this.type.not_null() | "unknown"
 ```
@@ -110,7 +110,6 @@ import ComponentSelect from '@theme/ComponentSelect';
 <ComponentSelect type="outputs"></ComponentSelect>
 
 [processors]: /docs/components/processors/about
-[processor.bloblang]: /docs/components/processors/bloblang
 [output.broker]: /docs/components/outputs/broker
 [output.switch]: /docs/components/outputs/switch
 [output.retry]: /docs/components/outputs/retry

--- a/website/docs/components/outputs/fallback.md
+++ b/website/docs/components/outputs/fallback.md
@@ -41,7 +41,7 @@ output:
         retries: 3
         retry_period: 1s
       processors:
-        - bloblang: 'root = "failed to send this message to foo: " + content()'
+        - mapping: 'root = "failed to send this message to foo: " + content()'
     - file:
         path: /usr/local/benthos/everything_failed.jsonl
 ```

--- a/website/docs/components/outputs/gcp_pubsub.md
+++ b/website/docs/components/outputs/gcp_pubsub.md
@@ -68,7 +68,7 @@ If you are blocked by this issue then a work around is to delete either the spec
 ```yaml
 pipeline:
   processors:
-    - bloblang: |
+    - mapping: |
         meta kafka_key = deleted()
 ```
 
@@ -77,7 +77,7 @@ Or delete all keys with:
 ```yaml
 pipeline:
   processors:
-    - bloblang: meta = deleted()
+    - mapping: meta = deleted()
 ```
 
 ## Performance

--- a/website/docs/components/outputs/sync_response.md
+++ b/website/docs/components/outputs/sync_response.md
@@ -48,7 +48,7 @@ output:
           topic: foo_topic
       - sync_response: {}
         processors:
-          - bloblang: 'root = content().uppercase()'
+          - mapping: 'root = content().uppercase()'
 ```
 
 Using the above example and posting the message 'hello world' to the endpoint

--- a/website/docs/components/processors/about.md
+++ b/website/docs/components/processors/about.md
@@ -3,7 +3,7 @@ title: Processors
 sidebar_label: About
 ---
 
-Benthos processors are functions applied to messages passing through a pipeline. The function signature allows a processor to mutate or drop messages depending on the content of the message. There are many types on offer but the most powerful is the [`bloblang` processor][processor.bloblang].
+Benthos processors are functions applied to messages passing through a pipeline. The function signature allows a processor to mutate or drop messages depending on the content of the message. There are many types on offer but the most powerful are the [`mapping`][processor.mapping] and [`mutation`][processor.mutation] processors.
 
 Processors are set via config, and depending on where in the config they are placed they will be run either immediately after a specific input (set in the input section), on all messages (set in the pipeline section) or before a specific output (set in the output section). Most processors apply to all messages and can be placed in the pipeline section:
 
@@ -12,7 +12,7 @@ pipeline:
   threads: 1
   processors:
     - label: my_cool_mapping
-      bloblang: |
+      mapping: |
         root.message = this
         root.meta.link_count = this.links.length()
 ```
@@ -55,10 +55,10 @@ output:
             url: tcp://localhost:6379
             command: sadd
             args_mapping: 'root = [ this.key, this.value ]'
-        - bloblang: root = deleted()
+        - mapping: root = deleted()
 ```
 
-The way this works is that if your processor with the side effect (`redis` in this case) succeeds then the final `bloblang` processor deletes the message which results in an acknowledgement. If the processor fails then the `try` block exits early without executing the `bloblang` processor and instead the message is routed to the `reject` output, which nacks the message with an error message containing the error obtained from the `redis` processor.
+The way this works is that if your processor with the side effect (`redis` in this case) succeeds then the final `mapping` processor deletes the message which results in an acknowledgement. If the processor fails then the `try` block exits early without executing the `mapping` processor and instead the message is routed to the `reject` output, which nacks the message with an error message containing the error obtained from the `redis` processor.
 
 import ComponentsByCategory from '@theme/ComponentsByCategory';
 
@@ -85,7 +85,8 @@ You can read more about batching [in this document][batching].
 [output.reject]: /docs/components/outputs/reject
 [processor.sql_insert]: /docs/components/processors/sql_insert
 [processor.redis]: /docs/components/processors/redis
-[processor.bloblang]: /docs/components/processors/bloblang
+[processor.mapping]: /docs/components/processors/mapping
+[processor.mutation]: /docs/components/processors/mutation
 [processor.split]: /docs/components/processors/split
 [processor.dedupe]: /docs/components/processors/dedupe
 [processor.for_each]: /docs/components/processors/for_each

--- a/website/docs/components/processors/jmespath.md
+++ b/website/docs/components/processors/jmespath.md
@@ -27,7 +27,7 @@ jmespath:
 ```
 
 :::note Try out Bloblang
-For better performance and improved capabilities try out native Benthos mapping with the [bloblang processor](/docs/components/processors/bloblang).
+For better performance and improved capabilities try out native Benthos mapping with the [`mapping` processor](/docs/components/processors/mapping).
 :::
 
 

--- a/website/docs/components/processors/jq.md
+++ b/website/docs/components/processors/jq.md
@@ -49,7 +49,7 @@ jq:
 </Tabs>
 
 :::note Try out Bloblang
-For better performance and improved capabilities try out native Benthos mapping with the [bloblang processor](/docs/components/processors/bloblang).
+For better performance and improved capabilities try out native Benthos mapping with the [`mapping` processor](/docs/components/processors/mapping).
 :::
 
 The provided query is executed on each message, targeting either the contents

--- a/website/docs/components/processors/json_schema.md
+++ b/website/docs/components/processors/json_schema.md
@@ -88,7 +88,7 @@ pipeline:
     - log:
         level: ERROR
         message: "Schema validation failed due to: ${!error()}"
-    - bloblang: 'root = deleted()' # Drop messages that fail
+    - mapping: 'root = deleted()' # Drop messages that fail
 ```
 
 If a payload being processed looked like:

--- a/website/docs/components/processors/resource.md
+++ b/website/docs/components/processors/resource.md
@@ -28,7 +28,7 @@ This processor allows you to reference the same configured processor resource in
 ```yaml
 pipeline:
   processors:
-    - bloblang: |
+    - mapping: |
         root.message = this
         root.meta.link_count = this.links.length()
         root.user.age = this.user.age.number()
@@ -43,7 +43,7 @@ pipeline:
 
 processor_resources:
   - label: foo_proc
-    bloblang: |
+    mapping: |
       root.message = this
       root.meta.link_count = this.links.length()
       root.user.age = this.user.age.number()

--- a/website/docs/configuration/about.md
+++ b/website/docs/configuration/about.md
@@ -26,7 +26,7 @@ input:
 
 pipeline:
   processors:
-  - bloblang: |
+  - mapping: |
       root.message = this
       root.meta.link_count = this.links.length()
 
@@ -55,7 +55,7 @@ buffer:
 
 pipeline:
   processors:
-  - bloblang: |
+  - mapping: |
       root.message = this
       root.meta.link_count = this.links.length()
 
@@ -124,7 +124,7 @@ pipeline:
   processors:
     - resource: get_foo
     - catch:
-      - bloblang: |
+      - mapping: |
           root = this
           root.content = this.content.strip_html()
       - resource: get_foo
@@ -230,10 +230,10 @@ output:
 
 In order to make this process easier Benthos is able to generate usable configuration examples for any types, and you can do this from the binary using the `create` subcommand.
 
-If, for example, we wanted to generate a config with a websocket input, a Kafka output and a Bloblang processor in the middle, we could do it with the following command:
+If, for example, we wanted to generate a config with a websocket input, a Kafka output and a [`mapping` processor][processors.mapping] in the middle, we could do it with the following command:
 
 ```text
-benthos create websocket/bloblang/kafka
+benthos create websocket/mapping/kafka
 ```
 
 > If you need a gentle reminder as to which components Benthos offers you can see those as well with `benthos list`.
@@ -296,6 +296,7 @@ The `shutdown_timeout` option sets a hard deadline for Benthos process to gracef
 This option takes effect after the `shutdown_delay` duration has passed if that is enabled.
 
 [processors]: /docs/components/processors/about
+[processors.mapping]: /docs/components/processors/mapping
 [config-interp]: /docs/configuration/interpolation
 [config.testing]: /docs/configuration/unit_testing
 [config.templating]: /docs/configuration/templating

--- a/website/docs/configuration/error_handling.md
+++ b/website/docs/configuration/error_handling.md
@@ -69,7 +69,7 @@ pipeline:
   processors:
     - resource: foo # Processor that might fail
     - catch:
-      - bloblang: |
+      - mapping: |
           root = this
           root.meta.error = error()
 ```
@@ -95,12 +95,12 @@ This loop will block the pipeline and prevent the blocking message from being ac
 
 ## Drop Failed Messages
 
-In order to filter out any failed messages from your pipeline you can use a [`bloblang` processor][processor.bloblang]:
+In order to filter out any failed messages from your pipeline you can use a [`mapping` processor][processor.mapping]:
 
 ```yaml
 pipeline:
   processors:
-    - bloblang: root = if errored() { deleted() }
+    - mapping: root = if errored() { deleted() }
 ```
 
 This will remove any failed messages from a batch. Furthermore, dropping a message will propagate an acknowledgement (also known as "ack") upstream to the pipeline's input.
@@ -142,7 +142,7 @@ output:
 When the source of a rejected message is a sequential input without support for conventional nacks, such as the Kafka or file inputs, a rejected message will be reprocessed from scratch, applying back pressure until it is successfully processed. This can also sometimes be a useful pattern.
 
 [processors]: /docs/components/processors/about
-[processor.bloblang]: /docs/components/processors/bloblang
+[processor.mapping]: /docs/components/processors/mapping
 [processor.switch]: /docs/components/processors/switch
 [processor.while]: /docs/components/processors/while
 [processor.for_each]: /docs/components/processors/for_each

--- a/website/docs/configuration/metadata.md
+++ b/website/docs/configuration/metadata.md
@@ -8,12 +8,12 @@ When an input protocol supports attributes or metadata they will automatically b
 
 ## Editing Metadata
 
-Benthos allows you to add and remove metadata using the [`bloblang` processor][processors.bloblang]. For example, you can do something like this in your pipeline:
+Benthos allows you to add and remove metadata using the [`mapping` processor][processors.mapping]. For example, you can do something like this in your pipeline:
 
 ```yaml
 pipeline:
   processors:
-  - bloblang: |
+  - mapping: |
       # Remove all existing metadata from messages
       meta = deleted()
 
@@ -89,7 +89,7 @@ pipeline:
   processors:
     # Has an explicit list of public metadata keys, and everything else is given
     # an underscore prefix.
-    - bloblang: |
+    - mapping: |
         let allowed_meta = [
           "foo",
           "bar",
@@ -109,5 +109,5 @@ output:
 
 [interpolation]: /docs/configuration/interpolation
 [processors.switch]: /docs/components/processors/switch
-[processors.bloblang]: /docs/components/processors/bloblang
+[processors.mapping]: /docs/components/processors/mapping
 [guides.bloblang]: /docs/guides/bloblang/about

--- a/website/docs/configuration/processing_pipelines.md
+++ b/website/docs/configuration/processing_pipelines.md
@@ -13,7 +13,7 @@ input:
 pipeline:
   threads: 4
   processors:
-    - bloblang: |
+    - mapping: |
         root = this
         fans = fans.map_each(match {
           this.obsession > 0.5 => this

--- a/website/docs/configuration/resources.md
+++ b/website/docs/configuration/resources.md
@@ -29,7 +29,7 @@ input_resources:
 
 processor_resources:
   - label: bar
-    bloblang: 'root = content.lowercase()'
+    mapping: 'root = content.lowercase()'
 
 cache_resources:
   - label: baz
@@ -53,7 +53,7 @@ pipeline:
   processors:
     - resource: get_foo
     - catch:
-      - bloblang: |
+      - mapping: |
           root = this
           root.content = this.content.strip_html()
       - resource: get_foo

--- a/website/docs/configuration/templating.md
+++ b/website/docs/configuration/templating.md
@@ -67,7 +67,7 @@ input:
 
 pipeline:
   processors:
-    - bloblang: |
+    - mapping: |
         root.id = uuid_v4()
         root.foo = this.inner.foo
         root.body = this.outter
@@ -89,7 +89,7 @@ input:
 
 pipeline:
   processors:
-    - bloblang: |
+    - mapping: |
         root.id = uuid_v4()
         root.foo = this.inner.foo
         root.body = this.outter

--- a/website/docs/configuration/unit_testing.md
+++ b/website/docs/configuration/unit_testing.md
@@ -32,7 +32,7 @@ input:
 
 pipeline:
   processors:
-  - bloblang: '"%vend".format(content().uppercase().string())'
+  - mapping: '"%vend".format(content().uppercase().string())'
 
 output:
   aws_s3:
@@ -255,15 +255,15 @@ Sometimes you'll want to write tests for a series of processors, where one or mo
 ```yaml
 pipeline:
   processors:
-    - bloblang: 'root = "simon says: " + content()'
+    - mapping: 'root = "simon says: " + content()'
     - label: get_foobar_api
       http:
         url: http://example.com/foobar
         verb: GET
-    - bloblang: 'root = content().uppercase()'
+    - mapping: 'root = content().uppercase()'
 ```
 
-Rather than create a fake service for the `http` processor to interact with we can define a mock in our test definition that replaces it with a `bloblang` processor. Mocks are configured as a map of labels that identify a processor to replace and the config to replace it with:
+Rather than create a fake service for the `http` processor to interact with we can define a mock in our test definition that replaces it with a [`mapping` processor][processors.mapping]. Mocks are configured as a map of labels that identify a processor to replace and the config to replace it with:
 
 ```yaml
 tests:
@@ -271,14 +271,14 @@ tests:
     target_processors: '/pipeline/processors'
     mocks:
       get_foobar_api:
-        bloblang: 'root = content().string() + " this is some mock content"'
+        mapping: 'root = content().string() + " this is some mock content"'
     input_batch:
       - content: "hello world"
     output_batches:
       - - content_equals: "SIMON SAYS: HELLO WORLD THIS IS SOME MOCK CONTENT"
 ```
 
-With the above test definition the `http` processor will be swapped out for `bloblang: 'root = content().string() + " this is some mock content"'`. For the purposes of mocking it is recommended that you use a `bloblang` processor that simply mutates the message in a way that you would expect the mocked processor to.
+With the above test definition the `http` processor will be swapped out for `mapping: 'root = content().string() + " this is some mock content"'`. For the purposes of mocking it is recommended that you use a [`mapping` processor][processors.mapping] that simply mutates the message in a way that you would expect the mocked processor to.
 
 > Note: It's not currently possible to mock components that are imported as separate resource files (using `--resource`/`-r`). It is recommended that you mock these by maintaining separate definitions for test purposes (`-r "./test/*.yaml"`).
 
@@ -292,7 +292,7 @@ tests:
     target_processors: '/pipeline/processors'
     mocks:
       /pipeline/processors/1:
-        bloblang: 'root = content().string() + " this is some mock content"'
+        mapping: 'root = content().string() + " this is some mock content"'
     input_batch:
       - content: "hello world"
     output_batches:
@@ -356,7 +356,7 @@ Default: `""`
 
 ### `tests[].mocks`
 
-An optional map of processors to mock. Keys should contain either a label or a JSON pointer of a processor that should be mocked. Values should contain a processor definition, which will replace the mocked processor. Most of the time you'll want to use a `bloblang` processor here, and use it to create a result that emulates the target processor.
+An optional map of processors to mock. Keys should contain either a label or a JSON pointer of a processor that should be mocked. Values should contain a processor definition, which will replace the mocked processor. Most of the time you'll want to use a [`mapping` processor][processors.mapping] here, and use it to create a result that emulates the target processor.
 
 
 Type: map of `unknown`  
@@ -366,11 +366,11 @@ Type: map of `unknown`
 
 mocks:
   get_foobar_api:
-    bloblang: root = content().string() + " this is some mock content"
+    mapping: root = content().string() + " this is some mock content"
 
 mocks:
   /pipeline/processors/1:
-    bloblang: root = content().string() + " this is some mock content"
+    mapping: root = content().string() + " this is some mock content"
 ```
 
 ### `tests[].input_batch`
@@ -616,3 +616,4 @@ file_json_contains: ./foo/bar.json
 [json-pointer]: https://tools.ietf.org/html/rfc6901
 [bloblang]: /docs/guides/bloblang/about
 [logger]: /docs/components/logger/about
+[processors.mapping]: /docs/components/processors/mapping

--- a/website/docs/configuration/using_cue.md
+++ b/website/docs/configuration/using_cue.md
@@ -63,7 +63,7 @@ benthos.#Config & {
   pipeline: {
     processors: [
       {
-        bloblang: """
+        mapping: """
         root = this
         root.id = uuid_v4()
         """
@@ -91,7 +91,7 @@ input:
     mapping: 'root = { "message": "Hello, CUE!" }'
 pipeline:
   processors:
-    - bloblang: |-
+    - mapping: |-
         root = this
         root.id = uuid_v4()
 output:
@@ -122,7 +122,7 @@ benthos.#Config & {
 
   pipeline: processors: [
     {
-      bloblang: """
+      mapping: """
       root = this
       root.id = uuid_v4()
       """

--- a/website/docs/configuration/windowed_processing.md
+++ b/website/docs/configuration/windowed_processing.md
@@ -84,7 +84,7 @@ pipeline:
     - group_by_value:
         value: ${! json("traffic_light") }
 
-    - bloblang: |
+    - mapping: |
         let is_first_message = batch_index() == 0
 
         root.traffic_light = this.traffic_light

--- a/website/docs/guides/bloblang/advanced.md
+++ b/website/docs/guides/bloblang/advanced.md
@@ -78,12 +78,12 @@ Expanding a single message into multiple messages can be done by mapping message
 }
 ```
 
-We can pull `items` out to the root with `root = items` with a [`bloblang` processor][processors.bloblang] and follow it with an [`unarchive` processor][processors.unarchive] to expand each element into its own independent message:
+We can pull `items` out to the root with `root = items` with a [`mapping` processor][processors.mapping] and follow it with an [`unarchive` processor][processors.unarchive] to expand each element into its own independent message:
 
 ```yaml
 pipeline:
   processors:
-    - bloblang: root = this.items
+    - mapping: root = this.items
     - unarchive:
         format: json_array
 ```
@@ -112,7 +112,7 @@ Also note that when we set `doc_root` we remove the field `items` from the targe
 ```yaml
 pipeline:
   processors:
-    - bloblang: |
+    - mapping: |
         let doc_root = this.without("items")
         root = this.items.map_each($doc_root.merge(this))
     - unarchive:
@@ -156,5 +156,5 @@ output:
 
 Perhaps the first expansion of this mapping that would be worthwhile is to add an explicit list of column names, or at least confirm that the number of values in a row matches an expected count.
 
-[processors.bloblang]: /docs/components/processors/bloblang
+[processors.mapping]: /docs/components/processors/mapping
 [processors.unarchive]: /docs/components/processors/unarchive

--- a/website/docs/guides/getting_started.md
+++ b/website/docs/guides/getting_started.md
@@ -86,7 +86,7 @@ benthos -c ./config.yaml
 
 Anything you write to stdin will get written unchanged to stdout, cool! Resist the temptation to play with this for hours, there's more stuff to try out.
 
-Next, let's add some processing steps in order to mutate messages. The most powerful one is the [`bloblang` processor][processors.bloblang] which allows us to perform mappings, let's add a mapping to uppercase our messages:
+Next, let's add some processing steps in order to mutate messages. The most powerful one is the [`mapping` processor][processors.mapping] which allows us to perform mappings, let's add a mapping to uppercase our messages:
 
 ```yaml
 input:
@@ -94,7 +94,7 @@ input:
 
 pipeline:
   processors:
-    - bloblang: root = content().uppercase()
+    - mapping: root = content().uppercase()
 
 output:
   stdout: {}
@@ -112,7 +112,7 @@ pipeline:
   processors:
     - sleep:
         duration: 500ms
-    - bloblang: |
+    - mapping: |
         root.doc = this
         root.first_name = this.names.index(0).uppercase()
         root.last_name = this.names.index(-1).hash("sha256").encode("base64")
@@ -148,10 +148,10 @@ How exciting! I don't know about you but I'm going to need to lie down for a whi
 - [Cookbooks][cookbooks]
 - [More about configuration][configuration]
 
-[processors.bloblang]: /docs/components/processors/bloblang
 [proc_proc_field]: /docs/components/processors/process_field
 [proc_text]: /docs/components/processors/text
 [processors]: /docs/components/processors/about
+[processors.mapping]: /docs/components/processors/mapping
 [inputs]: /docs/components/inputs/about
 [outputs]: /docs/components/outputs/about
 [jmespath]: http://jmespath.org/

--- a/website/docs/guides/migration/v4.md
+++ b/website/docs/guides/migration/v4.md
@@ -278,7 +278,7 @@ pipeline:
               key: ${! content() }
               value: t
     # Delete all messages if we failed
-    - bloblang: |
+    - mapping: |
         root = if errored().from(0) {
           deleted()
         }

--- a/website/docs/guides/streams_mode/about.md
+++ b/website/docs/guides/streams_mode/about.md
@@ -32,7 +32,7 @@ input:
     path: /meow
 pipeline:
   processors:
-    - bloblang: 'root = "meow " + content()'
+    - mapping: 'root = "meow " + content()'
 output:
   sync_response: {}
 ```

--- a/website/docs/guides/streams_mode/streams_api.md
+++ b/website/docs/guides/streams_mode/streams_api.md
@@ -74,7 +74,7 @@ input:
     paths: [ /tmp/input.ndjson ]
 pipeline:
   processors:
-    - bloblang: root = content().uppercase()
+    - mapping: root = content().uppercase()
 output:
   file:
     path: /tmp/output.ndjson

--- a/website/docs/guides/streams_mode/using_config_files.md
+++ b/website/docs/guides/streams_mode/using_config_files.md
@@ -29,7 +29,7 @@ input:
 pipeline:
   threads: 4
   processors:
-    - bloblang: 'root = {"id": this.user.id, "content": this.body.content}'
+    - mapping: 'root = {"id": this.user.id, "content": this.body.content}'
 output:
   http_server: {}
 EOF
@@ -44,7 +44,7 @@ input:
 pipeline:
   threads: 1
   processors:
-    - bloblang: 'root = this.uppercase()'
+    - mapping: 'root = this.uppercase()'
 output:
   elasticsearch:
     urls:
@@ -102,7 +102,7 @@ $ curl http://localhost:4195/streams/foo | jq '.'
     "pipeline": {
       "processors": [
         {
-          "bloblang": "root = {\"id\": this.user.id, \"content\": this.body.content}",
+          "mapping": "root = {\"id\": this.user.id, \"content\": this.body.content}",
         }
       ],
       "threads": 4

--- a/website/docs/guides/streams_mode/using_rest_api.md
+++ b/website/docs/guides/streams_mode/using_rest_api.md
@@ -25,7 +25,7 @@ buffer:
 pipeline:
   threads: 4
   processors:
-    - bloblang: |
+    - mapping: |
         root = {
           "id": this.user.id,
           "content": this.body.content
@@ -67,7 +67,7 @@ input:
 pipeline:
   threads: 1
   processors:
-    - bloblang: 'root = this.uppercase()'
+    - mapping: 'root = this.uppercase()'
 output:
   elasticsearch:
     urls:
@@ -130,7 +130,7 @@ input:
 pipeline:
   threads: 4
   processors:
-  - bloblang: |
+  - mapping: |
       root = {
         "id": this.user.id,
         "content": this.body.content

--- a/website/docs/guides/sync_responses.md
+++ b/website/docs/guides/sync_responses.md
@@ -36,7 +36,7 @@ input:
     path: /post
 pipeline:
   processors:
-    - bloblang: root = content().uppercase()
+    - mapping: root = content().uppercase()
 output:
   sync_response: {}
 ```
@@ -58,7 +58,7 @@ output:
           topic: foo_topic
       - sync_response: {}
         processors:
-          - bloblang: root = content().uppercase()
+          - mapping: root = content().uppercase()
 ```
 
 Using the above example, sending a request 'foo bar' to the path `/post` passes the message unchanged to the Kafka topic `foo_topic` and also returns the response 'FOO BAR'.
@@ -78,9 +78,9 @@ input:
 
 pipeline:
   processors:
-    - bloblang: root = "%v baz".format(content().string())
+    - mapping: root = "%v baz".format(content().string())
     - sync_response: {}
-    - bloblang: root = content().uppercase()
+    - mapping: root = content().uppercase()
 
 output:
   kafka:

--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -61,7 +61,7 @@ const snippets = [
 
 pipeline:
   processors:
-    - bloblang: |
+    - mapping: |
         root.message = this
         root.meta.link_count = this.links.length()
         root.user.age = this.user.age.number()
@@ -117,7 +117,7 @@ pipeline:
   processors:
     - group_by_value:
         value: '\${! json("traffic_light_id") }'
-    - bloblang: |
+    - mapping: |
         root = if batch_index() == 0 {
           {
             "traffic_light_id": this.traffic_light_id,


### PR DESCRIPTION
The bloblang processor will be [deprecated](https://www.benthos.dev/docs/components/processors/bloblang#component-rename) in the future.

Not sure if some of these should be `mutation` instead of `mapping`. Guess not. Worst case, people who copy / paste won't get the best perf they can get 😈 