### PR TITLE
Allow FS to be swapped by service users

### DIFF
--- a/internal/manager/type.go
+++ b/internal/manager/type.go
@@ -158,6 +158,14 @@ func OptSetStreamsMode(b bool) OptFunc {
 	}
 }
 
+// OptSetFS determines which ifs.FS implementation to use for its filesystem.
+// This can be used to override the default os based filesystem implementation.
+func OptSetFS(fs ifs.FS) OptFunc {
+	return func(t *Type) {
+		t.fs = fs
+	}
+}
+
 // New returns an instance of manager.Type, which can be shared amongst
 // components and logical threads of a Benthos service.
 func New(conf ResourceConfig, opts ...OptFunc) (*Type, error) {

--- a/public/service/environment.go
+++ b/public/service/environment.go
@@ -21,6 +21,7 @@ import (
 	"github.com/benthosdev/benthos/v4/internal/component/tracer"
 	"github.com/benthosdev/benthos/v4/internal/config"
 	"github.com/benthosdev/benthos/v4/internal/docs"
+	"github.com/benthosdev/benthos/v4/internal/filepath/ifs"
 	"github.com/benthosdev/benthos/v4/public/bloblang"
 )
 
@@ -32,11 +33,13 @@ import (
 type Environment struct {
 	internal    *bundle.Environment
 	bloblangEnv *bloblang.Environment
+	fs          ifs.FS
 }
 
 var globalEnvironment = &Environment{
 	internal:    bundle.GlobalEnvironment,
 	bloblangEnv: bloblang.GlobalEnvironment(),
+	fs:          ifs.OS(),
 }
 
 // GlobalEnvironment returns a reference to the global environment, adding
@@ -58,6 +61,7 @@ func (e *Environment) Clone() *Environment {
 	return &Environment{
 		internal:    e.internal.Clone(),
 		bloblangEnv: e.bloblangEnv.WithoutFunctions().WithoutMethods(),
+		fs:          e.fs,
 	}
 }
 
@@ -65,6 +69,12 @@ func (e *Environment) Clone() *Environment {
 // components constructed with it to a specific Bloblang environment.
 func (e *Environment) UseBloblangEnvironment(bEnv *bloblang.Environment) {
 	e.bloblangEnv = bEnv
+}
+
+// UseFS configures the service environment to use an implementation of ifs.FS
+// as its filesystem.
+func (e *Environment) UseFS(fs ifs.FS) {
+	e.fs = fs
 }
 
 // NewStreamBuilder creates a new StreamBuilder upon the defined environment,

--- a/public/service/environment.go
+++ b/public/service/environment.go
@@ -33,7 +33,7 @@ import (
 type Environment struct {
 	internal    *bundle.Environment
 	bloblangEnv *bloblang.Environment
-	fs          ifs.FS
+	fs          FS
 }
 
 var globalEnvironment = &Environment{
@@ -73,7 +73,7 @@ func (e *Environment) UseBloblangEnvironment(bEnv *bloblang.Environment) {
 
 // UseFS configures the service environment to use an implementation of ifs.FS
 // as its filesystem.
-func (e *Environment) UseFS(fs ifs.FS) {
+func (e *Environment) UseFS(fs FS) {
 	e.fs = fs
 }
 

--- a/public/service/environment.go
+++ b/public/service/environment.go
@@ -33,7 +33,7 @@ import (
 type Environment struct {
 	internal    *bundle.Environment
 	bloblangEnv *bloblang.Environment
-	fs          FS
+	fs          ifs.FS
 }
 
 var globalEnvironment = &Environment{
@@ -73,7 +73,7 @@ func (e *Environment) UseBloblangEnvironment(bEnv *bloblang.Environment) {
 
 // UseFS configures the service environment to use an implementation of ifs.FS
 // as its filesystem.
-func (e *Environment) UseFS(fs FS) {
+func (e *Environment) UseFS(fs *FS) {
 	e.fs = fs
 }
 

--- a/public/service/environment_test.go
+++ b/public/service/environment_test.go
@@ -188,11 +188,11 @@ func TestEnvironmentUseFS(t *testing.T) {
 	outFilePath := filepath.Join(tmpDir, "out.txt")
 
 	env := service.NewEnvironment()
-	env.UseFS(testFS{ifs.OS(), fstest.MapFS{
+	env.UseFS(service.NewFS(testFS{ifs.OS(), fstest.MapFS{
 		"hello.txt": {
 			Data: []byte("hello\nworld"),
 		},
-	}})
+	}}))
 
 	b := env.NewStreamBuilder()
 

--- a/public/service/resources.go
+++ b/public/service/resources.go
@@ -84,7 +84,7 @@ func (r *Resources) OtelTracer() trace.TracerProvider {
 	return r.mgr.Tracer()
 }
 
-// IFS is a superset of fs.FS that includes goodies that benthos components
+// FS is a superset of fs.FS that includes goodies that benthos components
 // specifically need.
 type FS interface {
 	Open(name string) (fs.File, error)

--- a/public/service/resources.go
+++ b/public/service/resources.go
@@ -84,17 +84,82 @@ func (r *Resources) OtelTracer() trace.TracerProvider {
 	return r.mgr.Tracer()
 }
 
-// FS is a superset of fs.FS that includes goodies that benthos components
-// specifically need.
-type FS interface {
-	Open(name string) (fs.File, error)
-	OpenFile(name string, flag int, perm fs.FileMode) (fs.File, error)
-	Stat(name string) (fs.FileInfo, error)
-	Remove(name string) error
-	MkdirAll(path string, perm fs.FileMode) error
+// wrapperFS provides extra methods support around a bare fs.FS that does
+// fully implement ifs.FS, this allows us to keep some clean interfaces while
+// also ensuring backward compatibility.
+type wrapperFS struct {
+	fs       fs.FS
+	fallback ifs.FS
 }
 
-// FS returns an FS implementation that provides isolation or customised
+// Open opens the named file for reading.
+func (f *wrapperFS) Open(name string) (fs.File, error) {
+	return f.fs.Open(name)
+}
+
+// OpenFile is the generalized open call.
+func (f *wrapperFS) OpenFile(name string, flag int, perm fs.FileMode) (fs.File, error) {
+	return f.fallback.OpenFile(name, flag, perm)
+}
+
+// Stat returns a FileInfo describing the named file.
+func (f *wrapperFS) Stat(name string) (fs.FileInfo, error) {
+	return f.fallback.Stat(name)
+}
+
+// Remove removes the named file or (empty) directory.
+func (f *wrapperFS) Remove(name string) error {
+	return f.fallback.Remove(name)
+}
+
+// MkdirAll creates a directory named path, along with any necessary parents,
+// and returns nil, or else returns an error.
+func (f *wrapperFS) MkdirAll(path string, perm fs.FileMode) error {
+	return f.fallback.MkdirAll(path, perm)
+}
+
+// FS implements a superset of fs.FS and includes goodies that benthos
+// components specifically need.
+type FS struct {
+	i ifs.FS
+}
+
+// NewFS provides a new instance of a filesystem. The fs.FS passed in can
+// optionally implement methods from benthos ifs.FS
+func NewFS(filesystem fs.FS) *FS {
+	if fsimpl, ok := filesystem.(ifs.FS); ok {
+		return &FS{fsimpl}
+	}
+	return &FS{&wrapperFS{filesystem, ifs.OS()}}
+}
+
+// Open opens the named file for reading.
+func (f *FS) Open(name string) (fs.File, error) {
+	return f.i.Open(name)
+}
+
+// OpenFile is the generalized open call.
+func (f *FS) OpenFile(name string, flag int, perm fs.FileMode) (fs.File, error) {
+	return f.i.OpenFile(name, flag, perm)
+}
+
+// Stat returns a FileInfo describing the named file.
+func (f *FS) Stat(name string) (fs.FileInfo, error) {
+	return f.i.Stat(name)
+}
+
+// Remove removes the named file or (empty) directory.
+func (f *FS) Remove(name string) error {
+	return f.i.Remove(name)
+}
+
+// MkdirAll creates a directory named path, along with any necessary parents,
+// and returns nil, or else returns an error.
+func (f *FS) MkdirAll(path string, perm fs.FileMode) error {
+	return f.i.MkdirAll(path, perm)
+}
+
+// FS returns an fs.FS implementation that provides isolation or customised
 // behaviour for components that access the filesystem. For example, this might
 // be used to tally files being accessed by components for observability
 // purposes, or to customise where relative paths are resolved from.
@@ -102,11 +167,11 @@ type FS interface {
 // Components should use this instead of accessing the os directly. However, the
 // default behaviour of an environment FS is to access the OS from the directory
 // the process is running from, which matches calling the os package directly.
-func (r *Resources) FS() FS {
+func (r *Resources) FS() *FS {
 	if r == nil || r.mgr == nil {
-		return ifs.OS()
+		return &FS{i: ifs.OS()}
 	}
-	return r.mgr.FS()
+	return &FS{i: r.mgr.FS()}
 }
 
 // AccessCache attempts to access a cache resource by name. This action can

--- a/public/service/stream_builder.go
+++ b/public/service/stream_builder.go
@@ -834,6 +834,7 @@ func (s *StreamBuilder) buildWithEnv(env *bundle.Environment) (*Stream, error) {
 		manager.OptSetTracer(tracer),
 		manager.OptSetEnvironment(env),
 		manager.OptSetBloblangEnvironment(s.env.getBloblangParserEnv()),
+		manager.OptSetFS(s.env.fs),
 	)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
There are use cases where I'd like to override the underlying ifs.FS for a particular stream/environment. Mainly to be able to source credentials from memory rather than store it on disk (think keystores etc).

I know not all components use `FS()` (I think I need to fix that in our NATS components), but this should hopefully be a start.
