### PR TITLE
Add open_message_type flag for websocket input

### DIFF
--- a/internal/component/input/config_websocket.go
+++ b/internal/component/input/config_websocket.go
@@ -5,10 +5,21 @@ import (
 	btls "github.com/benthosdev/benthos/v4/internal/tls"
 )
 
+// OpenMsgType represents the type of the open_message field.
+type OpenMsgType string
+
+const (
+	// OpenMsgTypeBinary sets the type of open_message to binary.
+	OpenMsgTypeBinary OpenMsgType = "binary"
+	// OpenMsgTypeText sets the type of open_message to text (UTF-8 encoded text data).
+	OpenMsgTypeText OpenMsgType = "text"
+)
+
 // WebsocketConfig contains configuration fields for the Websocket input type.
 type WebsocketConfig struct {
-	URL                  string `json:"url" yaml:"url"`
-	OpenMsg              string `json:"open_message" yaml:"open_message"`
+	URL                  string      `json:"url" yaml:"url"`
+	OpenMsg              string      `json:"open_message" yaml:"open_message"`
+	OpenMsgType          OpenMsgType `json:"open_message_type" yaml:"open_message_type"`
 	oldconfig.AuthConfig `json:",inline" yaml:",inline"`
 	TLS                  btls.Config `json:"tls" yaml:"tls"`
 }
@@ -16,9 +27,10 @@ type WebsocketConfig struct {
 // NewWebsocketConfig creates a new WebsocketConfig with default values.
 func NewWebsocketConfig() WebsocketConfig {
 	return WebsocketConfig{
-		URL:        "",
-		OpenMsg:    "",
-		AuthConfig: oldconfig.NewAuthConfig(),
-		TLS:        btls.NewConfig(),
+		URL:         "",
+		OpenMsg:     "",
+		OpenMsgType: OpenMsgTypeBinary,
+		AuthConfig:  oldconfig.NewAuthConfig(),
+		TLS:         btls.NewConfig(),
 	}
 }

--- a/website/docs/components/inputs/websocket.md
+++ b/website/docs/components/inputs/websocket.md
@@ -43,6 +43,7 @@ input:
   websocket:
     url: ""
     open_message: ""
+    open_message_type: text
     tls:
       enabled: false
       skip_cert_verify: false
@@ -96,6 +97,20 @@ An optional message to send to the server upon connection.
 
 Type: `string`  
 Default: `""`  
+
+### `open_message_type`
+
+An optional flag to indicate the data type of open_message.
+
+
+Type: `string`  
+Default: `"text"`  
+
+| Option | Summary |
+|---|---|
+| `binary` | Binary data open_message. |
+| `text` | Text data open_message. The text message payload is interpreted as UTF-8 encoded text data. |
+
 
 ### `tls`
 


### PR DESCRIPTION
According to [the docs](https://pkg.go.dev/github.com/gorilla/websocket?utm_source=godoc#hdr-Data_Messages), the type is recorded in the data frame. It looks like in some cases, it should be set to `TextMessage` instead of `BinaryMessage`. For example this config doesn't work without setting `open_message_type: binary`:

```yaml
input:
  websocket:
    url: "wss://ws.blockchain.info/inv"
    open_message: '{"op":"ping_block"}'
  processors:
    - log:
        message: ${! content() }

output:
  stdout: {}
```