### PR TITLE
Fix MongoDB input integration test

### DIFF
--- a/internal/impl/mongodb/input_test.go
+++ b/internal/impl/mongodb/input_test.go
@@ -44,10 +44,6 @@ query: |
 func TestInputIntegration(t *testing.T) {
 	integration.CheckSkip(t)
 
-	if testing.Short() {
-		t.Skip("Skipping integration test in short mode")
-	}
-
 	pool, err := dockertest.NewPool("")
 	if err != nil {
 		t.Skipf("Could not connect to docker: %s", err)
@@ -129,6 +125,7 @@ func TestInputIntegration(t *testing.T) {
 	type testCase struct {
 		query           func(coll *mongo.Collection) (*mongo.Cursor, error)
 		placeholderConf string
+		jsonMarshalMode client.JSONMarshalMode
 	}
 	cases := map[string]testCase{
 		"find": {
@@ -145,9 +142,11 @@ username: mongoadmin
 password: secret
 database: "TestDB"
 collection: "TestCollection"
+json_marshal_mode: relaxed
 query: |
   root.age = {"$gte": 18}
 `,
+			jsonMarshalMode: client.JSONMarshalModeRelaxed,
 		},
 		"aggregate": {
 			query: func(coll *mongo.Collection) (*mongo.Cursor, error) {
@@ -171,6 +170,7 @@ password: secret
 database: "TestDB"
 collection: "TestCollection"
 operation: "aggregate"
+json_marshal_mode: canonical
 query: |
   root = [
     {
@@ -185,18 +185,27 @@ query: |
     }
   ]
 `,
+			jsonMarshalMode: client.JSONMarshalModeCanonical,
 		},
 	}
 
 	port := resource.GetPort("27017/tcp")
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			testInput(port, tc.query, tc.placeholderConf, t)
+			testInput(t, port, tc.query, tc.placeholderConf, tc.jsonMarshalMode)
 		})
 	}
 }
 
-func testInput(port string, controlQuery func(collection *mongo.Collection) (cursor *mongo.Cursor, err error), placeholderConf string, t *testing.T) {
+func testInput(
+	t *testing.T,
+	port string,
+	controlQuery func(collection *mongo.Collection) (cursor *mongo.Cursor, err error),
+	placeholderConf string,
+	jsonMarshalMode client.JSONMarshalMode,
+) {
+	t.Helper()
+
 	controlCtx := context.Background()
 	controlConn, err := mongo.Connect(controlCtx, options.Client().ApplyURI("mongodb://mongoadmin:secret@localhost:"+port))
 	require.NoError(t, err)
@@ -206,11 +215,11 @@ func testInput(port string, controlQuery func(collection *mongo.Collection) (cur
 	var wantResults []map[string]any
 	err = controlCur.All(controlCtx, &wantResults)
 	require.NoError(t, err)
-	var wantMsgs []*service.Message
+	var wantMsgs [][]byte
 	for _, res := range wantResults {
-		wantMsg := service.NewMessage(nil)
-		wantMsg.SetStructured(res)
-		wantMsgs = append(wantMsgs, wantMsg)
+		resBytes, err := bson.MarshalExtJSON(res, jsonMarshalMode == client.JSONMarshalModeCanonical, false)
+		require.NoError(t, err)
+		wantMsgs = append(wantMsgs, resBytes)
 	}
 
 	conf := fmt.Sprintf(placeholderConf, port)
@@ -228,12 +237,16 @@ func testInput(port string, controlQuery func(collection *mongo.Collection) (cur
 	err = selectInput.Connect(ctx)
 	require.NoError(t, err)
 	for _, wMsg := range wantMsgs {
-		msg, _, err := selectInput.Read(ctx)
+		msg, ack, err := selectInput.Read(ctx)
 		require.NoError(t, err)
-		assert.Equal(t, wMsg, msg)
+		msgBytes, err := msg.AsBytes()
+		require.NoError(t, err)
+		assert.JSONEq(t, string(wMsg), string(msgBytes))
+		require.NoError(t, ack(ctx, nil))
 	}
-	_, _, err = selectInput.Read(ctx)
+	_, ack, err := selectInput.Read(ctx)
 	assert.Equal(t, service.ErrEndOfInput, err)
+	require.Nil(t, ack)
 
 	require.NoError(t, selectInput.Close(context.Background()))
 }

--- a/internal/impl/mongodb/processor_test.go
+++ b/internal/impl/mongodb/processor_test.go
@@ -23,10 +23,6 @@ import (
 func TestProcessorIntegration(t *testing.T) {
 	integration.CheckSkip(t)
 
-	if testing.Short() {
-		t.Skip("Skipping integration test in short mode")
-	}
-
 	pool, err := dockertest.NewPool("")
 	if err != nil {
 		t.Skipf("Could not connect to docker: %s", err)


### PR DESCRIPTION
Guess this one hasn't been run in a while...

LE: The tests should finish quickly once the container is running, so we shouldn't need to use `testing.Short()` unless we want to do that for all Docker-based integration tests.