### PR TITLE
Add optional range parameters to `random_int` function

### DIFF
--- a/website/docs/guides/bloblang/functions.md
+++ b/website/docs/guides/bloblang/functions.md
@@ -119,11 +119,13 @@ root.id = nanoid(54, "abcde")
 
 ### `random_int`
 
-Generates a non-negative pseudo-random 64-bit integer. An optional integer argument can be provided in order to seed the random number generator.
+Generates a non-negative pseudo-random 64-bit integer. An optional integer argument can be provided in order to seed the random number generator. Optional `min` and `max` arguments can be provided to make the generated numbers within a range.
 
 #### Parameters
 
 **`seed`** &lt;query expression, default `{"Value":0}`&gt; A seed to use, if a query is provided it will only be resolved once during the lifetime of the mapping.  
+**`min`** &lt;integer, default `0`&gt; The minimum value the random generated number will have. The default value is 0.  
+**`max`** &lt;integer, default `9223372036854775806`&gt; The maximum value the random generated number will have. The default value is 9223372036854775806 (math.MaxInt64 - 1).  
 
 #### Examples
 
@@ -131,6 +133,11 @@ Generates a non-negative pseudo-random 64-bit integer. An optional integer argum
 ```coffee
 root.first = random_int()
 root.second = random_int(1)
+root.third = random_int(max:20)
+root.forth = random_int(min:10, max:20)
+root.fifth = random_int(timestamp_unix_nano(), 5, 20)
+root.sixth = random_int(seed:timestamp_unix_nano(), max:20)
+
 ```
 
 It is possible to specify a dynamic seed argument, in which case the argument will only be resolved once during the lifetime of the mapping.


### PR DESCRIPTION
I've added optional range parameters to the `random_int` function that allows us to specify a range for our resulting random numbers.

We can use it in a mapping like this: 

```yml
input:
  label: generate
  generate:
    mapping: |
      root = {
        "random": random_int(), 
        "random_seed": random_int(1), 
        "random_ge_0_le_20": random_int(timestamp_unix_nano(), 0, 20),
        "random_le_20": random_int(max:20),
        "random_ge_0_le_5_with_seed": random_int(seed:timestamp_unix_nano(), min:0, max:5)
      }
```
