### PR TITLE
add opt 'dump_request_log' on http_client (i/o) and http (processor)

### DIFF
--- a/internal/httpclient/client.go
+++ b/internal/httpclient/client.go
@@ -77,6 +77,11 @@ func NewClientFromOldConfig(conf oldconfig.OldConfig, mgr bundle.NewManagement, 
 	h.clientCtx, h.clientCancel = context.WithCancel(context.Background())
 	h.client = conf.OAuth2.Client(h.clientCtx)
 
+	h.client.Transport, err = newRequestLog(h.client.Transport, h.log, conf.DumpRequestLog)
+	if err != nil {
+		return nil, fmt.Errorf("failed to config logger for request dump: %v", err)
+	}
+
 	if tout := conf.Timeout; len(tout) > 0 {
 		var err error
 		if h.client.Timeout, err = time.ParseDuration(tout); err != nil {

--- a/internal/httpclient/config.go
+++ b/internal/httpclient/config.go
@@ -19,6 +19,11 @@ func OldFieldSpec(forOutput bool, extraChildren ...docs.FieldSpec) docs.FieldSpe
 		}).IsInterpolated().Map().HasDefault(map[string]any{}),
 		docs.FieldObject("metadata", "Specify optional matching rules to determine which metadata keys should be added to the HTTP request as headers.").Advanced().
 			WithChildren(metadata.IncludeFilterDocs()...),
+		docs.FieldObject("dump_request_log", "Dump the request and response payload in stdout as logger").WithChildren(
+			docs.FieldBool("enable", "Whether to print dump request log or not.", true).HasDefault(false),
+			docs.FieldString("level", "At what level this request-response log will be printed.", "TRACE").HasOptions("TRACE", "DEBUG", "INFO", "WARN", "ERROR", "FATAL").HasDefault("TRACE"),
+			docs.FieldString("message", "Message printed to the logger.", "request log to service xxx").HasDefault("http request log"),
+		).Advanced(),
 	}
 
 	extractHeadersDesc := "Specify which response headers should be added to resulting messages as metadata. Header keys are lowercased before matching, so ensure that your patterns target lowercased versions of the header keys that you expect."

--- a/internal/httpclient/logger.go
+++ b/internal/httpclient/logger.go
@@ -66,7 +66,11 @@ func (r *RoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 		_, reqBodyErr = io.Copy(reqBodyBuf, req.Body)
 		if reqBodyErr != nil {
 			errCum = multierr.Append(errCum, fmt.Errorf("error copy request body: %w", reqBodyErr))
-			reqBodyBuf = bytes.NewBufferString("")
+			reqBodyBuf = &bytes.Buffer{}
+		}
+
+		if _err := req.Body.Close(); _err != nil {
+			errCum = multierr.Append(errCum, fmt.Errorf("error closing request body: %w", _err))
 		}
 
 		req.Body = io.NopCloser(reqBodyBuf)
@@ -93,7 +97,11 @@ func (r *RoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 		_, respErrBody = io.Copy(respBodyBuf, respOriginal.Body)
 		if respErrBody != nil {
 			errCum = multierr.Append(errCum, fmt.Errorf("error copy response body: %w", respErrBody))
-			respBodyBuf = bytes.NewBufferString("")
+			respBodyBuf = &bytes.Buffer{}
+		}
+
+		if _err := respOriginal.Body.Close(); _err != nil {
+			errCum = multierr.Append(errCum, fmt.Errorf("error closing response body: %w", _err))
 		}
 
 		respOriginal.Body = io.NopCloser(respBodyBuf)

--- a/internal/httpclient/logger.go
+++ b/internal/httpclient/logger.go
@@ -18,12 +18,12 @@ import (
 type RoundTripper struct {
 	Base   http.RoundTripper
 	Logger log.Modular
-	Config oldconfig.DumpRequestLog
+	Config oldconfig.DumpRequestLogConfig
 }
 
 var _ http.RoundTripper = (*RoundTripper)(nil)
 
-func newRequestLog(base http.RoundTripper, logger log.Modular, cfg oldconfig.DumpRequestLog) (http.RoundTripper, error) {
+func newRequestLog(base http.RoundTripper, logger log.Modular, cfg oldconfig.DumpRequestLogConfig) (http.RoundTripper, error) {
 	if base == nil {
 		base = http.DefaultTransport
 	}

--- a/internal/httpclient/logger.go
+++ b/internal/httpclient/logger.go
@@ -15,13 +15,13 @@ import (
 	"go.uber.org/multierr"
 )
 
-type RoundTripper struct {
+type roundTripper struct {
 	Base   http.RoundTripper
 	Logger log.Modular
 	Config oldconfig.DumpRequestLogConfig
 }
 
-var _ http.RoundTripper = (*RoundTripper)(nil)
+var _ http.RoundTripper = (*roundTripper)(nil)
 
 func newRequestLog(base http.RoundTripper, logger log.Modular, cfg oldconfig.DumpRequestLogConfig) (http.RoundTripper, error) {
 	if base == nil {
@@ -41,14 +41,14 @@ func newRequestLog(base http.RoundTripper, logger log.Modular, cfg oldconfig.Dum
 		cfg.Level = "TRACE"
 	}
 
-	return &RoundTripper{
+	return &roundTripper{
 		Base:   base,
 		Logger: logger,
 		Config: cfg,
 	}, nil
 }
 
-func (r *RoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+func (r *roundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	t0 := time.Now()
 
 	var (

--- a/internal/httpclient/logger.go
+++ b/internal/httpclient/logger.go
@@ -1,0 +1,168 @@
+package httpclient
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/benthosdev/benthos/v4/internal/httpclient/oldconfig"
+	"github.com/benthosdev/benthos/v4/internal/log"
+
+	"go.uber.org/multierr"
+)
+
+type RoundTripper struct {
+	Base   http.RoundTripper
+	Logger log.Modular
+	Config oldconfig.DumpRequestLog
+}
+
+var _ http.RoundTripper = (*RoundTripper)(nil)
+
+func newRequestLog(base http.RoundTripper, logger log.Modular, cfg oldconfig.DumpRequestLog) (http.RoundTripper, error) {
+	if base == nil {
+		base = http.DefaultTransport
+	}
+
+	if !cfg.Enable {
+		return base, nil
+	}
+
+	if logger == nil {
+		return nil, fmt.Errorf("logger on dump_request_log is not configured")
+	}
+
+	cfg.Level = strings.TrimSpace(cfg.Level)
+	if cfg.Level == "" {
+		cfg.Level = "TRACE"
+	}
+
+	return &RoundTripper{
+		Base:   base,
+		Logger: logger,
+		Config: cfg,
+	}, nil
+}
+
+func (r *RoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	t0 := time.Now()
+
+	var (
+		respOriginal *http.Response // final response
+		errCum       error          // final error
+	)
+
+	var (
+		reqBodyCaptured interface{}
+		reqBody         []byte
+		reqBodyErr      error
+	)
+
+	if req != nil && req.Body != nil {
+		reqBody, reqBodyErr = io.ReadAll(req.Body)
+		if reqBodyErr != nil {
+			errCum = multierr.Append(errCum, fmt.Errorf("error read request body: %w", reqBodyErr))
+			reqBody = []byte{}
+		}
+
+		req.Body = io.NopCloser(bytes.NewReader(reqBody))
+	}
+
+	if _err := json.Unmarshal(reqBody, &reqBodyCaptured); _err != nil && len(reqBody) > 0 {
+		reqBodyCaptured = string(reqBody)
+	}
+
+	var roundTripErr error
+	respOriginal, roundTripErr = r.Base.RoundTrip(req)
+	if roundTripErr != nil {
+		errCum = multierr.Append(errCum, fmt.Errorf("error doing actual request: %w", roundTripErr))
+	}
+
+	var (
+		respBodyCaptured interface{}
+		respBody         []byte
+		respErrBody      error
+	)
+
+	if respOriginal != nil && respOriginal.Body != nil {
+		respBody, respErrBody = io.ReadAll(respOriginal.Body)
+		if respErrBody != nil {
+			errCum = multierr.Append(errCum, fmt.Errorf("error read response body: %w", respErrBody))
+			respBody = []byte{}
+		}
+
+		respOriginal.Body = io.NopCloser(bytes.NewBuffer(respBody))
+	}
+
+	if _err := json.Unmarshal(respBody, &respBodyCaptured); _err != nil && len(respBody) > 0 {
+		respBodyCaptured = string(respBody)
+	}
+
+	// log outgoing request as simple map
+	accessLog := map[string]any{
+		"elapsed_ns": time.Since(t0).Nanoseconds(),
+	}
+
+	// append to map only when the http.Request is not nil
+	if req != nil {
+		accessLog["request"] = map[string]any{
+			"url":    req.URL.Redacted(),
+			"method": req.Method,
+			"header": toSimpleMap(req.Header),
+			"body":   reqBodyCaptured,
+		}
+	}
+
+	// append to map only when the http.Response is not nil
+	if respOriginal != nil {
+		accessLog["response"] = map[string]any{
+			"status_code":    respOriginal.StatusCode,
+			"content_length": respOriginal.ContentLength,
+			"header":         toSimpleMap(respOriginal.Header),
+			"body":           respBodyCaptured,
+		}
+	}
+
+	// append error if any
+	if errCum != nil {
+		accessLog["error"] = errCum.Error()
+	}
+
+	logger := r.Logger.With("access_log", accessLog)
+
+	msg := strings.TrimSpace(r.Config.Message)
+	if msg == "" {
+		msg = "http request log"
+	}
+
+	level := strings.ToUpper(r.Config.Level)
+	switch level {
+	case "TRACE":
+		logger.Traceln(msg)
+	case "DEBUG":
+		logger.Debugln(msg)
+	case "INFO":
+		logger.Infoln(msg)
+	case "WARN":
+		logger.Warnln(msg)
+	case "ERROR":
+		logger.Errorln(msg)
+	case "FATAL":
+		logger.Fatalln(msg)
+	}
+
+	return respOriginal, roundTripErr
+}
+
+var toSimpleMap = func(h http.Header) map[string]string {
+	out := map[string]string{}
+	for k, v := range h {
+		out[k] = strings.Join(v, " ")
+	}
+
+	return out
+}

--- a/internal/httpclient/logger_test.go
+++ b/internal/httpclient/logger_test.go
@@ -1,0 +1,297 @@
+package httpclient
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/benthosdev/benthos/v4/internal/httpclient/oldconfig"
+	"github.com/benthosdev/benthos/v4/internal/log"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewRequestLog(t *testing.T) {
+	t.Run("nil base", func(t *testing.T) {
+		httpRoundTrip, err := newRequestLog(nil, log.Noop(), oldconfig.DumpRequestLog{})
+		require.NotNil(t, httpRoundTrip)
+		require.NoError(t, err)
+	})
+
+	t.Run("nil log", func(t *testing.T) {
+		httpRoundTrip, err := newRequestLog(http.DefaultTransport, nil, oldconfig.DumpRequestLog{Enable: true})
+		require.Nil(t, httpRoundTrip)
+		require.Error(t, err)
+	})
+
+	t.Run("enable with log", func(t *testing.T) {
+		httpRoundTrip, err := newRequestLog(http.DefaultTransport, log.Noop(), oldconfig.DumpRequestLog{Enable: true})
+		require.NotNil(t, httpRoundTrip)
+		require.NoError(t, err)
+	})
+}
+
+func TestToSimpleMap(t *testing.T) {
+	t.Run("empty header", func(t *testing.T) {
+		m := toSimpleMap(http.Header{})
+		require.EqualValues(t, map[string]string{}, m)
+	})
+
+	t.Run("values header", func(t *testing.T) {
+		m := toSimpleMap(http.Header{
+			"Content Type": []string{"application/json", "charset=utf-8"},
+		})
+		require.EqualValues(t, map[string]string{
+			"Content Type": "application/json charset=utf-8",
+		}, m)
+	})
+}
+
+type mockHttpRoundTrip struct {
+	Error         error
+	CallRoundTrip func(request *http.Request) (*http.Response, error)
+}
+
+var _ http.RoundTripper = (*mockHttpRoundTrip)(nil)
+
+func newMockHttpRoundTripper() *mockHttpRoundTrip {
+	return &mockHttpRoundTrip{}
+}
+
+func newMockHttpRoundTripperWithErr(err error) *mockHttpRoundTrip {
+	return &mockHttpRoundTrip{
+		Error: err,
+	}
+}
+
+func (m *mockHttpRoundTrip) RoundTrip(request *http.Request) (*http.Response, error) {
+	if m.Error != nil {
+		return nil, m.Error
+	}
+
+	if request == nil {
+		return nil, fmt.Errorf("nil *http.Request")
+	}
+
+	// by default, non-nil error returned with empty http.Response
+	if m.CallRoundTrip == nil {
+		return &http.Response{}, nil
+	}
+
+	return m.CallRoundTrip(request)
+}
+
+func TestRoundTripper_RoundTrip(t *testing.T) {
+	t.Run("nil request", func(t *testing.T) {
+		transport := newMockHttpRoundTripper()
+
+		httpRoundTrip, err := newRequestLog(transport, log.Noop(), oldconfig.DumpRequestLog{Enable: true})
+		require.NotNil(t, httpRoundTrip)
+		require.NoError(t, err)
+
+		resp, err := httpRoundTrip.RoundTrip(nil)
+		require.Nil(t, resp)
+		require.Error(t, err)
+	})
+
+	t.Run("nil request body", func(t *testing.T) {
+		transport := newMockHttpRoundTripper()
+
+		httpRoundTrip, err := newRequestLog(transport, log.Noop(), oldconfig.DumpRequestLog{Enable: true})
+		require.NotNil(t, httpRoundTrip)
+		require.NoError(t, err)
+
+		req := &http.Request{}
+
+		resp, err := httpRoundTrip.RoundTrip(req)
+		require.NotNil(t, resp)
+		require.NoError(t, err)
+	})
+
+	t.Run("non-empty request body", func(t *testing.T) {
+		transport := newMockHttpRoundTripper()
+
+		httpRoundTrip, err := newRequestLog(transport, log.Noop(), oldconfig.DumpRequestLog{Enable: true})
+		require.NotNil(t, httpRoundTrip)
+		require.NoError(t, err)
+
+		req := &http.Request{
+			Body: io.NopCloser(bytes.NewBufferString(`{"foo":"bar"}`)),
+		}
+
+		resp, err := httpRoundTrip.RoundTrip(req)
+		require.NotNil(t, resp)
+		require.NoError(t, err)
+	})
+
+	t.Run("non-empty request body but error read", func(t *testing.T) {
+		transport := newMockHttpRoundTripper()
+
+		httpRoundTrip, err := newRequestLog(transport, log.Noop(), oldconfig.DumpRequestLog{Enable: true})
+		require.NotNil(t, httpRoundTrip)
+		require.NoError(t, err)
+
+		req := &http.Request{
+			Body: io.NopCloser(&Buf{err: fmt.Errorf("mock error buffer")}),
+		}
+
+		resp, err := httpRoundTrip.RoundTrip(req)
+		require.NotNil(t, resp)
+		require.NoError(t, err)
+	})
+
+	t.Run("non-empty request body no valid json", func(t *testing.T) {
+		transport := newMockHttpRoundTripper()
+
+		httpRoundTrip, err := newRequestLog(transport, log.Noop(), oldconfig.DumpRequestLog{Enable: true})
+		require.NotNil(t, httpRoundTrip)
+		require.NoError(t, err)
+
+		req := &http.Request{
+			Body: io.NopCloser(bytes.NewBufferString(`<html></html>`)),
+		}
+
+		resp, err := httpRoundTrip.RoundTrip(req)
+		require.NotNil(t, resp)
+		require.NoError(t, err)
+	})
+
+	t.Run("failed http.RoundTripper", func(t *testing.T) {
+		expectedErr := fmt.Errorf("failed to fetch data")
+		transport := newMockHttpRoundTripperWithErr(expectedErr)
+
+		httpRoundTrip, err := newRequestLog(transport, log.Noop(), oldconfig.DumpRequestLog{Enable: true})
+		require.NotNil(t, httpRoundTrip)
+		require.NoError(t, err)
+
+		req := &http.Request{
+			Body: io.NopCloser(bytes.NewBufferString(`{"foo":"bar"}`)),
+		}
+
+		resp, err := httpRoundTrip.RoundTrip(req)
+		require.Nil(t, resp)
+		require.Error(t, expectedErr)
+	})
+
+	t.Run("not-nil response with empty body", func(t *testing.T) {
+		transport := newMockHttpRoundTripper()
+
+		transport.CallRoundTrip = func(request *http.Request) (*http.Response, error) {
+			return &http.Response{}, nil
+		}
+
+		httpRoundTrip, err := newRequestLog(transport, log.Noop(), oldconfig.DumpRequestLog{Enable: true})
+		require.NotNil(t, httpRoundTrip)
+		require.NoError(t, err)
+
+		req := &http.Request{
+			Body: io.NopCloser(bytes.NewBufferString(`{"foo":"bar"}`)),
+		}
+
+		resp, err := httpRoundTrip.RoundTrip(req)
+		require.NotNil(t, resp)
+		require.NoError(t, err)
+	})
+
+	t.Run("not-nil response non-empty body", func(t *testing.T) {
+		transport := newMockHttpRoundTripper()
+
+		transport.CallRoundTrip = func(request *http.Request) (*http.Response, error) {
+			return &http.Response{
+				Body: io.NopCloser(bytes.NewBufferString(`{"FOO":"BAR"}`)),
+			}, nil
+		}
+
+		httpRoundTrip, err := newRequestLog(transport, log.Noop(), oldconfig.DumpRequestLog{Enable: true})
+		require.NotNil(t, httpRoundTrip)
+		require.NoError(t, err)
+
+		req := &http.Request{
+			Body: io.NopCloser(bytes.NewBufferString(`{"foo":"bar"}`)),
+		}
+
+		resp, err := httpRoundTrip.RoundTrip(req)
+		require.NotNil(t, resp)
+		require.NoError(t, err)
+	})
+
+	t.Run("not-nil response non-empty body with non-valid json", func(t *testing.T) {
+		transport := newMockHttpRoundTripper()
+
+		transport.CallRoundTrip = func(request *http.Request) (*http.Response, error) {
+			return &http.Response{
+				Body: io.NopCloser(bytes.NewBufferString(`<FOO>BAR</FOO>`)),
+			}, nil
+		}
+
+		httpRoundTrip, err := newRequestLog(transport, log.Noop(), oldconfig.DumpRequestLog{Enable: true})
+		require.NotNil(t, httpRoundTrip)
+		require.NoError(t, err)
+
+		req := &http.Request{
+			Body: io.NopCloser(bytes.NewBufferString(`{"foo":"bar"}`)),
+		}
+
+		resp, err := httpRoundTrip.RoundTrip(req)
+		require.NotNil(t, resp)
+		require.NoError(t, err)
+	})
+
+	t.Run("not-nil response non-empty body but failed to read", func(t *testing.T) {
+		transport := newMockHttpRoundTripper()
+
+		transport.CallRoundTrip = func(request *http.Request) (*http.Response, error) {
+			return &http.Response{
+				Body: io.NopCloser(&Buf{err: fmt.Errorf("failed to read response body buffer")}),
+			}, nil
+		}
+
+		httpRoundTrip, err := newRequestLog(transport, log.Noop(), oldconfig.DumpRequestLog{Enable: true})
+		require.NotNil(t, httpRoundTrip)
+		require.NoError(t, err)
+
+		req := &http.Request{
+			Body: io.NopCloser(bytes.NewBufferString(`{"foo":"bar"}`)),
+		}
+
+		resp, err := httpRoundTrip.RoundTrip(req)
+		require.NotNil(t, resp)
+		require.NoError(t, err)
+	})
+
+	t.Run("test all log level", func(t *testing.T) {
+		// cannot test FATAL because it really os.Exit(1) which make unit test error
+		levels := []string{"TRACE", "DEBUG", "INFO", "WARN", "ERROR"}
+
+		for _, level := range levels {
+			t.Run(level, func(t *testing.T) {
+				transport := newMockHttpRoundTripper()
+				httpRoundTrip, err := newRequestLog(transport, log.Noop(), oldconfig.DumpRequestLog{
+					Enable:  true,
+					Level:   level,
+					Message: "my custom message",
+				})
+				require.NotNil(t, httpRoundTrip)
+				require.NoError(t, err)
+
+				resp, err := httpRoundTrip.RoundTrip(nil)
+				require.Nil(t, resp)
+				require.Error(t, err)
+			})
+		}
+	})
+}
+
+type Buf struct {
+	err error
+}
+
+func (b *Buf) Read(p []byte) (n int, err error) {
+	if b.err != nil {
+		return 0, b.err
+	}
+
+	return len(p), nil
+}

--- a/internal/httpclient/logger_test.go
+++ b/internal/httpclient/logger_test.go
@@ -49,24 +49,24 @@ func TestToSimpleMap(t *testing.T) {
 	})
 }
 
-type mockHttpRoundTrip struct {
+type mockHTTPRoundTrip struct {
 	Error         error
 	CallRoundTrip func(request *http.Request) (*http.Response, error)
 }
 
-var _ http.RoundTripper = (*mockHttpRoundTrip)(nil)
+var _ http.RoundTripper = (*mockHTTPRoundTrip)(nil)
 
-func newMockHttpRoundTripper() *mockHttpRoundTrip {
-	return &mockHttpRoundTrip{}
+func newMockHTTPRoundTripper() *mockHTTPRoundTrip {
+	return &mockHTTPRoundTrip{}
 }
 
-func newMockHttpRoundTripperWithErr(err error) *mockHttpRoundTrip {
-	return &mockHttpRoundTrip{
+func newMockHTTPRoundTripperWithErr(err error) *mockHTTPRoundTrip {
+	return &mockHTTPRoundTrip{
 		Error: err,
 	}
 }
 
-func (m *mockHttpRoundTrip) RoundTrip(request *http.Request) (*http.Response, error) {
+func (m *mockHTTPRoundTrip) RoundTrip(request *http.Request) (*http.Response, error) {
 	if m.Error != nil {
 		return nil, m.Error
 	}
@@ -85,7 +85,7 @@ func (m *mockHttpRoundTrip) RoundTrip(request *http.Request) (*http.Response, er
 
 func TestRoundTripper_RoundTrip(t *testing.T) {
 	t.Run("nil request", func(t *testing.T) {
-		transport := newMockHttpRoundTripper()
+		transport := newMockHTTPRoundTripper()
 
 		httpRoundTrip, err := newRequestLog(transport, log.Noop(), oldconfig.DumpRequestLogConfig{Enable: true})
 		require.NotNil(t, httpRoundTrip)
@@ -97,7 +97,7 @@ func TestRoundTripper_RoundTrip(t *testing.T) {
 	})
 
 	t.Run("nil request body", func(t *testing.T) {
-		transport := newMockHttpRoundTripper()
+		transport := newMockHTTPRoundTripper()
 
 		httpRoundTrip, err := newRequestLog(transport, log.Noop(), oldconfig.DumpRequestLogConfig{Enable: true})
 		require.NotNil(t, httpRoundTrip)
@@ -111,7 +111,7 @@ func TestRoundTripper_RoundTrip(t *testing.T) {
 	})
 
 	t.Run("non-empty request body", func(t *testing.T) {
-		transport := newMockHttpRoundTripper()
+		transport := newMockHTTPRoundTripper()
 
 		httpRoundTrip, err := newRequestLog(transport, log.Noop(), oldconfig.DumpRequestLogConfig{Enable: true})
 		require.NotNil(t, httpRoundTrip)
@@ -127,7 +127,7 @@ func TestRoundTripper_RoundTrip(t *testing.T) {
 	})
 
 	t.Run("non-empty request body but error read", func(t *testing.T) {
-		transport := newMockHttpRoundTripper()
+		transport := newMockHTTPRoundTripper()
 
 		httpRoundTrip, err := newRequestLog(transport, log.Noop(), oldconfig.DumpRequestLogConfig{Enable: true})
 		require.NotNil(t, httpRoundTrip)
@@ -143,7 +143,7 @@ func TestRoundTripper_RoundTrip(t *testing.T) {
 	})
 
 	t.Run("non-empty request body but error close", func(t *testing.T) {
-		transport := newMockHttpRoundTripper()
+		transport := newMockHTTPRoundTripper()
 
 		httpRoundTrip, err := newRequestLog(transport, log.Noop(), oldconfig.DumpRequestLogConfig{Enable: true})
 		require.NotNil(t, httpRoundTrip)
@@ -162,7 +162,7 @@ func TestRoundTripper_RoundTrip(t *testing.T) {
 	})
 
 	t.Run("non-empty request body no valid json", func(t *testing.T) {
-		transport := newMockHttpRoundTripper()
+		transport := newMockHTTPRoundTripper()
 
 		httpRoundTrip, err := newRequestLog(transport, log.Noop(), oldconfig.DumpRequestLogConfig{Enable: true})
 		require.NotNil(t, httpRoundTrip)
@@ -179,7 +179,7 @@ func TestRoundTripper_RoundTrip(t *testing.T) {
 
 	t.Run("failed http.RoundTripper", func(t *testing.T) {
 		expectedErr := fmt.Errorf("failed to fetch data")
-		transport := newMockHttpRoundTripperWithErr(expectedErr)
+		transport := newMockHTTPRoundTripperWithErr(expectedErr)
 
 		httpRoundTrip, err := newRequestLog(transport, log.Noop(), oldconfig.DumpRequestLogConfig{Enable: true})
 		require.NotNil(t, httpRoundTrip)
@@ -189,13 +189,13 @@ func TestRoundTripper_RoundTrip(t *testing.T) {
 			Body: io.NopCloser(bytes.NewBufferString(`{"foo":"bar"}`)),
 		}
 
-		resp, err := httpRoundTrip.RoundTrip(req)
+		resp, respErr := httpRoundTrip.RoundTrip(req)
 		require.Nil(t, resp)
-		require.Error(t, expectedErr)
+		require.ErrorIs(t, respErr, expectedErr)
 	})
 
 	t.Run("not-nil response with empty resp body", func(t *testing.T) {
-		transport := newMockHttpRoundTripper()
+		transport := newMockHTTPRoundTripper()
 
 		transport.CallRoundTrip = func(request *http.Request) (*http.Response, error) {
 			return &http.Response{}, nil
@@ -215,7 +215,7 @@ func TestRoundTripper_RoundTrip(t *testing.T) {
 	})
 
 	t.Run("not-nil response non-empty resp body", func(t *testing.T) {
-		transport := newMockHttpRoundTripper()
+		transport := newMockHTTPRoundTripper()
 
 		transport.CallRoundTrip = func(request *http.Request) (*http.Response, error) {
 			return &http.Response{
@@ -237,7 +237,7 @@ func TestRoundTripper_RoundTrip(t *testing.T) {
 	})
 
 	t.Run("not-nil response body fail on close", func(t *testing.T) {
-		transport := newMockHttpRoundTripper()
+		transport := newMockHTTPRoundTripper()
 
 		transport.CallRoundTrip = func(request *http.Request) (*http.Response, error) {
 			return &http.Response{
@@ -262,7 +262,7 @@ func TestRoundTripper_RoundTrip(t *testing.T) {
 	})
 
 	t.Run("not-nil response non-empty resp body with non-valid json", func(t *testing.T) {
-		transport := newMockHttpRoundTripper()
+		transport := newMockHTTPRoundTripper()
 
 		transport.CallRoundTrip = func(request *http.Request) (*http.Response, error) {
 			return &http.Response{
@@ -284,7 +284,7 @@ func TestRoundTripper_RoundTrip(t *testing.T) {
 	})
 
 	t.Run("not-nil response non-empty resp body but failed to read", func(t *testing.T) {
-		transport := newMockHttpRoundTripper()
+		transport := newMockHTTPRoundTripper()
 
 		transport.CallRoundTrip = func(request *http.Request) (*http.Response, error) {
 			return &http.Response{
@@ -311,7 +311,7 @@ func TestRoundTripper_RoundTrip(t *testing.T) {
 
 		for _, level := range levels {
 			t.Run(level, func(t *testing.T) {
-				transport := newMockHttpRoundTripper()
+				transport := newMockHTTPRoundTripper()
 				httpRoundTrip, err := newRequestLog(transport, log.Noop(), oldconfig.DumpRequestLogConfig{
 					Enable:  true,
 					Level:   level,

--- a/internal/httpclient/logger_test.go
+++ b/internal/httpclient/logger_test.go
@@ -15,19 +15,19 @@ import (
 
 func TestNewRequestLog(t *testing.T) {
 	t.Run("nil base", func(t *testing.T) {
-		httpRoundTrip, err := newRequestLog(nil, log.Noop(), oldconfig.DumpRequestLog{})
+		httpRoundTrip, err := newRequestLog(nil, log.Noop(), oldconfig.DumpRequestLogConfig{})
 		require.NotNil(t, httpRoundTrip)
 		require.NoError(t, err)
 	})
 
 	t.Run("nil log", func(t *testing.T) {
-		httpRoundTrip, err := newRequestLog(http.DefaultTransport, nil, oldconfig.DumpRequestLog{Enable: true})
+		httpRoundTrip, err := newRequestLog(http.DefaultTransport, nil, oldconfig.DumpRequestLogConfig{Enable: true})
 		require.Nil(t, httpRoundTrip)
 		require.Error(t, err)
 	})
 
 	t.Run("enable with log", func(t *testing.T) {
-		httpRoundTrip, err := newRequestLog(http.DefaultTransport, log.Noop(), oldconfig.DumpRequestLog{Enable: true})
+		httpRoundTrip, err := newRequestLog(http.DefaultTransport, log.Noop(), oldconfig.DumpRequestLogConfig{Enable: true})
 		require.NotNil(t, httpRoundTrip)
 		require.NoError(t, err)
 	})
@@ -87,7 +87,7 @@ func TestRoundTripper_RoundTrip(t *testing.T) {
 	t.Run("nil request", func(t *testing.T) {
 		transport := newMockHttpRoundTripper()
 
-		httpRoundTrip, err := newRequestLog(transport, log.Noop(), oldconfig.DumpRequestLog{Enable: true})
+		httpRoundTrip, err := newRequestLog(transport, log.Noop(), oldconfig.DumpRequestLogConfig{Enable: true})
 		require.NotNil(t, httpRoundTrip)
 		require.NoError(t, err)
 
@@ -99,7 +99,7 @@ func TestRoundTripper_RoundTrip(t *testing.T) {
 	t.Run("nil request body", func(t *testing.T) {
 		transport := newMockHttpRoundTripper()
 
-		httpRoundTrip, err := newRequestLog(transport, log.Noop(), oldconfig.DumpRequestLog{Enable: true})
+		httpRoundTrip, err := newRequestLog(transport, log.Noop(), oldconfig.DumpRequestLogConfig{Enable: true})
 		require.NotNil(t, httpRoundTrip)
 		require.NoError(t, err)
 
@@ -113,7 +113,7 @@ func TestRoundTripper_RoundTrip(t *testing.T) {
 	t.Run("non-empty request body", func(t *testing.T) {
 		transport := newMockHttpRoundTripper()
 
-		httpRoundTrip, err := newRequestLog(transport, log.Noop(), oldconfig.DumpRequestLog{Enable: true})
+		httpRoundTrip, err := newRequestLog(transport, log.Noop(), oldconfig.DumpRequestLogConfig{Enable: true})
 		require.NotNil(t, httpRoundTrip)
 		require.NoError(t, err)
 
@@ -129,7 +129,7 @@ func TestRoundTripper_RoundTrip(t *testing.T) {
 	t.Run("non-empty request body but error read", func(t *testing.T) {
 		transport := newMockHttpRoundTripper()
 
-		httpRoundTrip, err := newRequestLog(transport, log.Noop(), oldconfig.DumpRequestLog{Enable: true})
+		httpRoundTrip, err := newRequestLog(transport, log.Noop(), oldconfig.DumpRequestLogConfig{Enable: true})
 		require.NotNil(t, httpRoundTrip)
 		require.NoError(t, err)
 
@@ -145,7 +145,7 @@ func TestRoundTripper_RoundTrip(t *testing.T) {
 	t.Run("non-empty request body no valid json", func(t *testing.T) {
 		transport := newMockHttpRoundTripper()
 
-		httpRoundTrip, err := newRequestLog(transport, log.Noop(), oldconfig.DumpRequestLog{Enable: true})
+		httpRoundTrip, err := newRequestLog(transport, log.Noop(), oldconfig.DumpRequestLogConfig{Enable: true})
 		require.NotNil(t, httpRoundTrip)
 		require.NoError(t, err)
 
@@ -162,7 +162,7 @@ func TestRoundTripper_RoundTrip(t *testing.T) {
 		expectedErr := fmt.Errorf("failed to fetch data")
 		transport := newMockHttpRoundTripperWithErr(expectedErr)
 
-		httpRoundTrip, err := newRequestLog(transport, log.Noop(), oldconfig.DumpRequestLog{Enable: true})
+		httpRoundTrip, err := newRequestLog(transport, log.Noop(), oldconfig.DumpRequestLogConfig{Enable: true})
 		require.NotNil(t, httpRoundTrip)
 		require.NoError(t, err)
 
@@ -182,7 +182,7 @@ func TestRoundTripper_RoundTrip(t *testing.T) {
 			return &http.Response{}, nil
 		}
 
-		httpRoundTrip, err := newRequestLog(transport, log.Noop(), oldconfig.DumpRequestLog{Enable: true})
+		httpRoundTrip, err := newRequestLog(transport, log.Noop(), oldconfig.DumpRequestLogConfig{Enable: true})
 		require.NotNil(t, httpRoundTrip)
 		require.NoError(t, err)
 
@@ -204,7 +204,7 @@ func TestRoundTripper_RoundTrip(t *testing.T) {
 			}, nil
 		}
 
-		httpRoundTrip, err := newRequestLog(transport, log.Noop(), oldconfig.DumpRequestLog{Enable: true})
+		httpRoundTrip, err := newRequestLog(transport, log.Noop(), oldconfig.DumpRequestLogConfig{Enable: true})
 		require.NotNil(t, httpRoundTrip)
 		require.NoError(t, err)
 
@@ -226,7 +226,7 @@ func TestRoundTripper_RoundTrip(t *testing.T) {
 			}, nil
 		}
 
-		httpRoundTrip, err := newRequestLog(transport, log.Noop(), oldconfig.DumpRequestLog{Enable: true})
+		httpRoundTrip, err := newRequestLog(transport, log.Noop(), oldconfig.DumpRequestLogConfig{Enable: true})
 		require.NotNil(t, httpRoundTrip)
 		require.NoError(t, err)
 
@@ -248,7 +248,7 @@ func TestRoundTripper_RoundTrip(t *testing.T) {
 			}, nil
 		}
 
-		httpRoundTrip, err := newRequestLog(transport, log.Noop(), oldconfig.DumpRequestLog{Enable: true})
+		httpRoundTrip, err := newRequestLog(transport, log.Noop(), oldconfig.DumpRequestLogConfig{Enable: true})
 		require.NotNil(t, httpRoundTrip)
 		require.NoError(t, err)
 
@@ -268,7 +268,7 @@ func TestRoundTripper_RoundTrip(t *testing.T) {
 		for _, level := range levels {
 			t.Run(level, func(t *testing.T) {
 				transport := newMockHttpRoundTripper()
-				httpRoundTrip, err := newRequestLog(transport, log.Noop(), oldconfig.DumpRequestLog{
+				httpRoundTrip, err := newRequestLog(transport, log.Noop(), oldconfig.DumpRequestLogConfig{
 					Enable:  true,
 					Level:   level,
 					Message: "my custom message",

--- a/internal/httpclient/logger_test.go
+++ b/internal/httpclient/logger_test.go
@@ -175,7 +175,7 @@ func TestRoundTripper_RoundTrip(t *testing.T) {
 		require.Error(t, expectedErr)
 	})
 
-	t.Run("not-nil response with empty body", func(t *testing.T) {
+	t.Run("not-nil response with empty resp body", func(t *testing.T) {
 		transport := newMockHttpRoundTripper()
 
 		transport.CallRoundTrip = func(request *http.Request) (*http.Response, error) {
@@ -195,7 +195,7 @@ func TestRoundTripper_RoundTrip(t *testing.T) {
 		require.NoError(t, err)
 	})
 
-	t.Run("not-nil response non-empty body", func(t *testing.T) {
+	t.Run("not-nil response non-empty resp body", func(t *testing.T) {
 		transport := newMockHttpRoundTripper()
 
 		transport.CallRoundTrip = func(request *http.Request) (*http.Response, error) {
@@ -217,7 +217,7 @@ func TestRoundTripper_RoundTrip(t *testing.T) {
 		require.NoError(t, err)
 	})
 
-	t.Run("not-nil response non-empty body with non-valid json", func(t *testing.T) {
+	t.Run("not-nil response non-empty resp body with non-valid json", func(t *testing.T) {
 		transport := newMockHttpRoundTripper()
 
 		transport.CallRoundTrip = func(request *http.Request) (*http.Response, error) {
@@ -239,7 +239,7 @@ func TestRoundTripper_RoundTrip(t *testing.T) {
 		require.NoError(t, err)
 	})
 
-	t.Run("not-nil response non-empty body but failed to read", func(t *testing.T) {
+	t.Run("not-nil response non-empty resp body but failed to read", func(t *testing.T) {
 		transport := newMockHttpRoundTripper()
 
 		transport.CallRoundTrip = func(request *http.Request) (*http.Response, error) {

--- a/internal/httpclient/oldconfig/config.go
+++ b/internal/httpclient/oldconfig/config.go
@@ -23,11 +23,11 @@ type OldConfig struct {
 	TLS             tls.Config                   `json:"tls" yaml:"tls"`
 	ProxyURL        string                       `json:"proxy_url" yaml:"proxy_url"`
 	AuthConfig      `json:",inline" yaml:",inline"`
-	OAuth2          OAuth2Config   `json:"oauth2" yaml:"oauth2"`
-	DumpRequestLog  DumpRequestLog `json:"dump_request_log" yaml:"dump_request_log"`
+	OAuth2          OAuth2Config         `json:"oauth2" yaml:"oauth2"`
+	DumpRequestLog  DumpRequestLogConfig `json:"dump_request_log" yaml:"dump_request_log"`
 }
 
-type DumpRequestLog struct {
+type DumpRequestLogConfig struct {
 	// Enable whether to print dump request log or not
 	// Default: false
 	Enable bool `json:"enable" yaml:"enable"`

--- a/internal/httpclient/oldconfig/config.go
+++ b/internal/httpclient/oldconfig/config.go
@@ -27,6 +27,7 @@ type OldConfig struct {
 	DumpRequestLog  DumpRequestLogConfig `json:"dump_request_log" yaml:"dump_request_log"`
 }
 
+// DumpRequestLogConfig is configuration to enable or disable the HTTP request/response in logger.
 type DumpRequestLogConfig struct {
 	// Enable whether to print dump request log or not
 	// Default: false

--- a/internal/httpclient/oldconfig/config.go
+++ b/internal/httpclient/oldconfig/config.go
@@ -23,7 +23,22 @@ type OldConfig struct {
 	TLS             tls.Config                   `json:"tls" yaml:"tls"`
 	ProxyURL        string                       `json:"proxy_url" yaml:"proxy_url"`
 	AuthConfig      `json:",inline" yaml:",inline"`
-	OAuth2          OAuth2Config `json:"oauth2" yaml:"oauth2"`
+	OAuth2          OAuth2Config   `json:"oauth2" yaml:"oauth2"`
+	DumpRequestLog  DumpRequestLog `json:"dump_request_log" yaml:"dump_request_log"`
+}
+
+type DumpRequestLog struct {
+	// Enable whether to print dump request log or not
+	// Default: false
+	Enable bool `json:"enable" yaml:"enable"`
+
+	// Level at what level this request-response log will be printed.
+	// Available level: TRACE, DEBUG, INFO, WARN, ERROR, FATAL
+	// Default: TRACE
+	Level string `json:"level" yaml:"level"`
+
+	// Message printed to the logger.
+	Message string `json:"message" yaml:"message"`
 }
 
 // NewOldConfig creates a new Config with default values.

--- a/website/docs/components/inputs/http_client.md
+++ b/website/docs/components/inputs/http_client.md
@@ -56,6 +56,10 @@ input:
     metadata:
       include_prefixes: []
       include_patterns: []
+    dump_request_log:
+      enable: false
+      level: TRACE
+      message: http request log
     oauth:
       enabled: false
       consumer_key: ""
@@ -246,6 +250,56 @@ include_patterns:
 
 include_patterns:
   - _timestamp_unix$
+```
+
+### `dump_request_log`
+
+Dump the request and response payload in stdout as logger
+
+
+Type: `object`  
+
+### `dump_request_log.enable`
+
+Whether to print dump request log or not.
+
+
+Type: `bool`  
+Default: `false`  
+
+```yml
+# Examples
+
+enable: true
+```
+
+### `dump_request_log.level`
+
+At what level this request-response log will be printed.
+
+
+Type: `string`  
+Default: `"TRACE"`  
+Options: `TRACE`, `DEBUG`, `INFO`, `WARN`, `ERROR`, `FATAL`.
+
+```yml
+# Examples
+
+level: TRACE
+```
+
+### `dump_request_log.message`
+
+Message printed to the logger.
+
+
+Type: `string`  
+Default: `"http request log"`  
+
+```yml
+# Examples
+
+message: request log to service xxx
 ```
 
 ### `oauth`

--- a/website/docs/components/outputs/http_client.md
+++ b/website/docs/components/outputs/http_client.md
@@ -57,6 +57,10 @@ output:
     metadata:
       include_prefixes: []
       include_patterns: []
+    dump_request_log:
+      enable: false
+      level: TRACE
+      message: http request log
     oauth:
       enabled: false
       consumer_key: ""
@@ -225,6 +229,56 @@ include_patterns:
 
 include_patterns:
   - _timestamp_unix$
+```
+
+### `dump_request_log`
+
+Dump the request and response payload in stdout as logger
+
+
+Type: `object`  
+
+### `dump_request_log.enable`
+
+Whether to print dump request log or not.
+
+
+Type: `bool`  
+Default: `false`  
+
+```yml
+# Examples
+
+enable: true
+```
+
+### `dump_request_log.level`
+
+At what level this request-response log will be printed.
+
+
+Type: `string`  
+Default: `"TRACE"`  
+Options: `TRACE`, `DEBUG`, `INFO`, `WARN`, `ERROR`, `FATAL`.
+
+```yml
+# Examples
+
+level: TRACE
+```
+
+### `dump_request_log.message`
+
+Message printed to the logger.
+
+
+Type: `string`  
+Default: `"http request log"`  
+
+```yml
+# Examples
+
+message: request log to service xxx
 ```
 
 ### `oauth`

--- a/website/docs/components/processors/http.md
+++ b/website/docs/components/processors/http.md
@@ -52,6 +52,10 @@ http:
   metadata:
     include_prefixes: []
     include_patterns: []
+  dump_request_log:
+    enable: false
+    level: TRACE
+    message: http request log
   oauth:
     enabled: false
     consumer_key: ""
@@ -256,6 +260,56 @@ include_patterns:
 
 include_patterns:
   - _timestamp_unix$
+```
+
+### `dump_request_log`
+
+Dump the request and response payload in stdout as logger
+
+
+Type: `object`  
+
+### `dump_request_log.enable`
+
+Whether to print dump request log or not.
+
+
+Type: `bool`  
+Default: `false`  
+
+```yml
+# Examples
+
+enable: true
+```
+
+### `dump_request_log.level`
+
+At what level this request-response log will be printed.
+
+
+Type: `string`  
+Default: `"TRACE"`  
+Options: `TRACE`, `DEBUG`, `INFO`, `WARN`, `ERROR`, `FATAL`.
+
+```yml
+# Examples
+
+level: TRACE
+```
+
+### `dump_request_log.message`
+
+Message printed to the logger.
+
+
+Type: `string`  
+Default: `"http request log"`  
+
+```yml
+# Examples
+
+message: request log to service xxx
 ```
 
 ### `oauth`


### PR DESCRIPTION
It might be useful if we can print the HTTP request and response via logger with the level of this HTTP log is defined by user. For example, user wants to set the level to `INFO` but their main logger config is set to `ERROR` then the HTTP request-response log (this PR) won't show on their log (because we use the same logger instance).

Also, we can let the user to opt-in/opt-out this HTTP logging (by default off) if they think that the request-response body may contain sensitive data.

When this feature is useful:
* When user want to track and make sure that their `bloblang` or `mapping` processor is really send in the expected format (currently we have to create new `log` processor each time we modify our data)
* When user want to see the actual HTTP response (body and header) on their server log. Currently, it seems hard to see the actual HTTP response returned by the HTTP service unless we're using `propagate_response` which only propagate back to the input (in most cases, we only want to know the log, not propagate back the response)