### PR TITLE
add application properties map to amqp_1 output

### DIFF
--- a/internal/component/output/config_amqp_1.go
+++ b/internal/component/output/config_amqp_1.go
@@ -8,22 +8,24 @@ import (
 
 // AMQP1Config contains configuration fields for the AMQP1 output type.
 type AMQP1Config struct {
-	URL           string                       `json:"url" yaml:"url"`
-	TargetAddress string                       `json:"target_address" yaml:"target_address"`
-	MaxInFlight   int                          `json:"max_in_flight" yaml:"max_in_flight"`
-	TLS           btls.Config                  `json:"tls" yaml:"tls"`
-	SASL          shared.SASLConfig            `json:"sasl" yaml:"sasl"`
-	Metadata      metadata.ExcludeFilterConfig `json:"metadata" yaml:"metadata"`
+	URL                          string                       `json:"url" yaml:"url"`
+	TargetAddress                string                       `json:"target_address" yaml:"target_address"`
+	MaxInFlight                  int                          `json:"max_in_flight" yaml:"max_in_flight"`
+	TLS                          btls.Config                  `json:"tls" yaml:"tls"`
+	SASL                         shared.SASLConfig            `json:"sasl" yaml:"sasl"`
+	Metadata                     metadata.ExcludeFilterConfig `json:"metadata" yaml:"metadata"`
+	ApplicationPropertiesMapping string                       `json:"application_properties_map" yaml:"application_properties_map"`
 }
 
 // NewAMQP1Config creates a new AMQP1Config with default values.
 func NewAMQP1Config() AMQP1Config {
 	return AMQP1Config{
-		URL:           "",
-		TargetAddress: "",
-		MaxInFlight:   64,
-		TLS:           btls.NewConfig(),
-		SASL:          shared.NewSASLConfig(),
-		Metadata:      metadata.NewExcludeFilterConfig(),
+		URL:                          "",
+		TargetAddress:                "",
+		MaxInFlight:                  64,
+		TLS:                          btls.NewConfig(),
+		SASL:                         shared.NewSASLConfig(),
+		Metadata:                     metadata.NewExcludeFilterConfig(),
+		ApplicationPropertiesMapping: "",
 	}
 }

--- a/internal/impl/amqp1/output.go
+++ b/internal/impl/amqp1/output.go
@@ -197,7 +197,6 @@ func (a *amqp1Writer) WriteBatch(ctx context.Context, msg message.Batch) error {
 
 	return output.IterateBatchedSend(msg, func(i int, p *message.Part) error {
 		m := amqp.NewMessage(p.AsBytes())
-		var err error
 
 		if a.applicationPropertiesMap != nil {
 			value, err := a.applicationPropertiesMap.Query(p)
@@ -218,7 +217,7 @@ func (a *amqp1Writer) WriteBatch(ctx context.Context, msg message.Batch) error {
 			m.Annotations[k] = v
 			return nil
 		})
-		err = s.Send(ctx, m)
+		err := s.Send(ctx, m)
 		if err != nil {
 			if err == amqp.ErrTimeout || ctx.Err() != nil {
 				err = component.ErrTimeout

--- a/website/docs/components/outputs/amqp_1.md
+++ b/website/docs/components/outputs/amqp_1.md
@@ -58,6 +58,7 @@ output:
       root_cas: ""
       root_cas_file: ""
       client_certs: []
+    application_properties_map: ""
     sasl:
       mechanism: none
       user: ""
@@ -261,6 +262,14 @@ password: foo
 
 password: ${KEY_PASSWORD}
 ```
+
+### `application_properties_map`
+
+Mapping to set the `application-properties` on output messages
+
+
+Type: `string`  
+Default: `""`  
 
 ### `sasl`
 


### PR DESCRIPTION
Should populate the following in amqp_1 https://docs.oasis-open.org/amqp/core/v1.0/os/amqp-core-messaging-v1.0-os.html#type-application-properties.

Azure Service Bus or Event Hub use fields in this to provide deduplication. Internally we use it for routing messages to proper handlers as well without having to run multiple queues/hubs.