### PR TITLE
Add extra array methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ All notable changes to this project will be documented in this file.
 - New `base64_encode` and `base64_decode` functions for the awk processor.
 - Param `use_number` added to the `parse_json` bloblang method.
 - Fields `init_statement` and `init_files` added to all sql components.
+- New `find` and `find_all` bloblang array methods.
 
 ### Fixed
 

--- a/internal/bloblang/query/methods_structured.go
+++ b/internal/bloblang/query/methods_structured.go
@@ -209,17 +209,6 @@ var _ = registerSimpleMethod(
 		if err != nil {
 			return nil, err
 		}
-		compareFn := func(compareLeft any) bool {
-			return ICompare(compareRight, compareLeft)
-		}
-		if compareRightNum, err := IGetNumber(compareRight); err == nil {
-			compareFn = func(compareLeft any) bool {
-				if leftAsNum, err := IGetNumber(compareLeft); err == nil {
-					return leftAsNum == compareRightNum
-				}
-				return false
-			}
-		}
 		sub := IToString(compareRight)
 		bsub := IToBytes(compareRight)
 		return func(v any, ctx FunctionContext) (any, error) {
@@ -230,13 +219,13 @@ var _ = registerSimpleMethod(
 				return bytes.Contains(t, bsub), nil
 			case []any:
 				for _, compareLeft := range t {
-					if compareFn(compareLeft) {
+					if ICompare(compareRight, compareLeft) {
 						return true, nil
 					}
 				}
 			case map[string]any:
 				for _, compareLeft := range t {
-					if compareFn(compareLeft) {
+					if ICompare(compareRight, compareLeft) {
 						return true, nil
 					}
 				}

--- a/internal/bloblang/query/methods_structured.go
+++ b/internal/bloblang/query/methods_structured.go
@@ -428,6 +428,121 @@ When filtering objects the mapping query argument is provided a context with a f
 
 var _ = registerSimpleMethod(
 	NewMethodSpec(
+		"find",
+		"Returns the index of the first occurrence of a value or query in an array. `-1` is returned if there are no matches. Numerical comparisons are made irrespective of the representation type (float versus integer).",
+	).InCategory(
+		MethodCategoryObjectAndArray, "",
+		NewExampleSpec("",
+			`root.index = this.find("bar")`,
+			`["foo", "bar", "baz"]`,
+			`{"index":1}`,
+		),
+		NewExampleSpec("",
+			`root.index = this.find(v -> v != "bar")`,
+			`["foo", "bar", "baz"]`,
+			`{"index":0}`,
+		),
+		NewExampleSpec("",
+			`root.index = this.find(v -> v != "foo")`,
+			`["foo"]`,
+			`{"index":-1}`,
+		),
+	).Beta().Param(ParamQuery("value", "A value to find. If a query is provided it will only be resolved once during the lifetime of the mapping.", false)),
+	func(args *ParsedParams) (simpleMethod, error) {
+		val, err := args.Field("value")
+		if err != nil {
+			return nil, err
+		}
+
+		return func(v any, ctx FunctionContext) (any, error) {
+			array, ok := v.([]any)
+			if !ok {
+				return nil, NewTypeError(v, ValueArray)
+			}
+
+			for i, elem := range array {
+				if found, err := findMethodICompare(ctx, val, elem); err != nil {
+					return nil, err
+				} else if found {
+					return i, nil
+				}
+			}
+
+			return -1, nil
+		}, nil
+	},
+)
+
+func findMethodICompare(ctx FunctionContext, compareLeft, compareRight any) (bool, error) {
+	switch compareLeftTyped := compareLeft.(type) {
+	case *Literal:
+		return ICompare(compareLeftTyped.Value, compareRight), nil
+	case Function:
+		if value, err := compareLeftTyped.Exec(ctx.WithValue(compareRight)); err != nil {
+			return false, fmt.Errorf("failed to execute query: %w", err)
+		} else if v, ok := value.(bool); ok {
+			return v, nil
+		}
+		return false, errors.New("query did not return a boolean value")
+	}
+
+	return false, fmt.Errorf("wrong argument type, expected literal or query, got %v", ITypeOf(compareLeft))
+}
+
+//------------------------------------------------------------------------------
+
+var _ = registerSimpleMethod(
+	NewMethodSpec(
+		"find_all",
+		"Returns an array containing the indexes of all occurrences of a value or query in an array. An empty array is returned if there are no matches. Numerical comparisons are made irrespective of the representation type (float versus integer).",
+	).InCategory(
+		MethodCategoryObjectAndArray, "",
+		NewExampleSpec("",
+			`root.index = this.find_all("bar")`,
+			`["foo", "bar", "baz", "bar"]`,
+			`{"index":[1,3]}`,
+		),
+		NewExampleSpec("",
+			`root.index = this.find_all(v -> v != "bar")`,
+			`["foo", "bar", "baz"]`,
+			`{"index":[0,2]}`,
+		),
+		NewExampleSpec("",
+			`root.index = this.find_all(v -> v != "foo")`,
+			`["foo"]`,
+			`{"index":[]}`,
+		),
+	).Beta().Param(ParamQuery("value", "A value to find. If a query is provided it will only be resolved once during the lifetime of the mapping.", false)),
+	func(args *ParsedParams) (simpleMethod, error) {
+		val, err := args.Field("value")
+		if err != nil {
+			return nil, err
+		}
+
+		return func(v any, ctx FunctionContext) (any, error) {
+			array, ok := v.([]any)
+			if !ok {
+				return nil, NewTypeError(v, ValueArray)
+			}
+
+			output := []int{}
+			for i, elem := range array {
+				if found, err := findMethodICompare(ctx, val, elem); err != nil {
+					return nil, err
+				} else if found {
+					output = append(output, i)
+				}
+			}
+
+			return output, nil
+		}, nil
+	},
+)
+
+//------------------------------------------------------------------------------
+
+var _ = registerSimpleMethod(
+	NewMethodSpec(
 		"flatten",
 		"Iterates an array and any element that is itself an array is removed and has its elements inserted directly in the resulting array.",
 	).InCategory(

--- a/website/docs/guides/bloblang/methods.md
+++ b/website/docs/guides/bloblang/methods.md
@@ -1579,6 +1579,76 @@ root.new_dict = this.dict.filter(item -> item.value.contains("foo"))
 # Out: {"new_dict":{"first":"hello foo","third":"this foo is great"}}
 ```
 
+### `find`
+
+:::caution BETA
+This method is mostly stable but breaking changes could still be made outside of major version releases if a fundamental problem with it is found.
+:::
+Returns the index of the first occurrence of a value or query in an array. `-1` is returned if there are no matches. Numerical comparisons are made irrespective of the representation type (float versus integer).
+
+#### Parameters
+
+**`value`** &lt;query expression&gt; A value to find. If a query is provided it will only be resolved once during the lifetime of the mapping.  
+
+#### Examples
+
+
+```coffee
+root.index = this.find("bar")
+
+# In:  ["foo", "bar", "baz"]
+# Out: {"index":1}
+```
+
+```coffee
+root.index = this.find(v -> v != "bar")
+
+# In:  ["foo", "bar", "baz"]
+# Out: {"index":0}
+```
+
+```coffee
+root.index = this.find(v -> v != "foo")
+
+# In:  ["foo"]
+# Out: {"index":-1}
+```
+
+### `find_all`
+
+:::caution BETA
+This method is mostly stable but breaking changes could still be made outside of major version releases if a fundamental problem with it is found.
+:::
+Returns an array containing the indexes of all occurrences of a value or query in an array. An empty array is returned if there are no matches. Numerical comparisons are made irrespective of the representation type (float versus integer).
+
+#### Parameters
+
+**`value`** &lt;query expression&gt; A value to find. If a query is provided it will only be resolved once during the lifetime of the mapping.  
+
+#### Examples
+
+
+```coffee
+root.index = this.find_all("bar")
+
+# In:  ["foo", "bar", "baz", "bar"]
+# Out: {"index":[1,3]}
+```
+
+```coffee
+root.index = this.find_all(v -> v != "bar")
+
+# In:  ["foo", "bar", "baz"]
+# Out: {"index":[0,2]}
+```
+
+```coffee
+root.index = this.find_all(v -> v != "foo")
+
+# In:  ["foo"]
+# Out: {"index":[]}
+```
+
 ### `flatten`
 
 Iterates an array and any element that is itself an array is removed and has its elements inserted directly in the resulting array.


### PR DESCRIPTION
I saw this [come up on Slack](https://gophers.slack.com/archives/CLWCBK7FY/p1665005208025259) where someone was looking smth similar to [`index_of`](https://www.benthos.dev/docs/guides/bloblang/methods#index_of) for arrays and thought it might be a good-to-have utility, although after I implemented these methods, I realised that [`enumerated`](https://www.benthos.dev/docs/guides/bloblang/methods#enumerated) can be leveraged for the use case I had in mind. I picked `find` because there's [`std::find`](https://en.cppreference.com/w/cpp/algorithm/find) in C++ and C# has [`Find` for arrays](https://learn.microsoft.com/en-us/dotnet/api/system.array.find). I'm OK to rename them to smth else or discard them entirely if they don't really seem useful.

I also did a bit of cleanup in 6865938.