### PR TITLE
Fix PKCS#1 encrypted private key validation

### DIFF
--- a/internal/tls/type_test.go
+++ b/internal/tls/type_test.go
@@ -102,12 +102,13 @@ func TestCertificateFileWithEncryptedKey(t *testing.T) {
 		},
 	}
 
+	tmpDir := t.TempDir()
 	for _, test := range tests {
-		fCert, _ := os.CreateTemp("", "cert.pem")
+		fCert, _ := os.CreateTemp(tmpDir, "cert.pem")
 		_, _ = fCert.Write(test.kp.cert)
 		fCert.Close()
 
-		fKey, _ := os.CreateTemp("", "key.pem")
+		fKey, _ := os.CreateTemp(tmpDir, "key.pem")
 		_, _ = fKey.Write(test.kp.key)
 		fKey.Close()
 
@@ -171,12 +172,13 @@ func TestCertificateFileWithEncryptedKeyAndWrongPassword(t *testing.T) {
 		},
 	}
 
+	tmpDir := t.TempDir()
 	for _, test := range tests {
-		fCert, _ := os.CreateTemp("", "cert.pem")
+		fCert, _ := os.CreateTemp(tmpDir, "cert.pem")
 		_, _ = fCert.Write(test.kp.cert)
 		fCert.Close()
 
-		fKey, _ := os.CreateTemp("", "key.pem")
+		fKey, _ := os.CreateTemp(tmpDir, "key.pem")
 		_, _ = fKey.Write(test.kp.key)
 		fKey.Close()
 
@@ -224,11 +226,13 @@ func TestEncryptedKeyWithWrongPassword(t *testing.T) {
 func TestCertificateFileWithNoEncryption(t *testing.T) {
 	cert, key := createCertificates()
 
-	fCert, _ := os.CreateTemp("", "cert.pem")
+	tmpDir := t.TempDir()
+
+	fCert, _ := os.CreateTemp(tmpDir, "cert.pem")
 	_, _ = fCert.Write(cert)
 	defer fCert.Close()
 
-	fKey, _ := os.CreateTemp("", "key.pem")
+	fKey, _ := os.CreateTemp(tmpDir, "key.pem")
 	_, _ = fKey.Write(key)
 	defer fKey.Close()
 


### PR DESCRIPTION
This will also prevent the `TestCertificateFileWithEncryptedKeyAndWrongPassword` test from failing occasionally: https://github.com/benthosdev/benthos/actions/runs/3560623299/jobs/5980779779#step:7:124