### PR TITLE
Expose the client_session_keep_alive param for snowflake_put

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 
 - Field `default_encoding` added to the `parquet_encode` processor.
+- Field `client_session_keep_alive` added to the `snowflake_put` output.
 
 ## 4.10.0 - 2022-10-26
 

--- a/website/docs/components/outputs/snowflake_put.md
+++ b/website/docs/components/outputs/snowflake_put.md
@@ -80,6 +80,7 @@ output:
     upload_parallel_threads: 4
     compression: AUTO
     snowpipe: ""
+    client_session_keep_alive: false
     batching:
       count: 0
       byte_size: 0
@@ -491,6 +492,14 @@ This field supports [interpolation functions](/docs/configuration/interpolation#
 
 
 Type: `string`  
+
+### `client_session_keep_alive`
+
+Enable Snowflake keepalive mechanism to prevent the client session from expiring after 4 hours (error 390114).
+
+
+Type: `bool`  
+Default: `false`  
 
 ### `batching`
 


### PR DESCRIPTION
This is a refinement to the fix in #1557 for issue #1556. I started to worry that there might be some reason (permissions, costs, etc) for which the `gosnowflake` authors left this as an opt-in thing.