### PR TITLE
Fix outter typo

### DIFF
--- a/internal/bloblang/parser/mapping_parser_test.go
+++ b/internal/bloblang/parser/mapping_parser_test.go
@@ -420,10 +420,10 @@ foo = "static"`,
 }
 root = this.apply("foo")`,
 			input: []part{
-				{Content: `{"outter":{"inner":"hello world"}}`},
+				{Content: `{"outer":{"inner":"hello world"}}`},
 			},
 			output: part{
-				Content: `{"applied":["foo"],"bar":{"outter":{"inner":"hello world"}},"foo":"static foo"}`,
+				Content: `{"applied":["foo"],"bar":{"outer":{"inner":"hello world"}},"foo":"static foo"}`,
 			},
 		},
 		"test nested maps": {
@@ -440,10 +440,10 @@ map bar {
 }
 root = this.apply("foo")`,
 			input: []part{
-				{Content: `{"outter":{"inner":"hello world"}}`},
+				{Content: `{"outer":{"inner":"hello world"}}`},
 			},
 			output: part{
-				Content: `{"applied":["bar","foo"],"foo":{"bar":{"outter":{"inner":"hello world"}},"static":"this is valid"}}`,
+				Content: `{"applied":["bar","foo"],"foo":{"bar":{"outer":{"inner":"hello world"}},"static":"this is valid"}}`,
 			},
 		},
 		"test imported map": {
@@ -451,10 +451,10 @@ root = this.apply("foo")`,
 
 root = this.apply("foo")`, goodMapFile),
 			input: []part{
-				{Content: `{"outter":{"inner":"hello world"}}`},
+				{Content: `{"outer":{"inner":"hello world"}}`},
 			},
 			output: part{
-				Content: `{"foo":"this is valid","nested":{"outter":{"inner":"hello world"}}}`,
+				Content: `{"foo":"this is valid","nested":{"outer":{"inner":"hello world"}}}`,
 			},
 		},
 		"test directly imported map": {

--- a/internal/bloblang/query/docs.go
+++ b/internal/bloblang/query/docs.go
@@ -69,7 +69,7 @@ type FunctionSpec struct {
 	// Examples shows general usage for the function.
 	Examples []ExampleSpec `json:"examples,omitempty"`
 
-	// Impure indicates that a function accesses or interacts with the outter
+	// Impure indicates that a function accesses or interacts with the outer
 	// environment, and is therefore unsafe to execute in shared environments.
 	Impure bool `json:"impure"`
 
@@ -186,7 +186,7 @@ type MethodSpec struct {
 	// Categories that this method fits within.
 	Categories []MethodCatSpec `json:"categories,omitempty"`
 
-	// Impure indicates that a method accesses or interacts with the outter
+	// Impure indicates that a method accesses or interacts with the outer
 	// environment, and is therefore unsafe to execute in shared environments.
 	Impure bool `json:"impure"`
 

--- a/internal/cli/service.go
+++ b/internal/cli/service.go
@@ -152,7 +152,7 @@ func (s *swappableStopper) Replace(fn func() (stoppable, error)) error {
 	defer s.mut.Unlock()
 
 	if s.stopped {
-		// If the outter stream has been stopped then do not create a new one.
+		// If the outer stream has been stopped then do not create a new one.
 		return nil
 	}
 

--- a/internal/docs/yaml_path_test.go
+++ b/internal/docs/yaml_path_test.go
@@ -271,7 +271,7 @@ pipeline:
 `,
 		},
 		{
-			name: "set 2D array value outter index",
+			name: "set 2D array value outer index",
 			input: `
 pipeline:
   processors:
@@ -521,7 +521,7 @@ func TestGetPathDocs(t *testing.T) {
 			resKind: "scalar",
 		},
 		{
-			name:    "workflow 2D array outter",
+			name:    "workflow 2D array outer",
 			path:    "/pipeline/processors/0/workflow/order",
 			resName: "order",
 			resType: "string",

--- a/internal/impl/pure/input_sequence_test.go
+++ b/internal/impl/pure/input_sequence_test.go
@@ -100,7 +100,7 @@ func TestSequenceJoins(t *testing.T) {
 	conf.Type = "sequence"
 	conf.Sequence.ShardedJoin.IDPath = "id"
 	conf.Sequence.ShardedJoin.Iterations = 1
-	conf.Sequence.ShardedJoin.Type = "full-outter"
+	conf.Sequence.ShardedJoin.Type = "full-outer"
 
 	csvConf := input.NewConfig()
 	csvConf.Type = "csv"
@@ -224,9 +224,9 @@ func TestSequenceJoinsMergeStrategies(t *testing.T) {
 			conf.Sequence.ShardedJoin.IDPath = "id"
 			conf.Sequence.ShardedJoin.MergeStrategy = test.mergeStrat
 			if test.flushOnFinal {
-				conf.Sequence.ShardedJoin.Type = "outter"
+				conf.Sequence.ShardedJoin.Type = "outer"
 			} else {
-				conf.Sequence.ShardedJoin.Type = "full-outter"
+				conf.Sequence.ShardedJoin.Type = "full-outer"
 			}
 			conf.Sequence.ShardedJoin.Iterations = 1
 
@@ -294,7 +294,7 @@ func TestSequenceJoinsBig(t *testing.T) {
 	conf.Type = "sequence"
 	conf.Sequence.ShardedJoin.IDPath = "id"
 	conf.Sequence.ShardedJoin.Iterations = 5
-	conf.Sequence.ShardedJoin.Type = "full-outter"
+	conf.Sequence.ShardedJoin.Type = "full-outer"
 
 	csvConf := input.NewConfig()
 	csvConf.Type = "csv"

--- a/internal/impl/pure/output_broker_test.go
+++ b/internal/impl/pure/output_broker_test.go
@@ -347,10 +347,10 @@ broker:
       processors:
         - bloblang: 'root = content().uppercase()'
 processors:
-  - bloblang: 'root = "outter: " + content()'
+  - bloblang: 'root = "outer: " + content()'
 `,
 			output: map[string]struct{}{
-				"OUTTER: HELLO WORLD 1": {},
+				"OUTER: HELLO WORLD 1": {},
 			},
 		},
 		{
@@ -363,7 +363,7 @@ generate:
 `,
 			outputConfig: `
 processors:
-  - bloblang: 'root = "outter: " + content()'
+  - bloblang: 'root = "outer: " + content()'
 
 broker:
   batching:
@@ -378,7 +378,7 @@ broker:
         - bloblang: 'root = "inner: " + content()'
 `,
 			output: map[string]struct{}{
-				"inner: outter: hello world 1\noutter: hello world 1\noutter: hello world 1": {},
+				"inner: outer: hello world 1\nouter: hello world 1\nouter: hello world 1": {},
 			},
 		},
 	} {

--- a/internal/template/docs.md
+++ b/internal/template/docs.md
@@ -70,7 +70,7 @@ pipeline:
     - bloblang: |
         root.id = uuid_v4()
         root.foo = this.inner.foo
-        root.body = this.outter
+        root.body = this.outer
 ```
 
 </TabItem>
@@ -92,7 +92,7 @@ pipeline:
     - bloblang: |
         root.id = uuid_v4()
         root.foo = this.inner.foo
-        root.body = this.outter
+        root.body = this.outer
 ```
 
 </TabItem>

--- a/website/docs/components/inputs/sequence.md
+++ b/website/docs/components/inputs/sequence.md
@@ -115,7 +115,7 @@ With the following config:
 input:
   sequence:
     sharded_join:
-      type: full-outter
+      type: full-outer
       id_path: uuid
       merge_strategy: array
     inputs:
@@ -160,7 +160,7 @@ With the following config:
 input:
   sequence:
     sharded_join:
-      type: full-outter
+      type: full-outer
       id_path: uuid
       iterations: 10
       merge_strategy: array
@@ -183,7 +183,7 @@ input:
 
 ### `sharded_join`
 
-EXPERIMENTAL: Provides a way to perform outter joins of arbitrarily structured and unordered data resulting from the input sequence, even when the overall size of the data surpasses the memory available on the machine.
+EXPERIMENTAL: Provides a way to perform outer joins of arbitrarily structured and unordered data resulting from the input sequence, even when the overall size of the data surpasses the memory available on the machine.
 
 When configured the sequence of inputs will be consumed one or more times according to the number of iterations, and when more than one iteration is specified each iteration will process an entirely different set of messages by sharding them by the ID field. Increasing the number of iterations reduces the memory consumption at the cost of needing to fully parse the data each time.
 
@@ -195,12 +195,12 @@ Requires version 3.40.0 or newer
 
 ### `sharded_join.type`
 
-The type of join to perform. A `full-outter` ensures that all identifiers seen in any of the input sequences are sent, and is performed by consuming all input sequences before flushing the joined results. An `outter` join consumes all input sequences but only writes data joined from the last input in the sequence, similar to a left or right outter join. With an `outter` join if an identifier appears multiple times within the final sequence input it will be flushed each time it appears.
+The type of join to perform. A `full-outer` ensures that all identifiers seen in any of the input sequences are sent, and is performed by consuming all input sequences before flushing the joined results. An `outer` join consumes all input sequences but only writes data joined from the last input in the sequence, similar to a left or right outer join. With an `outer` join if an identifier appears multiple times within the final sequence input it will be flushed each time it appears. `full-outter` and `outter` have been deprecated in favour of `full-outer` and `outer`.
 
 
 Type: `string`  
 Default: `"none"`  
-Options: `none`, `full-outter`, `outter`.
+Options: `none`, `full-outer`, `outer`, `full-outter`, `outter`.
 
 ### `sharded_join.id_path`
 

--- a/website/docs/configuration/templating.md
+++ b/website/docs/configuration/templating.md
@@ -70,7 +70,7 @@ pipeline:
     - bloblang: |
         root.id = uuid_v4()
         root.foo = this.inner.foo
-        root.body = this.outter
+        root.body = this.outer
 ```
 
 </TabItem>
@@ -92,7 +92,7 @@ pipeline:
     - bloblang: |
         root.id = uuid_v4()
         root.foo = this.inner.foo
-        root.body = this.outter
+        root.body = this.outer
 ```
 
 </TabItem>


### PR DESCRIPTION
Guess this should cover the rename to `outer` including the deprecation notice. Also feel free to close it if you think it's over the top and unnecessary :) Just thought it would be good to match the SQL `OUTER JOIN`.