### PR TITLE
Fix memory cache docs bug

### DIFF
--- a/internal/impl/pure/cache_memory.go
+++ b/internal/impl/pure/cache_memory.go
@@ -16,7 +16,7 @@ func memCacheConfig() *service.ConfigSpec {
 		Summary(`Stores key/value pairs in a map held in memory. This cache is therefore reset every time the service restarts. Each item in the cache has a TTL set from the moment it was last edited, after which it will be removed during the next compaction.`).
 		Description(`The compaction interval determines how often the cache is cleared of expired items, and this process is only triggered on writes to the cache. Access to the cache is blocked during this process.
 
-Item expiry can be disabled entirely by either setting the ` + "`compaction_interval`" + ` to an empty string.
+Item expiry can be disabled entirely by setting the ` + "`compaction_interval`" + ` to an empty string.
 
 The field ` + "`init_values`" + ` can be used to prepopulate the memory cache with any number of key/value pairs which are exempt from TTLs:
 

--- a/website/docs/components/caches/memory.md
+++ b/website/docs/components/caches/memory.md
@@ -51,7 +51,7 @@ memory:
 
 The compaction interval determines how often the cache is cleared of expired items, and this process is only triggered on writes to the cache. Access to the cache is blocked during this process.
 
-Item expiry can be disabled entirely by either setting the `compaction_interval` to an empty string.
+Item expiry can be disabled entirely by setting the `compaction_interval` to an empty string.
 
 The field `init_values` can be used to prepopulate the memory cache with any number of key/value pairs which are exempt from TTLs:
 


### PR DESCRIPTION
Not sure if that `either` was used to suggest some alternative mechanism in the past, but I guess setting `compaction_interval: ""` is the only mechanism to disable compaction now.