### PR TITLE
feat: add `service.ErrEmptyRead`

### DIFF
--- a/internal/component/errors.go
+++ b/internal/component/errors.go
@@ -28,6 +28,7 @@ func ErrInvalidType(typeStr, tried string) error {
 var (
 	ErrTimeout    = errors.New("action timed out")
 	ErrTypeClosed = errors.New("type was closed")
+	ErrEmptyRead  = errors.New("empty read from source")
 
 	ErrNotConnected = errors.New("not connected to target source or sink")
 

--- a/internal/component/input/async_reader.go
+++ b/internal/component/input/async_reader.go
@@ -141,7 +141,7 @@ func (r *AsyncReader) loop() {
 		}
 
 		if err != nil || msg == nil {
-			if err != nil && err != component.ErrTimeout && err != component.ErrNotConnected {
+			if err != nil && err != component.ErrTimeout && err != component.ErrNotConnected && err != component.ErrEmptyRead {
 				r.mgr.Logger().Errorf("Failed to read message: %v\n", err)
 			}
 			select {

--- a/public/service/input.go
+++ b/public/service/input.go
@@ -121,6 +121,8 @@ func (a *airGapReader) ReadBatch(ctx context.Context) (message.Batch, input.Asyn
 			err = component.ErrNotConnected
 		} else if errors.Is(err, ErrEndOfInput) {
 			err = component.ErrTypeClosed
+		} else if errors.Is(err, ErrEmptyRead) {
+			err = component.ErrEmptyRead
 		}
 		return nil, nil, err
 	}

--- a/public/service/package.go
+++ b/public/service/package.go
@@ -28,6 +28,12 @@ var (
 	// pipeline.
 	ErrEndOfInput = errors.New("end of input")
 
+	// ErrEmptyRead is returned by inputs that have attemtped to read from their
+	// underlying source but received no new data. Unlike ErrEndOfInput, this
+	// does not mean that the input exhausted its source of data and instead it's
+	// worth attempting subsequent reads.
+	ErrEmptyRead = errors.New("empty read from input")
+
 	// ErrEndOfBuffer is returned by a buffer Read/ReadBatch method when the
 	// contents of the buffer has been emptied and the source of the data is
 	// ended (as indicated by EndOfInput). This error prompts the upstream


### PR DESCRIPTION
ErrEmptyRead is returned by inputs that have attemtped to read from their underlying source but received no new data. Unlike ErrEndOfInput, this does not mean that the input exhausted its source of data and instead it's worth attempting subsequent reads.