### PR TITLE
feat: add `FieldInterpolatedStringList`

### DIFF
--- a/public/service/config_interpolated_string.go
+++ b/public/service/config_interpolated_string.go
@@ -1,10 +1,15 @@
 package service
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
 	"github.com/benthosdev/benthos/v4/internal/docs"
+)
+
+var (
+	errInvalidInterpolation = errors.New("failed to parse interpolated field")
 )
 
 // NewInterpolatedStringField defines a new config field that describes a
@@ -22,6 +27,15 @@ func NewInterpolatedStringField(name string) *ConfigField {
 // with the method FieldInterpolatedStringMap.
 func NewInterpolatedStringMapField(name string) *ConfigField {
 	tf := docs.FieldString(name, "").IsInterpolated().Map()
+	return &ConfigField{field: tf}
+}
+
+// NewInterpolatedStringListField describes a new config field consisting of a
+// list of interpolated string values. It is then possible to extract a slice of
+// *InterpolatedString from the resulting parsed config with the method
+// FieldInterpolatedStringList.
+func NewInterpolatedStringListField(name string) *ConfigField {
+	tf := docs.FieldString(name, "").IsInterpolated().Array()
 	return &ConfigField{field: tf}
 }
 
@@ -86,4 +100,37 @@ func (p *ParsedConfig) FieldInterpolatedStringMap(path ...string) (map[string]*I
 		sMap[k] = &InterpolatedString{expr: e}
 	}
 	return sMap, nil
+}
+
+// FieldInterpolatedStringList accesses a field that is a list of interpolated
+// string values from the parsed config.
+//
+// Returns an error if the field is not found, or is not an list of interpolated
+// strings.
+func (p *ParsedConfig) FieldInterpolatedStringList(path ...string) ([]*InterpolatedString, error) {
+	v, exists := p.field(path...)
+	if !exists {
+		return nil, fmt.Errorf("field '%v' was not found in the config", p.fullDotPath(path...))
+	}
+
+	raw, ok := v.([]any)
+	if !ok {
+		return nil, fmt.Errorf("expected field '%v' to be a string list, got %T", p.fullDotPath(path...), v)
+	}
+
+	values := make([]*InterpolatedString, 0, len(raw))
+	for _, rawValue := range raw {
+		var parsed string
+		var ok bool
+		if parsed, ok = rawValue.(string); !ok {
+			return nil, fmt.Errorf("expected field '%v' to be a string list, found an element of type %T", p.fullDotPath(path...), rawValue)
+		}
+
+		e, err := p.mgr.BloblEnvironment().NewField(parsed)
+		if err != nil {
+			return nil, fmt.Errorf("%w '%v': %v", errInvalidInterpolation, strings.Join(path, "."), err)
+		}
+		values = append(values, &InterpolatedString{expr: e})
+	}
+	return values, nil
 }

--- a/public/service/config_interpolated_string_test.go
+++ b/public/service/config_interpolated_string_test.go
@@ -1,0 +1,49 @@
+package service
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestFieldInterpolatedStringList(t *testing.T) {
+	conf := `
+listfield:
+  - hello ${! json("name").uppercase() }
+  - see you in ${! meta("ttl_days") } days
+`
+
+	spec := NewConfigSpec().Field(NewInterpolatedStringListField("listfield"))
+	env := NewEnvironment()
+	parsed, err := spec.ParseYAML(conf, env)
+	require.NoError(t, err)
+
+	field, err := parsed.FieldInterpolatedStringList("listfield")
+	require.NoError(t, err)
+
+	msg := NewMessage([]byte(`{"name": "world"}`))
+	msg.MetaSet("ttl_days", "3")
+
+	var out []string
+	for _, f := range field {
+		out = append(out, f.String(msg))
+	}
+
+	require.Equal(t, []string{"hello WORLD", "see you in 3 days"}, out)
+}
+
+func TestFieldInterpolatedStringList_InvalidInterpolation(t *testing.T) {
+	conf := `
+listfield:
+  - hello ${! json("name")$$uppercas }
+  - see you in ${! meta("ttl_days") } days
+`
+
+	spec := NewConfigSpec().Field(NewInterpolatedStringListField("listfield"))
+	env := NewEnvironment()
+	parsed, err := spec.ParseYAML(conf, env)
+	require.NoError(t, err)
+
+	_, err = parsed.FieldInterpolatedStringList("listfield")
+	require.ErrorIs(t, err, errInvalidInterpolation)
+}


### PR DESCRIPTION
Adds a new field type to represent a list of interpolated strings. This field can be declared with `service.NewInterpolatedStringListField` and accessed with `service.FieldInterpolatedStringList`.