### PR TITLE
Make install take bensos_install_path as a second parameter

### DIFF
--- a/website/static/sh/install
+++ b/website/static/sh/install
@@ -36,7 +36,25 @@ check_tools() {
 install_benthos()
 {
 	trap 'echo -e "Aborted, error $? in command: $BASH_COMMAND"; trap ERR; exit 1' ERR
-	install_path="/usr/local/bin"
+
+  # Process the command line
+	if [[ "$#" -eq 2 ]]; then
+		benthos_tag="v$1"
+		benthos_version="$1"
+    benthos_install_path="$2"
+	elif [[ "$#" -eq 1 ]]; then
+		benthos_tag="v$1"
+		benthos_version=$1
+    benthos_install_path="/usr/local/bin"
+	elif [[ "$#" -eq 0 ]]; then
+		benthos_tag=$(curl -s https://api.github.com/repos/benthosdev/benthos/releases/latest | grep 'tag_name' | cut -d\" -f4)
+		benthos_version=$(echo ${benthos_tag} | cut -c2-)
+    benthos_install_path="/usr/local/bin"
+	else
+		echo "Too many arguments."
+		exit 1
+	fi
+
 	benthos_os="unsupported"
 	benthos_arch="unknown"
 	benthos_arm=""
@@ -45,12 +63,12 @@ install_benthos()
 	check_tools
 
 	if [[ -n "$PREFIX" ]]; then
-		install_path="$PREFIX/bin"
+		benthos_install_path="$PREFIX/bin"
 	fi
 
 	# Fall back to /usr/bin if necessary
-	if [[ ! -d $install_path ]]; then
-		install_path="/usr/bin"
+	if [[ ! -d $benthos_install_path ]]; then
+		benthos_install_path="/usr/bin"
 	fi
 
 	# Not every platform has or needs sudo (https://termux.com/linux.html)
@@ -111,19 +129,6 @@ install_benthos()
 	echo "Downloading Benthos for ${benthos_os}/${benthos_arch}${benthos_arm}..."
 	benthos_file="benthos_${benthos_os}_${benthos_arch}${benthos_arm}${benthos_dl_ext}"
 
-	if [[ "$#" -eq 0 ]]; then
-		# get latest release
-		benthos_tag=$(curl -s https://api.github.com/repos/benthosdev/benthos/releases/latest | grep 'tag_name' | cut -d\" -f4)
-		benthos_version=$(echo ${benthos_tag} | cut -c2-)
-	elif [[ "$#" -gt 1 ]]; then
-		echo "Too many arguments."
-		exit 1
-	elif [ -n $1  ]; then
-		# try to get passed version
-		benthos_tag="v$1"
-		benthos_version=$1
-	fi
-
 	benthos_url="https://github.com/benthosdev/benthos/releases/download/${benthos_tag}/benthos_${benthos_version}_${benthos_os}_${benthos_arch}${benthos_arm}.tar.gz"
 
 	dl="/tmp/$benthos_file"
@@ -137,12 +142,15 @@ install_benthos()
 	esac
 	chmod +x "$PREFIX/tmp/$benthos_bin"
 
-	echo "Putting benthos in $install_path (may require password)"
-	$sudo_cmd mv "$PREFIX/tmp/$benthos_bin" "$install_path/$benthos_bin"
+	echo "Putting benthos in $benthos_install_path (may require password)"
+	$sudo_cmd mv "$PREFIX/tmp/$benthos_bin" "$benthos_install_path/$benthos_bin"
 	$sudo_cmd rm -- "$dl"
 
 	# check installation
-	$benthos_bin -version
+	$benthos_install_path/$benthos_bin -version
+	if ! check_cmd benthos; then
+    echo "Do not forget to add $benthos_install_path to your PATH!"
+	fi
 
 	echo "Successfully installed"
 	trap ERR

--- a/website/static/sh/install
+++ b/website/static/sh/install
@@ -19,142 +19,142 @@ EOF
 }
 
 check_cmd() {
-	command -v "$1" > /dev/null 2>&1
+  command -v "$1" > /dev/null 2>&1
 }
 
 check_tools() {
-	Tools=("curl" "grep" "cut" "tar" "uname" "chmod" "mv" "rm")
+  Tools=("curl" "grep" "cut" "tar" "uname" "chmod" "mv" "rm")
 
-	for tool in ${Tools[*]}; do
-		if ! check_cmd $tool; then
-			echo "Aborted, missing $tool, sorry!"
-			exit 6
-		fi
-	done
+  for tool in ${Tools[*]}; do
+    if ! check_cmd $tool; then
+      echo "Aborted, missing $tool, sorry!"
+      exit 6
+    fi
+  done
 }
 
 install_benthos()
 {
-	trap 'echo -e "Aborted, error $? in command: $BASH_COMMAND"; trap ERR; exit 1' ERR
+  trap 'echo -e "Aborted, error $? in command: $BASH_COMMAND"; trap ERR; exit 1' ERR
 
   # Process the command line
-	if [[ "$#" -eq 2 ]]; then
-		benthos_tag="v$1"
-		benthos_version="$1"
+  if [[ "$#" -eq 2 ]]; then
+    benthos_tag="v$1"
+    benthos_version="$1"
     benthos_install_path="$2"
-	elif [[ "$#" -eq 1 ]]; then
-		benthos_tag="v$1"
-		benthos_version=$1
+  elif [[ "$#" -eq 1 ]]; then
+    benthos_tag="v$1"
+    benthos_version=$1
     benthos_install_path="/usr/local/bin"
-	elif [[ "$#" -eq 0 ]]; then
-		benthos_tag=$(curl -s https://api.github.com/repos/benthosdev/benthos/releases/latest | grep 'tag_name' | cut -d\" -f4)
-		benthos_version=$(echo ${benthos_tag} | cut -c2-)
+  elif [[ "$#" -eq 0 ]]; then
+    benthos_tag=$(curl -s https://api.github.com/repos/benthosdev/benthos/releases/latest | grep 'tag_name' | cut -d\" -f4)
+    benthos_version=$(echo ${benthos_tag} | cut -c2-)
     benthos_install_path="/usr/local/bin"
-	else
-		echo "Too many arguments."
-		exit 1
-	fi
+  else
+    echo "Too many arguments."
+    exit 1
+  fi
 
-	benthos_os="unsupported"
-	benthos_arch="unknown"
-	benthos_arm=""
+  benthos_os="unsupported"
+  benthos_arch="unknown"
+  benthos_arm=""
 
-	header
-	check_tools
+  header
+  check_tools
 
-	if [[ -n "$PREFIX" ]]; then
-		benthos_install_path="$PREFIX/bin"
-	fi
+  if [[ -n "$PREFIX" ]]; then
+    benthos_install_path="$PREFIX/bin"
+  fi
 
-	# Fall back to /usr/bin if necessary
-	if [[ ! -d $benthos_install_path ]]; then
-		benthos_install_path="/usr/bin"
-	fi
+  # Fall back to /usr/bin if necessary
+  if [[ ! -d $benthos_install_path ]]; then
+    benthos_install_path="/usr/bin"
+  fi
 
-	# Not every platform has or needs sudo (https://termux.com/linux.html)
-	((EUID)) && sudo_cmd="sudo"
+  # Not every platform has or needs sudo (https://termux.com/linux.html)
+  ((EUID)) && sudo_cmd="sudo"
 
-	#########################
-	# Which OS and version? #
-	#########################
+  #########################
+  # Which OS and version? #
+  #########################
 
-	benthos_bin="benthos"
-	benthos_dl_ext=".tar.gz"
+  benthos_bin="benthos"
+  benthos_dl_ext=".tar.gz"
 
-	# NOTE: `uname -m` is more accurate and universal than `arch`
-	# See https://en.wikipedia.org/wiki/Uname
-	unamem="$(uname -m)"
-	if [[ $unamem == *aarch64* ]]; then
-		benthos_arch="arm64"
-	elif [[ $unamem == *64* ]]; then
-		benthos_arch="amd64"
-	elif [[ $unamem == *armv5* ]]; then
-		benthos_arch="arm"
-		benthos_arm="v5"
-	elif [[ $unamem == *armv6l* ]]; then
-		benthos_arch="arm"
-		benthos_arm="v6"
-	elif [[ $unamem == *armv7l* ]]; then
-		benthos_arch="arm"
-		benthos_arm="v7"
-	else
-		echo "Aborted, unsupported or unknown architecture: $unamem"
-		return 2
-	fi
+  # NOTE: `uname -m` is more accurate and universal than `arch`
+  # See https://en.wikipedia.org/wiki/Uname
+  unamem="$(uname -m)"
+  if [[ $unamem == *aarch64* ]]; then
+    benthos_arch="arm64"
+  elif [[ $unamem == *64* ]]; then
+    benthos_arch="amd64"
+  elif [[ $unamem == *armv5* ]]; then
+    benthos_arch="arm"
+    benthos_arm="v5"
+  elif [[ $unamem == *armv6l* ]]; then
+    benthos_arch="arm"
+    benthos_arm="v6"
+  elif [[ $unamem == *armv7l* ]]; then
+    benthos_arch="arm"
+    benthos_arm="v7"
+  else
+    echo "Aborted, unsupported or unknown architecture: $unamem"
+    return 2
+  fi
 
-	unameu="$(tr '[:lower:]' '[:upper:]' <<<$(uname))"
-	if [[ $unameu == *DARWIN* ]]; then
-		benthos_os="darwin"
-		version=${vers##*ProductVersion:}
-	elif [[ $unameu == *LINUX* ]]; then
-		benthos_os="linux"
-	elif [[ $unameu == *FREEBSD* ]]; then
-		benthos_os="freebsd"
-	elif [[ $unameu == *OPENBSD* ]]; then
-		benthos_os="openbsd"
-	elif [[ $unameu == *WIN* || $unameu == MSYS* ]]; then
-		# Should catch cygwin
-		sudo_cmd=""
-		benthos_os="windows"
-		benthos_bin=$benthos_bin.exe
-	else
-		echo "Aborted, unsupported or unknown os: $uname"
-		return 6
-	fi
+  unameu="$(tr '[:lower:]' '[:upper:]' <<<$(uname))"
+  if [[ $unameu == *DARWIN* ]]; then
+    benthos_os="darwin"
+    version=${vers##*ProductVersion:}
+  elif [[ $unameu == *LINUX* ]]; then
+    benthos_os="linux"
+  elif [[ $unameu == *FREEBSD* ]]; then
+    benthos_os="freebsd"
+  elif [[ $unameu == *OPENBSD* ]]; then
+    benthos_os="openbsd"
+  elif [[ $unameu == *WIN* || $unameu == MSYS* ]]; then
+    # Should catch cygwin
+    sudo_cmd=""
+    benthos_os="windows"
+    benthos_bin=$benthos_bin.exe
+  else
+    echo "Aborted, unsupported or unknown os: $uname"
+    return 6
+  fi
 
-	########################
-	# Download and extract #
-	########################
+  ########################
+  # Download and extract #
+  ########################
 
-	echo "Downloading Benthos for ${benthos_os}/${benthos_arch}${benthos_arm}..."
-	benthos_file="benthos_${benthos_os}_${benthos_arch}${benthos_arm}${benthos_dl_ext}"
+  echo "Downloading Benthos for ${benthos_os}/${benthos_arch}${benthos_arm}..."
+  benthos_file="benthos_${benthos_os}_${benthos_arch}${benthos_arm}${benthos_dl_ext}"
 
-	benthos_url="https://github.com/benthosdev/benthos/releases/download/${benthos_tag}/benthos_${benthos_version}_${benthos_os}_${benthos_arch}${benthos_arm}.tar.gz"
+  benthos_url="https://github.com/benthosdev/benthos/releases/download/${benthos_tag}/benthos_${benthos_version}_${benthos_os}_${benthos_arch}${benthos_arm}.tar.gz"
 
-	dl="/tmp/$benthos_file"
-	rm -rf -- "$dl"
+  dl="/tmp/$benthos_file"
+  rm -rf -- "$dl"
 
-	curl -fsSL "$benthos_url" -o "$dl"
+  curl -fsSL "$benthos_url" -o "$dl"
 
-	echo "Extracting..."
-	case "$benthos_file" in
-		*.tar.gz) tar -xzf "$dl" -C "$PREFIX/tmp/" "$benthos_bin" ;;
-	esac
-	chmod +x "$PREFIX/tmp/$benthos_bin"
+  echo "Extracting..."
+  case "$benthos_file" in
+    *.tar.gz) tar -xzf "$dl" -C "$PREFIX/tmp/" "$benthos_bin" ;;
+  esac
+  chmod +x "$PREFIX/tmp/$benthos_bin"
 
-	echo "Putting benthos in $benthos_install_path (may require password)"
-	$sudo_cmd mv "$PREFIX/tmp/$benthos_bin" "$benthos_install_path/$benthos_bin"
-	$sudo_cmd rm -- "$dl"
+  echo "Putting benthos in $benthos_install_path (may require password)"
+  $sudo_cmd mv "$PREFIX/tmp/$benthos_bin" "$benthos_install_path/$benthos_bin"
+  $sudo_cmd rm -- "$dl"
 
-	# check installation
-	$benthos_install_path/$benthos_bin -version
-	if ! check_cmd benthos; then
+  # check installation
+  $benthos_install_path/$benthos_bin -version
+  if ! check_cmd benthos; then
     echo "Do not forget to add $benthos_install_path to your PATH!"
-	fi
+  fi
 
-	echo "Successfully installed"
-	trap ERR
-	return 0
+  echo "Successfully installed"
+  trap ERR
+  return 0
 }
 
 install_benthos $@

--- a/website/static/sh/install
+++ b/website/static/sh/install
@@ -8,7 +8,7 @@
 [[ $- = *i* ]] && echo "Don't source this script!" && return 10
 
 header() {
-    cat 1>&2 <<EOF
+		cat 1>&2 <<EOF
 Benthos Installer
 
 Website: https://www.benthos.dev
@@ -19,142 +19,142 @@ EOF
 }
 
 check_cmd() {
-  command -v "$1" > /dev/null 2>&1
+	command -v "$1" > /dev/null 2>&1
 }
 
 check_tools() {
-  Tools=("curl" "grep" "cut" "tar" "uname" "chmod" "mv" "rm")
+	Tools=("curl" "grep" "cut" "tar" "uname" "chmod" "mv" "rm")
 
-  for tool in ${Tools[*]}; do
-    if ! check_cmd $tool; then
-      echo "Aborted, missing $tool, sorry!"
-      exit 6
-    fi
-  done
+	for tool in ${Tools[*]}; do
+		if ! check_cmd $tool; then
+			echo "Aborted, missing $tool, sorry!"
+			exit 6
+		fi
+	done
 }
 
 install_benthos()
 {
-  trap 'echo -e "Aborted, error $? in command: $BASH_COMMAND"; trap ERR; exit 1' ERR
+	trap 'echo -e "Aborted, error $? in command: $BASH_COMMAND"; trap ERR; exit 1' ERR
 
-  # Process the command line
-  if [[ "$#" -eq 2 ]]; then
-    benthos_tag="v$1"
-    benthos_version="$1"
-    benthos_install_path="$2"
-  elif [[ "$#" -eq 1 ]]; then
-    benthos_tag="v$1"
-    benthos_version=$1
-    benthos_install_path="/usr/local/bin"
-  elif [[ "$#" -eq 0 ]]; then
-    benthos_tag=$(curl -s https://api.github.com/repos/benthosdev/benthos/releases/latest | grep 'tag_name' | cut -d\" -f4)
-    benthos_version=$(echo ${benthos_tag} | cut -c2-)
-    benthos_install_path="/usr/local/bin"
-  else
-    echo "Too many arguments."
-    exit 1
-  fi
+	# Process the command line
+	if [[ "$#" -eq 2 ]]; then
+		benthos_tag="v$1"
+		benthos_version="$1"
+		benthos_install_path="$2"
+	elif [[ "$#" -eq 1 ]]; then
+		benthos_tag="v$1"
+		benthos_version=$1
+		benthos_install_path="/usr/local/bin"
+	elif [[ "$#" -eq 0 ]]; then
+		benthos_tag=$(curl -s https://api.github.com/repos/benthosdev/benthos/releases/latest | grep 'tag_name' | cut -d\" -f4)
+		benthos_version=$(echo ${benthos_tag} | cut -c2-)
+		benthos_install_path="/usr/local/bin"
+	else
+		echo "Too many arguments."
+		exit 1
+	fi
 
-  benthos_os="unsupported"
-  benthos_arch="unknown"
-  benthos_arm=""
+	benthos_os="unsupported"
+	benthos_arch="unknown"
+	benthos_arm=""
 
-  header
-  check_tools
+	header
+	check_tools
 
-  if [[ -n "$PREFIX" ]]; then
-    benthos_install_path="$PREFIX/bin"
-  fi
+	if [[ -n "$PREFIX" ]]; then
+		benthos_install_path="$PREFIX/bin"
+	fi
 
-  # Fall back to /usr/bin if necessary
-  if [[ ! -d $benthos_install_path ]]; then
-    benthos_install_path="/usr/bin"
-  fi
+	# Fall back to /usr/bin if necessary
+	if [[ ! -d $benthos_install_path ]]; then
+		benthos_install_path="/usr/bin"
+	fi
 
-  # Not every platform has or needs sudo (https://termux.com/linux.html)
-  ((EUID)) && sudo_cmd="sudo"
+	# Not every platform has or needs sudo (https://termux.com/linux.html)
+	((EUID)) && sudo_cmd="sudo"
 
-  #########################
-  # Which OS and version? #
-  #########################
+	#########################
+	# Which OS and version? #
+	#########################
 
-  benthos_bin="benthos"
-  benthos_dl_ext=".tar.gz"
+	benthos_bin="benthos"
+	benthos_dl_ext=".tar.gz"
 
-  # NOTE: `uname -m` is more accurate and universal than `arch`
-  # See https://en.wikipedia.org/wiki/Uname
-  unamem="$(uname -m)"
-  if [[ $unamem == *aarch64* ]]; then
-    benthos_arch="arm64"
-  elif [[ $unamem == *64* ]]; then
-    benthos_arch="amd64"
-  elif [[ $unamem == *armv5* ]]; then
-    benthos_arch="arm"
-    benthos_arm="v5"
-  elif [[ $unamem == *armv6l* ]]; then
-    benthos_arch="arm"
-    benthos_arm="v6"
-  elif [[ $unamem == *armv7l* ]]; then
-    benthos_arch="arm"
-    benthos_arm="v7"
-  else
-    echo "Aborted, unsupported or unknown architecture: $unamem"
-    return 2
-  fi
+	# NOTE: `uname -m` is more accurate and universal than `arch`
+	# See https://en.wikipedia.org/wiki/Uname
+	unamem="$(uname -m)"
+	if [[ $unamem == *aarch64* ]]; then
+		benthos_arch="arm64"
+	elif [[ $unamem == *64* ]]; then
+		benthos_arch="amd64"
+	elif [[ $unamem == *armv5* ]]; then
+		benthos_arch="arm"
+		benthos_arm="v5"
+	elif [[ $unamem == *armv6l* ]]; then
+		benthos_arch="arm"
+		benthos_arm="v6"
+	elif [[ $unamem == *armv7l* ]]; then
+		benthos_arch="arm"
+		benthos_arm="v7"
+	else
+		echo "Aborted, unsupported or unknown architecture: $unamem"
+		return 2
+	fi
 
-  unameu="$(tr '[:lower:]' '[:upper:]' <<<$(uname))"
-  if [[ $unameu == *DARWIN* ]]; then
-    benthos_os="darwin"
-    version=${vers##*ProductVersion:}
-  elif [[ $unameu == *LINUX* ]]; then
-    benthos_os="linux"
-  elif [[ $unameu == *FREEBSD* ]]; then
-    benthos_os="freebsd"
-  elif [[ $unameu == *OPENBSD* ]]; then
-    benthos_os="openbsd"
-  elif [[ $unameu == *WIN* || $unameu == MSYS* ]]; then
-    # Should catch cygwin
-    sudo_cmd=""
-    benthos_os="windows"
-    benthos_bin=$benthos_bin.exe
-  else
-    echo "Aborted, unsupported or unknown os: $uname"
-    return 6
-  fi
+	unameu="$(tr '[:lower:]' '[:upper:]' <<<$(uname))"
+	if [[ $unameu == *DARWIN* ]]; then
+		benthos_os="darwin"
+		version=${vers##*ProductVersion:}
+	elif [[ $unameu == *LINUX* ]]; then
+		benthos_os="linux"
+	elif [[ $unameu == *FREEBSD* ]]; then
+		benthos_os="freebsd"
+	elif [[ $unameu == *OPENBSD* ]]; then
+		benthos_os="openbsd"
+	elif [[ $unameu == *WIN* || $unameu == MSYS* ]]; then
+		# Should catch cygwin
+		sudo_cmd=""
+		benthos_os="windows"
+		benthos_bin=$benthos_bin.exe
+	else
+		echo "Aborted, unsupported or unknown os: $uname"
+		return 6
+	fi
 
-  ########################
-  # Download and extract #
-  ########################
+	########################
+	# Download and extract #
+	########################
 
-  echo "Downloading Benthos for ${benthos_os}/${benthos_arch}${benthos_arm}..."
-  benthos_file="benthos_${benthos_os}_${benthos_arch}${benthos_arm}${benthos_dl_ext}"
+	echo "Downloading Benthos for ${benthos_os}/${benthos_arch}${benthos_arm}..."
+	benthos_file="benthos_${benthos_os}_${benthos_arch}${benthos_arm}${benthos_dl_ext}"
 
-  benthos_url="https://github.com/benthosdev/benthos/releases/download/${benthos_tag}/benthos_${benthos_version}_${benthos_os}_${benthos_arch}${benthos_arm}.tar.gz"
+	benthos_url="https://github.com/benthosdev/benthos/releases/download/${benthos_tag}/benthos_${benthos_version}_${benthos_os}_${benthos_arch}${benthos_arm}.tar.gz"
 
-  dl="/tmp/$benthos_file"
-  rm -rf -- "$dl"
+	dl="/tmp/$benthos_file"
+	rm -rf -- "$dl"
 
-  curl -fsSL "$benthos_url" -o "$dl"
+	curl -fsSL "$benthos_url" -o "$dl"
 
-  echo "Extracting..."
-  case "$benthos_file" in
-    *.tar.gz) tar -xzf "$dl" -C "$PREFIX/tmp/" "$benthos_bin" ;;
-  esac
-  chmod +x "$PREFIX/tmp/$benthos_bin"
+	echo "Extracting..."
+	case "$benthos_file" in
+		*.tar.gz) tar -xzf "$dl" -C "$PREFIX/tmp/" "$benthos_bin" ;;
+	esac
+	chmod +x "$PREFIX/tmp/$benthos_bin"
 
-  echo "Putting benthos in $benthos_install_path (may require password)"
-  $sudo_cmd mv "$PREFIX/tmp/$benthos_bin" "$benthos_install_path/$benthos_bin"
-  $sudo_cmd rm -- "$dl"
+	echo "Putting benthos in $benthos_install_path (may require password)"
+	$sudo_cmd mv "$PREFIX/tmp/$benthos_bin" "$benthos_install_path/$benthos_bin"
+	$sudo_cmd rm -- "$dl"
 
-  # check installation
-  $benthos_install_path/$benthos_bin -version
-  if ! check_cmd benthos; then
-    echo "Do not forget to add $benthos_install_path to your PATH!"
-  fi
+	# check installation
+	$benthos_install_path/$benthos_bin -version
+	if ! check_cmd benthos; then
+		echo "Do not forget to add $benthos_install_path to your PATH!"
+	fi
 
-  echo "Successfully installed"
-  trap ERR
-  return 0
+	echo "Successfully installed"
+	trap ERR
+	return 0
 }
 
 install_benthos $@


### PR DESCRIPTION
We are currently working to add `asdf` as an additional way to install `benthos` (because this gives us an elegant way to have multiple versions of benthos installed at the same time). #1568

The implementation is [here](https://github.com/benthosdev/benthos-asdf/pull/1).

This PR suggests a small backward compatible change/enhancement so that `install` can be used to implement the `asdf` plugin.

The change is to add the ability to also pass the `install_path` as an optional second parameter.

