### PR TITLE
Add max_attempts configuration to NSQ. Expose message metadata.

### DIFF
--- a/internal/component/input/config_nsq.go
+++ b/internal/component/input/config_nsq.go
@@ -13,7 +13,7 @@ type NSQConfig struct {
 	UserAgent       string      `json:"user_agent" yaml:"user_agent"`
 	TLS             btls.Config `json:"tls" yaml:"tls"`
 	MaxInFlight     int         `json:"max_in_flight" yaml:"max_in_flight"`
-	MaxAttempts     int         `json:"max_attempts" yaml:"max_attempts"`
+	MaxAttempts     uint16      `json:"max_attempts" yaml:"max_attempts"`
 }
 
 // NewNSQConfig creates a new NSQConfig with default values.

--- a/internal/component/input/config_nsq.go
+++ b/internal/component/input/config_nsq.go
@@ -13,6 +13,7 @@ type NSQConfig struct {
 	UserAgent       string      `json:"user_agent" yaml:"user_agent"`
 	TLS             btls.Config `json:"tls" yaml:"tls"`
 	MaxInFlight     int         `json:"max_in_flight" yaml:"max_in_flight"`
+	MaxAttempts     int         `json:"max_attempts" yaml:"max_attempts"`
 }
 
 // NewNSQConfig creates a new NSQConfig with default values.
@@ -25,5 +26,6 @@ func NewNSQConfig() NSQConfig {
 		UserAgent:       "",
 		TLS:             btls.NewConfig(),
 		MaxInFlight:     100,
+		MaxAttempts:     5,
 	}
 }

--- a/internal/impl/nsq/input.go
+++ b/internal/impl/nsq/input.go
@@ -136,6 +136,7 @@ func (n *nsqReader) Connect(ctx context.Context) (err error) {
 	cfg := nsq.NewConfig()
 	cfg.UserAgent = n.conf.UserAgent
 	cfg.MaxInFlight = n.conf.MaxInFlight
+	cfg.MaxAttempts = n.conf.MaxAttempts
 	if n.tlsConf != nil {
 		cfg.TlsV1 = true
 		cfg.TlsConfig = n.tlsConf

--- a/website/docs/components/inputs/nsq.md
+++ b/website/docs/components/inputs/nsq.md
@@ -36,6 +36,7 @@ input:
     channel: ""
     user_agent: ""
     max_in_flight: 100
+    max_attempts: 5
 ```
 
 </TabItem>
@@ -59,10 +60,25 @@ input:
     channel: ""
     user_agent: ""
     max_in_flight: 100
+    max_attempts: 5
 ```
 
 </TabItem>
 </Tabs>
+
+### Metadata
+
+This input adds the following metadata fields to each message:
+
+``` text
+- nsq_attempts
+- nsq_id
+- nsq_nsqd_address
+- nsq_timestamp
+```
+
+You can access these metadata fields using [function interpolation](/docs/configuration/interpolation#metadata).
+
 
 ## Fields
 
@@ -253,5 +269,13 @@ The maximum number of pending messages to consume at any given time.
 
 Type: `int`  
 Default: `100`  
+
+### `max_attempts`
+
+The maximum number of attempts to successfully consume a messages.
+
+
+Type: `int`  
+Default: `5`  
 
 


### PR DESCRIPTION
Fixes #1611 

* Add `max_attempts` property to `nsq` input. Default to `5`.
* Expose NSQ message metadata as Benthos message metadata:
  * NSQ `ID`: `nsq_id`
  * NSQ Attempts: `nsq_attempts`
  * NSQ Timestamp: `nsq_timestamp`
  * NSQ NSQD Address: `nsq_nsqd_address`