### PR TITLE
Set the default value of conn_max_idle for sql_* components to 2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 
 - The `sqlite` buffer should no longer print `Failed to ack buffer message` logs during graceful termination.
+- The default value of the `conn_max_idle` field has been changed from 0 to 2 for all `sql_*` components in accordance
+to the [`database/sql` docs](https://pkg.go.dev/database/sql#DB.SetMaxIdleConns).
 
 ## 4.11.0 - 2022-12-21
 

--- a/internal/impl/sql/conn_fields.go
+++ b/internal/impl/sql/conn_fields.go
@@ -86,6 +86,7 @@ CREATE TABLE IF NOT EXISTS some_table (
 			Advanced(),
 		service.NewIntField("conn_max_idle").
 			Description(`An optional maximum number of connections in the idle connection pool. If conn_max_open is greater than 0 but less than the new conn_max_idle, then the new conn_max_idle will be reduced to match the conn_max_open limit. If value <= 0, no idle connections are retained. The default max idle connections is currently 2. This may change in a future release.`).
+			Default(2).
 			Optional().
 			Advanced(),
 		service.NewIntField("conn_max_open").

--- a/website/docs/components/inputs/sql_raw.md
+++ b/website/docs/components/inputs/sql_raw.md
@@ -57,7 +57,7 @@ input:
     init_statement: ""
     conn_max_idle_time: ""
     conn_max_life_time: ""
-    conn_max_idle: 0
+    conn_max_idle: 2
     conn_max_open: 0
 ```
 
@@ -244,6 +244,7 @@ An optional maximum number of connections in the idle connection pool. If conn_m
 
 
 Type: `int`  
+Default: `2`  
 
 ### `conn_max_open`
 

--- a/website/docs/components/inputs/sql_select.md
+++ b/website/docs/components/inputs/sql_select.md
@@ -63,7 +63,7 @@ input:
     init_statement: ""
     conn_max_idle_time: ""
     conn_max_life_time: ""
-    conn_max_idle: 0
+    conn_max_idle: 2
     conn_max_open: 0
 ```
 
@@ -288,6 +288,7 @@ An optional maximum number of connections in the idle connection pool. If conn_m
 
 
 Type: `int`  
+Default: `2`  
 
 ### `conn_max_open`
 

--- a/website/docs/components/outputs/sql_insert.md
+++ b/website/docs/components/outputs/sql_insert.md
@@ -65,7 +65,7 @@ output:
     init_statement: ""
     conn_max_idle_time: ""
     conn_max_life_time: ""
-    conn_max_idle: 0
+    conn_max_idle: 2
     conn_max_open: 0
     batching:
       count: 0
@@ -293,6 +293,7 @@ An optional maximum number of connections in the idle connection pool. If conn_m
 
 
 Type: `int`  
+Default: `2`  
 
 ### `conn_max_open`
 

--- a/website/docs/components/outputs/sql_raw.md
+++ b/website/docs/components/outputs/sql_raw.md
@@ -62,7 +62,7 @@ output:
     init_statement: ""
     conn_max_idle_time: ""
     conn_max_life_time: ""
-    conn_max_idle: 0
+    conn_max_idle: 2
     conn_max_open: 0
     batching:
       count: 0
@@ -271,6 +271,7 @@ An optional maximum number of connections in the idle connection pool. If conn_m
 
 
 Type: `int`  
+Default: `2`  
 
 ### `conn_max_open`
 

--- a/website/docs/components/processors/sql_insert.md
+++ b/website/docs/components/processors/sql_insert.md
@@ -56,7 +56,7 @@ sql_insert:
   init_statement: ""
   conn_max_idle_time: ""
   conn_max_life_time: ""
-  conn_max_idle: 0
+  conn_max_idle: 2
   conn_max_open: 0
 ```
 
@@ -273,6 +273,7 @@ An optional maximum number of connections in the idle connection pool. If conn_m
 
 
 Type: `int`  
+Default: `2`  
 
 ### `conn_max_open`
 

--- a/website/docs/components/processors/sql_raw.md
+++ b/website/docs/components/processors/sql_raw.md
@@ -55,7 +55,7 @@ sql_raw:
   init_statement: ""
   conn_max_idle_time: ""
   conn_max_life_time: ""
-  conn_max_idle: 0
+  conn_max_idle: 2
   conn_max_open: 0
 ```
 
@@ -277,6 +277,7 @@ An optional maximum number of connections in the idle connection pool. If conn_m
 
 
 Type: `int`  
+Default: `2`  
 
 ### `conn_max_open`
 

--- a/website/docs/components/processors/sql_select.md
+++ b/website/docs/components/processors/sql_select.md
@@ -58,7 +58,7 @@ sql_select:
   init_statement: ""
   conn_max_idle_time: ""
   conn_max_life_time: ""
-  conn_max_idle: 0
+  conn_max_idle: 2
   conn_max_open: 0
 ```
 
@@ -289,6 +289,7 @@ An optional maximum number of connections in the idle connection pool. If conn_m
 
 
 Type: `int`  
+Default: `2`  
 
 ### `conn_max_open`
 


### PR DESCRIPTION
Currently, this is implicitly set to 0, which deviates from the default value (2) that is specified in the standard library docs [here](https://pkg.go.dev/database/sql#DB.SetMaxIdleConns).

Guess some people who are currently using `conn_max_idle: 0` implicitly might bump into performance issues, not sure...