### PR TITLE
Add 'max_buffer' config option to s3 input to configure codecs

### DIFF
--- a/internal/component/input/config_aws_s3.go
+++ b/internal/component/input/config_aws_s3.go
@@ -33,6 +33,7 @@ type AWSS3Config struct {
 	sess.Config        `json:",inline" yaml:",inline"`
 	Bucket             string         `json:"bucket" yaml:"bucket"`
 	Codec              string         `json:"codec" yaml:"codec"`
+	MaxBuffer          int            `json:"max_buffer" yaml:"max_buffer"`
 	Prefix             string         `json:"prefix" yaml:"prefix"`
 	ForcePathStyleURLs bool           `json:"force_path_style_urls" yaml:"force_path_style_urls"`
 	DeleteObjects      bool           `json:"delete_objects" yaml:"delete_objects"`
@@ -46,6 +47,7 @@ func NewAWSS3Config() AWSS3Config {
 		Bucket:             "",
 		Prefix:             "",
 		Codec:              "all-bytes",
+		MaxBuffer:          1000000,
 		ForcePathStyleURLs: false,
 		DeleteObjects:      false,
 		SQS:                NewAWSS3SQSConfig(),

--- a/internal/impl/aws/input_s3.go
+++ b/internal/impl/aws/input_s3.go
@@ -89,6 +89,7 @@ You can access these metadata fields using [function interpolation](/docs/config
 			docs.FieldBool("force_path_style_urls", "Forces the client API to use path style URLs for downloading keys, which is often required when connecting to custom endpoints.").Advanced(),
 			docs.FieldBool("delete_objects", "Whether to delete downloaded objects from the bucket once they are processed.").Advanced(),
 			codec.ReaderDocs,
+			docs.FieldInt("max_buffer", "The largest token size expected when consuming s3 object (given codec like `lines`)").Advanced(),
 			docs.FieldObject("sqs", "Consume SQS messages in order to trigger key downloads.").WithChildren(
 				docs.FieldURL("url", "An optional SQS URL to connect to. When specified this queue will control which objects are downloaded."),
 				docs.FieldString("endpoint", "A custom endpoint to use when connecting to SQS.").Advanced(),
@@ -537,7 +538,10 @@ func newAmazonS3Reader(conf input.AWSS3Config, nm bundle.NewManagement) (*awsS3R
 		log:  nm.Logger(),
 	}
 	var err error
-	if s.objectScannerCtor, err = codec.GetReader(conf.Codec, codec.NewReaderConfig()); err != nil {
+	readerConfig := codec.ReaderConfig{
+		MaxScanTokenSize: conf.MaxBuffer,
+	}
+	if s.objectScannerCtor, err = codec.GetReader(conf.Codec, readerConfig); err != nil {
 		return nil, err
 	}
 	if len(conf.SQS.DelayPeriod) > 0 {


### PR DESCRIPTION
Fixes #1636.  Please note using the same larger default `max_buffer` of 1000000 as other inputs.