### PR TITLE
Set backoff.MaxElapsedTime to 0 in aws_sqs input

### DIFF
--- a/internal/impl/aws/input_sqs.go
+++ b/internal/impl/aws/input_sqs.go
@@ -217,6 +217,7 @@ func (a *awsSQSReader) readLoop(wg *sync.WaitGroup) {
 	backoff := backoff.NewExponentialBackOff()
 	backoff.InitialInterval = 100 * time.Millisecond
 	backoff.MaxInterval = 5 * time.Minute
+	backoff.MaxElapsedTime = 0
 
 	getMsgs := func() {
 		ctx, done := a.closeSignal.CloseAtLeisureCtx(context.Background())


### PR DESCRIPTION
This is a follow-up for https://github.com/benthosdev/benthos/pull/1450

Unfortunately, I didn't noticed that ExponentialBackOff implementation has MaxElapsedTime set to 15 minutes by default.
After that, NextBackOff() starts to return -1, effectively turning polling loop into hot one and we are back to the initial problem :(.

Thus, I propose to set MaxElapsedTime to 0, because I think this is the expected behaviour here.