### PR TITLE
Set `Content-Type` header when returning lint errors

### DIFF
--- a/internal/stream/manager/api.go
+++ b/internal/stream/manager/api.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"sort"
 	"strings"
 	"sync"
 
@@ -81,6 +80,10 @@ func (c ConfigSet) UnmarshalYAML(value *yaml.Node) error {
 		c[k] = conf
 	}
 	return nil
+}
+
+type lintErrors struct {
+	LintErrs []string `json:"lint_errors"`
 }
 
 func lintStreamConfigNode(node *yaml.Node) (lints []string) {
@@ -161,12 +164,10 @@ func (m *Type) HandleStreamsCRUD(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 		if len(lints) > 0 {
-			sort.Strings(lints)
-			errBytes, _ := json.Marshal(struct {
-				LintErrs []string `json:"lint_errors"`
-			}{
+			errBytes, _ := json.Marshal(lintErrors{
 				LintErrs: lints,
 			})
+			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusBadRequest)
 			_, _ = w.Write(errBytes)
 			return
@@ -343,11 +344,10 @@ func (m *Type) HandleStreamCRUD(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		if len(lints) > 0 {
-			errBytes, _ := json.Marshal(struct {
-				LintErrs []string `json:"lint_errors"`
-			}{
+			errBytes, _ := json.Marshal(lintErrors{
 				LintErrs: lints,
 			})
+			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusBadRequest)
 			_, _ = w.Write(errBytes)
 			return
@@ -381,11 +381,10 @@ func (m *Type) HandleStreamCRUD(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		if len(lints) > 0 {
-			errBytes, _ := json.Marshal(struct {
-				LintErrs []string `json:"lint_errors"`
-			}{
+			errBytes, _ := json.Marshal(lintErrors{
 				LintErrs: lints,
 			})
+			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusBadRequest)
 			_, _ = w.Write(errBytes)
 			return
@@ -522,11 +521,10 @@ func (m *Type) HandleResourceCRUD(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 	if len(lints) > 0 {
-		errBytes, _ := json.Marshal(struct {
-			LintErrs []string `json:"lint_errors"`
-		}{
+		errBytes, _ := json.Marshal(lintErrors{
 			LintErrs: lints,
 		})
+		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusBadRequest)
 		_, _ = w.Write(errBytes)
 		return

--- a/internal/stream/manager/api_test.go
+++ b/internal/stream/manager/api_test.go
@@ -609,8 +609,9 @@ func TestTypeAPIStreamsLinting(t *testing.T) {
 	response := httptest.NewRecorder()
 	r.ServeHTTP(response, request)
 	assert.Equal(t, http.StatusBadRequest, response.Code)
+	assert.Equal(t, "application/json", response.Result().Header.Get("Content-Type"))
 
-	expLints := `{"lint_errors":["stream 'bar': (15,1) field generate is invalid when the component type is inproc (input)","stream 'foo': (10,1) field inproc is invalid when the component type is drop (output)"]}`
+	expLints := `{"lint_errors":["stream 'foo': (10,1) field inproc is invalid when the component type is drop (output)","stream 'bar': (15,1) field generate is invalid when the component type is inproc (input)"]}`
 	assert.Equal(t, expLints, response.Body.String())
 
 	request, err = http.NewRequest("POST", "/streams?chilled=true", bytes.NewReader(body))
@@ -682,6 +683,7 @@ func TestTypeAPILinting(t *testing.T) {
 	response := httptest.NewRecorder()
 	r.ServeHTTP(response, request)
 	assert.Equal(t, http.StatusBadRequest, response.Code)
+	assert.Equal(t, "application/json", response.Result().Header.Get("Content-Type"))
 
 	expLints := `{"lint_errors":["(9,1) field inproc is invalid when the component type is drop (output)","(11,1) field cache_resources not recognised"]}`
 	assert.Equal(t, expLints, response.Body.String())
@@ -773,6 +775,7 @@ func TestResourceAPILinting(t *testing.T) {
 			response := httptest.NewRecorder()
 			r.ServeHTTP(response, request)
 			assert.Equal(t, http.StatusBadRequest, response.Code)
+			assert.Equal(t, "application/json", response.Result().Header.Get("Content-Type"))
 
 			expLints, err := json.Marshal(struct {
 				LintErrors []string `json:"lint_errors"`


### PR DESCRIPTION
I noticed today that although lint errors return a JSON body and a 400 response code, the `Content-Type` header isn't explicitly set. This causes the http module to assume `text/plain`.

We're using a library that only parses the body as JSON if the content type is properly set, which caused us to trip up when errors were encountered in bloblang syntax.

This adds an explicit `Content-Type` header to any lint error return path, as well as tests for it to be set.

I removed a `sort.Strings()` call as well on one of the four places lint errors were returned. It seemed odd that we didn't do it in all cases, and thinking through it, it is best to leave lint errors in line number order. Doing a sort causes a line 11 error to be sorted before a line 9 error, which isn't intuitive.