### PR TITLE
feat: add support for subscription creation on gcp_pubsub input

### DIFF
--- a/internal/component/input/config_gcp_pubsub.go
+++ b/internal/component/input/config_gcp_pubsub.go
@@ -2,13 +2,17 @@ package input
 
 // GCPPubSubConfig contains configuration values for the input type.
 type GCPPubSubConfig struct {
-	ProjectID              string `json:"project" yaml:"project"`
-	SubscriptionID         string `json:"subscription" yaml:"subscription"`
-	TopicID                string `json:"topic" yaml:"topic"`
-	MaxOutstandingMessages int    `json:"max_outstanding_messages" yaml:"max_outstanding_messages"`
-	MaxOutstandingBytes    int    `json:"max_outstanding_bytes" yaml:"max_outstanding_bytes"`
-	Sync                   bool   `json:"sync" yaml:"sync"`
-	CreateSubscription     bool   `json:"create_subscription" yaml:"create_subscription"`
+	ProjectID              string                      `json:"project" yaml:"project"`
+	SubscriptionID         string                      `json:"subscription" yaml:"subscription"`
+	MaxOutstandingMessages int                         `json:"max_outstanding_messages" yaml:"max_outstanding_messages"`
+	MaxOutstandingBytes    int                         `json:"max_outstanding_bytes" yaml:"max_outstanding_bytes"`
+	Sync                   bool                        `json:"sync" yaml:"sync"`
+	CreateSubscription     GCPPubSubSubscriptionConfig `json:"create_subscription" yaml:"create_subscription"`
+}
+
+type GCPPubSubSubscriptionConfig struct {
+	Enabled bool   `json:"enabled" yaml:"enabled"`
+	TopicID string `json:"topic" yaml:"topic"`
 }
 
 // NewGCPPubSubConfig creates a new Config with default values.
@@ -16,10 +20,12 @@ func NewGCPPubSubConfig() GCPPubSubConfig {
 	return GCPPubSubConfig{
 		ProjectID:              "",
 		SubscriptionID:         "",
-		TopicID:                "",
 		MaxOutstandingMessages: 1000, // pubsub.DefaultReceiveSettings.MaxOutstandingMessages
 		MaxOutstandingBytes:    1e9,  // pubsub.DefaultReceiveSettings.MaxOutstandingBytes (1G)
 		Sync:                   false,
-		CreateSubscription:     false,
+		CreateSubscription: GCPPubSubSubscriptionConfig{
+			Enabled: false,
+			TopicID: "",
+		},
 	}
 }

--- a/internal/component/input/config_gcp_pubsub.go
+++ b/internal/component/input/config_gcp_pubsub.go
@@ -4,9 +4,11 @@ package input
 type GCPPubSubConfig struct {
 	ProjectID              string `json:"project" yaml:"project"`
 	SubscriptionID         string `json:"subscription" yaml:"subscription"`
+	TopicID                string `json:"topic" yaml:"topic"`
 	MaxOutstandingMessages int    `json:"max_outstanding_messages" yaml:"max_outstanding_messages"`
 	MaxOutstandingBytes    int    `json:"max_outstanding_bytes" yaml:"max_outstanding_bytes"`
 	Sync                   bool   `json:"sync" yaml:"sync"`
+	CreateSubscription     bool   `json:"create_subscription" yaml:"create_subscription"`
 }
 
 // NewGCPPubSubConfig creates a new Config with default values.
@@ -14,8 +16,10 @@ func NewGCPPubSubConfig() GCPPubSubConfig {
 	return GCPPubSubConfig{
 		ProjectID:              "",
 		SubscriptionID:         "",
+		TopicID:                "",
 		MaxOutstandingMessages: 1000, // pubsub.DefaultReceiveSettings.MaxOutstandingMessages
 		MaxOutstandingBytes:    1e9,  // pubsub.DefaultReceiveSettings.MaxOutstandingBytes (1G)
 		Sync:                   false,
+		CreateSubscription:     false,
 	}
 }

--- a/internal/impl/gcp/input_pubsub.go
+++ b/internal/impl/gcp/input_pubsub.go
@@ -89,9 +89,9 @@ func createSubscription(conf input.GCPPubSubConfig, client *pubsub.Client, log l
 	}
 
 	log.Infof("Creating subscription '%v' on topic '%v'\n", conf.SubscriptionID, conf.TopicID)
-	_, exception := client.CreateSubscription(context.Background(), conf.SubscriptionID, pubsub.SubscriptionConfig{Topic: client.Topic(conf.TopicID)})
+	_, err = client.CreateSubscription(context.Background(), conf.SubscriptionID, pubsub.SubscriptionConfig{Topic: client.Topic(conf.TopicID)})
 
-	if exception != nil {
+	if err != nil {
 		log.Errorf("Error creating subscription %v", err)
 	}
 }

--- a/internal/impl/gcp/input_pubsub.go
+++ b/internal/impl/gcp/input_pubsub.go
@@ -44,7 +44,9 @@ You can access these metadata fields using
 		Config: docs.FieldComponent().WithChildren(
 			docs.FieldString("project", "The project ID of the target subscription."),
 			docs.FieldString("subscription", "The target subscription ID."),
+			docs.FieldString("topic", "The target topic that the subscription is vinculated."),
 			docs.FieldBool("sync", "Enable synchronous pull mode."),
+			docs.FieldBool("create_subscription", "Should create target subscription or not"),
 			docs.FieldInt("max_outstanding_messages", "The maximum number of outstanding pending messages to be consumed at a given time."),
 			docs.FieldInt("max_outstanding_bytes", "The maximum number of outstanding pending messages to be consumed measured in bytes."),
 		).ChildDefaultAndTypesFromStruct(input.NewGCPPubSubConfig()),
@@ -56,11 +58,42 @@ You can access these metadata fields using
 
 func newGCPPubSubInput(conf input.Config, mgr bundle.NewManagement, log log.Modular, stats metrics.Type) (input.Streamed, error) {
 	var c input.Async
+	var client *pubsub.Client
 	var err error
-	if c, err = newGCPPubSubReader(conf.GCPPubSub, log, stats); err != nil {
+	if c, client, err = newGCPPubSubReader(conf.GCPPubSub, log, stats); err != nil {
 		return nil, err
 	}
+
+	if conf.GCPPubSub.CreateSubscription {
+		createSubscription(conf.GCPPubSub, client, log)
+	}
 	return input.NewAsyncReader("gcp_pubsub", true, c, mgr)
+}
+
+func createSubscription(conf input.GCPPubSubConfig, client *pubsub.Client, log log.Modular) {
+	subsExists, err := client.Subscription(conf.SubscriptionID).Exists(context.Background())
+
+	if err != nil {
+		log.Errorf("Error checking if subscription exists", err)
+		return
+	}
+
+	if subsExists {
+		log.Infof("Subscription '%v' already exists", conf.SubscriptionID)
+		return
+	}
+
+	if conf.TopicID == "" {
+		log.Infof("Subscription won't be created because TopicID is not defined")
+		return
+	}
+
+	log.Infof("Creating subscription '%v' on topic '%v'\n", conf.SubscriptionID, conf.TopicID)
+	_, exception := client.CreateSubscription(context.Background(), conf.SubscriptionID, pubsub.SubscriptionConfig{Topic: client.Topic(conf.TopicID)})
+
+	if exception != nil {
+		log.Errorf("Error creating subscription %v", err)
+	}
 }
 
 type gcpPubSubReader struct {
@@ -76,16 +109,16 @@ type gcpPubSubReader struct {
 	log log.Modular
 }
 
-func newGCPPubSubReader(conf input.GCPPubSubConfig, log log.Modular, stats metrics.Type) (*gcpPubSubReader, error) {
+func newGCPPubSubReader(conf input.GCPPubSubConfig, log log.Modular, stats metrics.Type) (*gcpPubSubReader, *pubsub.Client, error) {
 	client, err := pubsub.NewClient(context.Background(), conf.ProjectID)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	return &gcpPubSubReader{
 		conf:   conf,
 		log:    log,
 		client: client,
-	}, nil
+	}, client, nil
 }
 
 func (c *gcpPubSubReader) Connect(ignored context.Context) error {

--- a/internal/impl/gcp/integration_pubsub_test.go
+++ b/internal/impl/gcp/integration_pubsub_test.go
@@ -72,8 +72,9 @@ input:
   gcp_pubsub:
     project: benthos-test-project
     subscription: sub-$ID
-    topic: topic-$ID
-    create_subscription: true
+    create_subscription:
+      enabled: true
+      topic: topic-$ID
 `
 	suiteOpts := []integration.StreamTestOptFunc{
 		integration.StreamTestOptSleepAfterInput(100 * time.Millisecond),

--- a/internal/impl/gcp/integration_pubsub_test.go
+++ b/internal/impl/gcp/integration_pubsub_test.go
@@ -72,6 +72,8 @@ input:
   gcp_pubsub:
     project: benthos-test-project
     subscription: sub-$ID
+    topic: topic-$ID
+    create_subscription: true
 `
 	suiteOpts := []integration.StreamTestOptFunc{
 		integration.StreamTestOptSleepAfterInput(100 * time.Millisecond),
@@ -81,17 +83,7 @@ input:
 			client, err := pubsub.NewClient(ctx, "benthos-test-project")
 			require.NoError(t, err)
 
-			topic, err := client.CreateTopic(ctx, fmt.Sprintf("topic-%v", testID))
-			require.NoError(t, err)
-
-			_, err = client.CreateSubscription(ctx, fmt.Sprintf("sub-%v", testID), pubsub.SubscriptionConfig{
-				AckDeadline: time.Second * 10,
-				RetryPolicy: &pubsub.RetryPolicy{
-					MaximumBackoff: time.Millisecond * 10,
-					MinimumBackoff: time.Millisecond * 10,
-				},
-				Topic: topic,
-			})
+			_, err = client.CreateTopic(ctx, fmt.Sprintf("topic-%v", testID))
 			require.NoError(t, err)
 
 			client.Close()


### PR DESCRIPTION
If the user configures it, Benthos can submit a new subscription to PubSub;

I just created a new object property on gcp_pubsub input:

```yaml
create_subscription:
  enabled: true
  topic: "topic-id"
```

Closes #1579 