### PR TITLE
feat: add find and update and mongo client options

### DIFF
--- a/internal/component/processor/config_mongodb.go
+++ b/internal/component/processor/config_mongodb.go
@@ -10,13 +10,16 @@ type MongoDBConfig struct {
 	MongoDB      client.Config       `json:",inline" yaml:",inline"`
 	WriteConcern client.WriteConcern `json:"write_concern" yaml:"write_concern"`
 
-	Operation       string                 `json:"operation" yaml:"operation"`
-	FilterMap       string                 `json:"filter_map" yaml:"filter_map"`
-	DocumentMap     string                 `json:"document_map" yaml:"document_map"`
-	Upsert          bool                   `json:"upsert" yaml:"upsert"`
-	HintMap         string                 `json:"hint_map" yaml:"hint_map"`
-	RetryConfig     retries.Config         `json:",inline" yaml:",inline"`
-	JSONMarshalMode client.JSONMarshalMode `json:"json_marshal_mode" yaml:"json_marshal_mode"`
+	Operation               string                 `json:"operation" yaml:"operation"`
+	FilterMap               string                 `json:"filter_map" yaml:"filter_map"`
+	DocumentMap             string                 `json:"document_map" yaml:"document_map"`
+	Upsert                  bool                   `json:"upsert" yaml:"upsert"`
+	HintMap                 string                 `json:"hint_map" yaml:"hint_map"`
+	SortMap                 string                 `json:"sort_map" yaml:"sort_map"`
+	Comment                 string                 `json:"comment" yaml:"comment"`
+	FindAndUpdateReturnMode string                 `json:"find_and_update_return_mode" yaml:"find_and_update_return_mode"`
+	RetryConfig             retries.Config         `json:",inline" yaml:",inline"`
+	JSONMarshalMode         client.JSONMarshalMode `json:"json_marshal_mode" yaml:"json_marshal_mode"`
 }
 
 // NewMongoDBConfig returns a MongoDBConfig with default values.

--- a/internal/impl/mongodb/client/config.go
+++ b/internal/impl/mongodb/client/config.go
@@ -26,6 +26,8 @@ const (
 	OperationUpdateOne Operation = "update-one"
 	// OperationFindOne Find one operation.
 	OperationFindOne Operation = "find-one"
+	// OperationFindAndUpdate Find and update operation.
+	OperationFindAndUpdate Operation = "find-and-update"
 	// OperationInvalid Invalid operation.
 	OperationInvalid Operation = "invalid"
 )
@@ -45,6 +47,8 @@ func NewOperation(op string) Operation {
 		return OperationUpdateOne
 	case "find-one":
 		return OperationFindOne
+	case "find-and-update":
+		return OperationFindAndUpdate
 	default:
 		return OperationInvalid
 	}
@@ -62,11 +66,21 @@ const (
 
 // Config is a config struct for a mongo connection.
 type Config struct {
-	URL        string `json:"url" yaml:"url"`
-	Database   string `json:"database" yaml:"database"`
-	Collection string `json:"collection" yaml:"collection"`
-	Username   string `json:"username" yaml:"username"`
-	Password   string `json:"password" yaml:"password"`
+	URL                     string            `json:"url" yaml:"url"`
+	Database                string            `json:"database" yaml:"database"`
+	AuthSource              string            `json:"auth_source" yaml:"auth_source"`
+	AuthMechanism           string            `json:"auth_mecanism" yaml:"auth_mecanism"`
+	AuthMechanismProperties map[string]string `json:"auth_mecanism_properties" yaml:"auth_mecanism_properties"`
+	Collection              string            `json:"collection" yaml:"collection"`
+	Username                string            `json:"username" yaml:"username"`
+	Password                string            `json:"password" yaml:"password"`
+	PasswordSet             bool              `json:"password_set" yaml:"password_set"`
+	ConnectionTimeout       string            `json:"connection_timeout" yaml:"connection_timeout"`
+	SocketTimeout           string            `json:"socket_timeout" yaml:"socket_timeout"`
+	ServerSelectionTimeout  string            `json:"server_selection_timeout" yaml:"server_selection_timeout"`
+	AppName                 string            `json:"app_name" yaml:"app_name"`
+	MaxPoolSize             *uint64           `json:"max_pool_size" yaml:"max_pool_size"`
+	MinPoolSize             *uint64           `json:"min_pool_size" yaml:"min_pool_size"`
 }
 
 // WriteConcern describes a write concern for MongoDB.
@@ -79,28 +93,81 @@ type WriteConcern struct {
 // NewConfig returns a Config with default values.
 func NewConfig() Config {
 	return Config{
-		URL:        "",
-		Database:   "",
-		Collection: "",
-		Username:   "",
-		Password:   "",
+		URL:                     "",
+		Database:                "",
+		Collection:              "",
+		Username:                "",
+		Password:                "",
+		PasswordSet:             false,
+		AuthSource:              "",
+		AuthMechanism:           "",
+		AuthMechanismProperties: map[string]string{},
+		AppName:                 "",
+		ConnectionTimeout:       "10s",
+		SocketTimeout:           "30s",
+		ServerSelectionTimeout:  "30s",
 	}
 }
 
 // Client returns a new mongodb client based on the configuration parameters.
 func (m Config) Client() (*mongo.Client, error) {
-	opt := options.Client().
-		SetConnectTimeout(10 * time.Second).
-		SetSocketTimeout(30 * time.Second).
-		SetServerSelectionTimeout(30 * time.Second).
-		ApplyURI(m.URL)
+	opt := options.Client().ApplyURI(m.URL)
+
+	if m.ConnectionTimeout == "" {
+		opt.SetConnectTimeout(10 * time.Second)
+
+	} else {
+		if connectionTimeout, err := time.ParseDuration(m.ConnectionTimeout); err != nil {
+			return nil, fmt.Errorf("unable to parse connection timeout duration string: %w", err)
+		} else {
+			opt.SetConnectTimeout(connectionTimeout)
+		}
+	}
+
+	if m.SocketTimeout == "" {
+		opt.SetSocketTimeout(30 * time.Second)
+
+	} else {
+		if socketTimeout, err := time.ParseDuration(m.SocketTimeout); err != nil {
+			return nil, fmt.Errorf("unable to parse socket timeout duration string: %w", err)
+		} else {
+			opt.SetSocketTimeout(socketTimeout)
+		}
+	}
+
+	if m.ServerSelectionTimeout == "" {
+		opt.SetServerSelectionTimeout(30 * time.Second)
+
+	} else {
+		if serverSelectionTimeout, err := time.ParseDuration(m.ServerSelectionTimeout); err != nil {
+			return nil, fmt.Errorf("unable to parse server selection timeout duration string: %w", err)
+		} else {
+			opt.SetServerSelectionTimeout(serverSelectionTimeout)
+		}
+	}
+
+	if m.MinPoolSize != nil {
+		opt.SetMinPoolSize(*m.MinPoolSize)
+	}
+
+	if m.MaxPoolSize != nil {
+		opt.SetMaxPoolSize(*m.MaxPoolSize)
+	}
 
 	if m.Username != "" && m.Password != "" {
 		creds := options.Credential{
-			Username: m.Username,
-			Password: m.Password,
+			Username:                m.Username,
+			Password:                m.Password,
+			AuthSource:              m.AuthSource,
+			PasswordSet:             m.PasswordSet,
+			AuthMechanism:           m.AuthMechanism,
+			AuthMechanismProperties: m.AuthMechanismProperties,
 		}
 		opt.SetAuth(creds)
+	}
+
+	if m.AppName != "" {
+		opt.SetAppName(m.AppName)
 	}
 
 	client, err := mongo.NewClient(opt)
@@ -121,5 +188,14 @@ func ConfigDocs() docs.FieldSpecs {
 		docs.FieldString("database", "The name of the target MongoDB DB."),
 		docs.FieldString("username", "The username to connect to the database."),
 		docs.FieldString("password", "The password to connect to the database."),
+		docs.FieldString("password_set", "For GSSAPI, this must be true if a password is specified, even if the password is the empty string, and false if no password is specified, indicating that the password should be taken from the context of the running process. For other mechanisms, this field is ignored.").Advanced().AtVersion("4.11.0"),
+		docs.FieldString("auth_source", `The name of the database to use for authentication. This can also be set through the "authSource" URI option (e.g. "authSource=otherDb"). For more information, see [MongoDB docs](https://www.mongodb.com/docs/manual/reference/connection-string/#mongodb-urioption-urioption.authSource).`).Advanced().AtVersion("4.11.0"),
+		docs.FieldString("auth_mechanism", `The mechanism to use for authentication. This can also be set through the "authMechanism" URI option. (e.g. "authMechanism=PLAIN"). For more information, see [MongoDB docs](https://docs.mongodb.com/manual/core/authentication-mechanisms/).`).Advanced().AtVersion("4.11.0"),
+		docs.FieldString("app_name", "The [appName](https://www.mongodb.com/docs/manual/reference/connection-string/#mongodb-urioption-urioption.appName) to use in the client connection.").Advanced().AtVersion("4.11.0"),
+		docs.FieldString("connect_timeout", "Connect timeout while connecting to the database.").HasDefault("10s").Advanced().AtVersion("4.11.0"),
+		docs.FieldString("socket_timeout", "Socket timeout while connecting to the database.").HasDefault("30s").Advanced().AtVersion("4.11.0"),
+		docs.FieldString("server_selection_timeout", "Server selection timeout while connecting to the database.").HasDefault("30s").Advanced().AtVersion("4.11.0"),
+		docs.FieldString("min_pool_size", "The minimum number of connections allowed in the driver's connection pool to each server.").HasDefault("0").Advanced().AtVersion("4.11.0"),
+		docs.FieldString("max_pool_size", "The maximum number of connections allowed in the driver's connection pool to each server.").HasDefault("100").Advanced().AtVersion("4.11.0"),
 	}
 }

--- a/internal/impl/mongodb/docs.go
+++ b/internal/impl/mongodb/docs.go
@@ -8,7 +8,7 @@ import (
 
 func processorOperationDocs(defaultOperation client.Operation) docs.FieldSpec {
 	fs := outputOperationDocs(defaultOperation)
-	return fs.HasOptions(append(fs.Options, string(client.OperationFindOne))...)
+	return fs.HasOptions(append(fs.Options, string(client.OperationFindOne), string(client.OperationFindAndUpdate))...)
 }
 
 func outputOperationDocs(defaultOperation client.Operation) docs.FieldSpec {

--- a/internal/impl/mongodb/mongodb.go
+++ b/internal/impl/mongodb/mongodb.go
@@ -4,7 +4,7 @@ import "github.com/benthosdev/benthos/v4/internal/impl/mongodb/client"
 
 func isDocumentAllowed(op client.Operation) bool {
 	switch op {
-	case client.OperationInsertOne, client.OperationReplaceOne, client.OperationUpdateOne:
+	case client.OperationInsertOne, client.OperationReplaceOne, client.OperationUpdateOne, client.OperationFindAndUpdate:
 		return true
 	default:
 		return false
@@ -13,7 +13,7 @@ func isDocumentAllowed(op client.Operation) bool {
 
 func isFilterAllowed(op client.Operation) bool {
 	switch op {
-	case client.OperationDeleteOne, client.OperationDeleteMany, client.OperationReplaceOne, client.OperationUpdateOne, client.OperationFindOne:
+	case client.OperationDeleteOne, client.OperationDeleteMany, client.OperationReplaceOne, client.OperationUpdateOne, client.OperationFindOne, client.OperationFindAndUpdate:
 		return true
 	default:
 		return false
@@ -22,7 +22,25 @@ func isFilterAllowed(op client.Operation) bool {
 
 func isHintAllowed(op client.Operation) bool {
 	switch op {
-	case client.OperationDeleteOne, client.OperationDeleteMany, client.OperationReplaceOne, client.OperationUpdateOne, client.OperationFindOne:
+	case client.OperationDeleteOne, client.OperationDeleteMany, client.OperationReplaceOne, client.OperationUpdateOne, client.OperationFindOne, client.OperationFindAndUpdate:
+		return true
+	default:
+		return false
+	}
+}
+
+func isSortAllowed(op client.Operation) bool {
+	switch op {
+	case client.OperationFindOne, client.OperationFindAndUpdate:
+		return true
+	default:
+		return false
+	}
+}
+
+func isCommentAllowed(op client.Operation) bool {
+	switch op {
+	case client.OperationFindOne:
 		return true
 	default:
 		return false
@@ -31,7 +49,7 @@ func isHintAllowed(op client.Operation) bool {
 
 func isUpsertAllowed(op client.Operation) bool {
 	switch op {
-	case client.OperationReplaceOne, client.OperationUpdateOne:
+	case client.OperationReplaceOne, client.OperationUpdateOne, client.OperationFindAndUpdate:
 		return true
 	default:
 		return false

--- a/website/docs/components/outputs/mongodb.md
+++ b/website/docs/components/outputs/mongodb.md
@@ -69,6 +69,15 @@ output:
     database: ""
     username: ""
     password: ""
+    password_set: false
+    auth_source: ""
+    auth_mechanism: ""
+    app_name: ""
+    connect_timeout: 10s
+    socket_timeout: 30s
+    server_selection_timeout: 30s
+    min_pool_size: "0"
+    max_pool_size: "100"
     operation: update-one
     collection: ""
     write_concern:
@@ -146,6 +155,86 @@ The password to connect to the database.
 
 Type: `string`  
 Default: `""`  
+
+### `password_set`
+
+For GSSAPI, this must be true if a password is specified, even if the password is the empty string, and false if no password is specified, indicating that the password should be taken from the context of the running process. For other mechanisms, this field is ignored.
+
+
+Type: `string`  
+Default: `false`  
+Requires version 4.11.0 or newer  
+
+### `auth_source`
+
+The name of the database to use for authentication. This can also be set through the "authSource" URI option (e.g. "authSource=otherDb"). For more information, see [MongoDB docs](https://www.mongodb.com/docs/manual/reference/connection-string/#mongodb-urioption-urioption.authSource).
+
+
+Type: `string`  
+Default: `""`  
+Requires version 4.11.0 or newer  
+
+### `auth_mechanism`
+
+The mechanism to use for authentication. This can also be set through the "authMechanism" URI option. (e.g. "authMechanism=PLAIN"). For more information, see [MongoDB docs](https://docs.mongodb.com/manual/core/authentication-mechanisms/).
+
+
+Type: `string`  
+Requires version 4.11.0 or newer  
+
+### `app_name`
+
+The [appName](https://www.mongodb.com/docs/manual/reference/connection-string/#mongodb-urioption-urioption.appName) to use in the client connection.
+
+
+Type: `string`  
+Default: `""`  
+Requires version 4.11.0 or newer  
+
+### `connect_timeout`
+
+Connect timeout while connecting to the database.
+
+
+Type: `string`  
+Default: `"10s"`  
+Requires version 4.11.0 or newer  
+
+### `socket_timeout`
+
+Socket timeout while connecting to the database.
+
+
+Type: `string`  
+Default: `"30s"`  
+Requires version 4.11.0 or newer  
+
+### `server_selection_timeout`
+
+Server selection timeout while connecting to the database.
+
+
+Type: `string`  
+Default: `"30s"`  
+Requires version 4.11.0 or newer  
+
+### `min_pool_size`
+
+The minimum number of connections allowed in the driver's connection pool to each server.
+
+
+Type: `string`  
+Default: `"0"`  
+Requires version 4.11.0 or newer  
+
+### `max_pool_size`
+
+The maximum number of connections allowed in the driver's connection pool to each server.
+
+
+Type: `string`  
+Default: `"100"`  
+Requires version 4.11.0 or newer  
 
 ### `operation`
 

--- a/website/docs/components/processors/mongodb.md
+++ b/website/docs/components/processors/mongodb.md
@@ -47,6 +47,8 @@ mongodb:
   document_map: ""
   filter_map: ""
   hint_map: ""
+  sort_map: ""
+  comment: ""
   upsert: false
 ```
 
@@ -61,6 +63,15 @@ mongodb:
   database: ""
   username: ""
   password: ""
+  password_set: false
+  auth_source: ""
+  auth_mechanism: ""
+  app_name: ""
+  connect_timeout: 10s
+  socket_timeout: 30s
+  server_selection_timeout: 30s
+  min_pool_size: "0"
+  max_pool_size: "100"
   operation: insert-one
   collection: ""
   write_concern:
@@ -70,6 +81,9 @@ mongodb:
   document_map: ""
   filter_map: ""
   hint_map: ""
+  sort_map: ""
+  comment: ""
+  find_and_update_return_mode: before
   upsert: false
   json_marshal_mode: canonical
   max_retries: 3
@@ -122,6 +136,86 @@ The password to connect to the database.
 Type: `string`  
 Default: `""`  
 
+### `password_set`
+
+For GSSAPI, this must be true if a password is specified, even if the password is the empty string, and false if no password is specified, indicating that the password should be taken from the context of the running process. For other mechanisms, this field is ignored.
+
+
+Type: `string`  
+Default: `false`  
+Requires version 4.11.0 or newer  
+
+### `auth_source`
+
+The name of the database to use for authentication. This can also be set through the "authSource" URI option (e.g. "authSource=otherDb"). For more information, see [MongoDB docs](https://www.mongodb.com/docs/manual/reference/connection-string/#mongodb-urioption-urioption.authSource).
+
+
+Type: `string`  
+Default: `""`  
+Requires version 4.11.0 or newer  
+
+### `auth_mechanism`
+
+The mechanism to use for authentication. This can also be set through the "authMechanism" URI option. (e.g. "authMechanism=PLAIN"). For more information, see [MongoDB docs](https://docs.mongodb.com/manual/core/authentication-mechanisms/).
+
+
+Type: `string`  
+Requires version 4.11.0 or newer  
+
+### `app_name`
+
+The [appName](https://www.mongodb.com/docs/manual/reference/connection-string/#mongodb-urioption-urioption.appName) to use in the client connection.
+
+
+Type: `string`  
+Default: `""`  
+Requires version 4.11.0 or newer  
+
+### `connect_timeout`
+
+Connect timeout while connecting to the database.
+
+
+Type: `string`  
+Default: `"10s"`  
+Requires version 4.11.0 or newer  
+
+### `socket_timeout`
+
+Socket timeout while connecting to the database.
+
+
+Type: `string`  
+Default: `"30s"`  
+Requires version 4.11.0 or newer  
+
+### `server_selection_timeout`
+
+Server selection timeout while connecting to the database.
+
+
+Type: `string`  
+Default: `"30s"`  
+Requires version 4.11.0 or newer  
+
+### `min_pool_size`
+
+The minimum number of connections allowed in the driver's connection pool to each server.
+
+
+Type: `string`  
+Default: `"0"`  
+Requires version 4.11.0 or newer  
+
+### `max_pool_size`
+
+The maximum number of connections allowed in the driver's connection pool to each server.
+
+
+Type: `string`  
+Default: `"100"`  
+Requires version 4.11.0 or newer  
+
 ### `operation`
 
 The mongodb operation to perform.
@@ -129,7 +223,7 @@ The mongodb operation to perform.
 
 Type: `string`  
 Default: `"insert-one"`  
-Options: `insert-one`, `delete-one`, `delete-many`, `replace-one`, `update-one`, `find-one`.
+Options: `insert-one`, `delete-one`, `delete-many`, `replace-one`, `update-one`, `find-one`, `find-and-update`.
 
 ### `collection`
 
@@ -218,6 +312,48 @@ hint_map: |-
   root.a = this.foo
   root.b = this.bar
 ```
+
+### `sort_map`
+
+A bloblang map representing the sort for the mongo db command. This map is optional and is used only with find-one and find-and-modify operations. It is used to sort the documents in the mongodb.
+
+
+Type: `string`  
+Default: `""`  
+Requires version 4.11.0 or newer  
+
+```yml
+# Examples
+
+sort_map: |-
+  root.a = 1
+  root.b = -1
+```
+
+### `comment`
+
+A interpolated string representing a comment to send with the operation. This field is optional and is used only with find-one operation.
+
+
+Type: `string`  
+Default: `""`  
+Requires version 4.11.0 or newer  
+
+```yml
+# Examples
+
+comment: my comment
+```
+
+### `find_and_update_return_mode`
+
+The return mode for the find and modify operation. This field is used only for the find-and-update operation.
+
+
+Type: `string`  
+Default: `"before"`  
+Requires version 4.11.0 or newer  
+Options: `before`, `after`.
 
 ### `upsert`
 


### PR DESCRIPTION
This PR will add a new operation for MongoDB (find-and-update) and also new client options:

Default values:
```
  password_set: false
  auth_source: ""
  auth_mechanism: ""
  app_name: ""
  connect_timeout: 10s
  socket_timeout: 30s
  server_selection_timeout: 30s
  min_pool_size: "0"
  max_pool_size: "100"
```

It will also add two processor option:

```
  sort_map: ""
  comment: ""
```