### PR TITLE
Fix aws_sqs backoff reset behavior

### DIFF
--- a/internal/impl/aws/input_sqs.go
+++ b/internal/impl/aws/input_sqs.go
@@ -215,8 +215,8 @@ func (a *awsSQSReader) readLoop(wg *sync.WaitGroup) {
 	}()
 
 	backoff := backoff.NewExponentialBackOff()
-	backoff.InitialInterval = 100 * time.Millisecond
-	backoff.MaxInterval = 5 * time.Minute
+	backoff.InitialInterval = 10 * time.Millisecond
+	backoff.MaxInterval = 30 * time.Second
 	backoff.MaxElapsedTime = 0
 
 	getMsgs := func() {
@@ -237,6 +237,8 @@ func (a *awsSQSReader) readLoop(wg *sync.WaitGroup) {
 		}
 		if len(res.Messages) > 0 {
 			pendingMsgs = append(pendingMsgs, res.Messages...)
+		}
+		if len(res.Messages) > 0 || a.conf.WaitTimeSeconds > 0 {
 			backoff.Reset()
 		}
 	}


### PR DESCRIPTION
The current implementation results in artificial delays when reading from a queue that has an average receive message frequency lower than the configured receive wait timeout. For example, if a queue receives, on average, a burst of messages every 15-30m, and this input is configured with long polling enabled (using the max receive wait timeout of 20s), most messages will experience an artificial delay of 5m. This change removes the conditional clause around receiving > 0 messages for resetting the backoff, and instead resets it on every successful poll.