### PR TITLE
Add support for NATS credentials loaded via service.FS

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -63,6 +63,7 @@ require (
 	github.com/microcosm-cc/bluemonday v1.0.19
 	github.com/mitchellh/mapstructure v1.4.3
 	github.com/nats-io/nats.go v1.15.0
+	github.com/nats-io/nkeys v0.3.0
 	github.com/nats-io/stan.go v0.10.2
 	github.com/nsf/jsondiff v0.0.0-20210926074059-1e845ec5d249
 	github.com/nsqio/go-nsq v1.1.0
@@ -224,7 +225,6 @@ require (
 	github.com/mtibben/percent v0.2.1 // indirect
 	github.com/nats-io/nats-server/v2 v2.8.4 // indirect
 	github.com/nats-io/nats-streaming-server v0.24.6 // indirect
-	github.com/nats-io/nkeys v0.3.0 // indirect
 	github.com/nats-io/nuid v1.0.1 // indirect
 	github.com/olekukonko/tablewriter v0.0.5 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect

--- a/internal/impl/nats/auth.go
+++ b/internal/impl/nats/auth.go
@@ -1,13 +1,22 @@
 package nats
 
 import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+
 	"github.com/nats-io/nats.go"
+	"github.com/nats-io/nkeys"
 
 	"github.com/benthosdev/benthos/v4/internal/impl/nats/auth"
 	"github.com/benthosdev/benthos/v4/public/service"
 )
 
-func authConfToOptions(auth auth.Config) []nats.Option {
+func authConfToOptions(auth auth.Config, fs *service.FS) []nats.Option {
 	var opts []nats.Option
 	if auth.NKeyFile != "" {
 		if opt, err := nats.NkeyOptionFromSeed(auth.NKeyFile); err != nil {
@@ -17,9 +26,18 @@ func authConfToOptions(auth auth.Config) []nats.Option {
 		}
 	}
 
+	// Previously we used nats.UserCredentials to authenticate. In order to
+	// support a custom FS implementation in our NATS components, we needed to
+	// switch to the nats.UserJWT option, while still preserving the behavior
+	// of the nats.UserCredentials option, which includes things like path
+	// expansing, home directory support and wiping credentials held in memory
 	if auth.UserCredentialsFile != "" {
-		opts = append(opts, nats.UserCredentials(auth.UserCredentialsFile))
+		opts = append(opts, nats.UserJWT(
+			userJWTHandler(auth.UserCredentialsFile, fs),
+			sigHandler(auth.UserCredentialsFile, fs),
+		))
 	}
+
 	return opts
 }
 
@@ -37,4 +55,97 @@ func AuthFromParsedConfig(p *service.ParsedConfig) (c auth.Config, err error) {
 		}
 	}
 	return
+}
+
+func userJWTHandler(filename string, fs *service.FS) nats.UserJWTHandler {
+	return func() (string, error) {
+		contents, err := loadFileContents(filename, fs)
+		if err != nil {
+			return "", err
+		}
+		defer wipeSlice(contents)
+
+		return nkeys.ParseDecoratedJWT(contents)
+	}
+}
+
+func sigHandler(filename string, fs *service.FS) nats.SignatureHandler {
+	return func(nonce []byte) ([]byte, error) {
+		contents, err := loadFileContents(filename, fs)
+		if err != nil {
+			return nil, err
+		}
+		defer wipeSlice(contents)
+
+		kp, err := nkeys.ParseDecoratedNKey(contents)
+		if err != nil {
+			return nil, fmt.Errorf("unable to extract key pair from file %q: %v", filename, err)
+		}
+		defer kp.Wipe()
+
+		sig, _ := kp.Sign(nonce)
+		return sig, nil
+	}
+}
+
+// Just wipe slice with 'x', for clearing contents of creds or nkey seed file.
+func wipeSlice(buf []byte) {
+	for i := range buf {
+		buf[i] = 'x'
+	}
+}
+
+func expandPath(p string) (string, error) {
+	p = os.ExpandEnv(p)
+
+	if !strings.HasPrefix(p, "~") {
+		return p, nil
+	}
+
+	home, err := homeDir()
+	if err != nil {
+		return "", err
+	}
+
+	return filepath.Join(home, p[1:]), nil
+}
+
+func homeDir() (string, error) {
+	if runtime.GOOS == "windows" {
+		homeDrive, homePath := os.Getenv("HOMEDRIVE"), os.Getenv("HOMEPATH")
+		userProfile := os.Getenv("USERPROFILE")
+
+		var home string
+		if homeDrive == "" || homePath == "" {
+			if userProfile == "" {
+				return "", errors.New("nats: failed to get home dir, require %HOMEDRIVE% and %HOMEPATH% or %USERPROFILE%")
+			}
+			home = userProfile
+		} else {
+			home = filepath.Join(homeDrive, homePath)
+		}
+
+		return home, nil
+	}
+
+	home := os.Getenv("HOME")
+	if home == "" {
+		return "", errors.New("nats: failed to get home dir, require $HOME")
+	}
+	return home, nil
+}
+
+func loadFileContents(filename string, fs *service.FS) ([]byte, error) {
+	path, err := expandPath(filename)
+	if err != nil {
+		return nil, err
+	}
+
+	f, err := fs.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	return io.ReadAll(f)
 }

--- a/internal/impl/nats/auth_test.go
+++ b/internal/impl/nats/auth_test.go
@@ -1,0 +1,64 @@
+package nats
+
+import (
+	"testing"
+	"testing/fstest"
+
+	"github.com/benthosdev/benthos/v4/internal/impl/nats/auth"
+	"github.com/benthosdev/benthos/v4/public/service"
+	"github.com/nats-io/nats.go"
+	"github.com/nats-io/nkeys"
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	NATSUserCreds = `-----BEGIN NATS USER JWT-----
+eyJ0eXAiOiJKV1QiLCJhbGciOiJlZDI1NTE5LW5rZXkifQ.eyJqdGkiOiJZMzMzT0c1SlFOVzZXU01DNUlMQjY0Uk5UR0hSRExBM1RTNFJGQ1JaMkU3NElYTzVBTU5BIiwiaWF0IjoxNjYxNzkzMjIxLCJpc3MiOiJBQTRJS1VNN0xVTlZLMlNUQ1lWN0lJWlZTWFdBWEhVUEE1RUI1SjNQQ0Y0V1pOSVFUSk1aMlpWTiIsIm5hbWUiOiJ0ZXN0Iiwic3ViIjoiVUE0RkxNRFQySVZNWEQ2SVZVRjRPRFk3UTRTSVBSU0kzVFRLN1ZMR0hFVFNDVUI0SEczQlRYWUUiLCJuYXRzIjp7InB1YiI6e30sInN1YiI6e30sInN1YnMiOi0xLCJkYXRhIjotMSwicGF5bG9hZCI6LTEsImlzc3Vlcl9hY2NvdW50IjoiQURJQjZKNk40SUNTVlZWWDMzRlc3U1FERlZaSEtLQlhJM05YUkYzWk41WEs1UDI3NVYyWFVKUU4iLCJ0eXBlIjoidXNlciIsInZlcnNpb24iOjJ9fQ.o11HW6FXVDi8cTA2OcWzYZz3tfiFpDqRNlDEZM0nNg47klTfSBkDW9eTTUC_EsZfaEOpCcy1cafPmBo4vpw_AA
+------END NATS USER JWT------
+
+************************* IMPORTANT *************************
+NKEY Seed printed below can be used to sign and prove identity.
+NKEYs are sensitive and should be treated as secrets.
+
+-----BEGIN USER NKEY SEED-----
+SUABRFVRZW4YPTRCQOFZKF45ISHYBPRXPUV7NHHZJVF3D3M2HLZLDKIJ2U
+------END USER NKEY SEED------
+
+*************************************************************`
+
+	NATSUserJWT = "eyJ0eXAiOiJKV1QiLCJhbGciOiJlZDI1NTE5LW5rZXkifQ.eyJqdGkiOiJZMzMzT0c1SlFOVzZXU01DNUlMQjY0Uk5UR0hSRExBM1RTNFJGQ1JaMkU3NElYTzVBTU5BIiwiaWF0IjoxNjYxNzkzMjIxLCJpc3MiOiJBQTRJS1VNN0xVTlZLMlNUQ1lWN0lJWlZTWFdBWEhVUEE1RUI1SjNQQ0Y0V1pOSVFUSk1aMlpWTiIsIm5hbWUiOiJ0ZXN0Iiwic3ViIjoiVUE0RkxNRFQySVZNWEQ2SVZVRjRPRFk3UTRTSVBSU0kzVFRLN1ZMR0hFVFNDVUI0SEczQlRYWUUiLCJuYXRzIjp7InB1YiI6e30sInN1YiI6e30sInN1YnMiOi0xLCJkYXRhIjotMSwicGF5bG9hZCI6LTEsImlzc3Vlcl9hY2NvdW50IjoiQURJQjZKNk40SUNTVlZWWDMzRlc3U1FERlZaSEtLQlhJM05YUkYzWk41WEs1UDI3NVYyWFVKUU4iLCJ0eXBlIjoidXNlciIsInZlcnNpb24iOjJ9fQ.o11HW6FXVDi8cTA2OcWzYZz3tfiFpDqRNlDEZM0nNg47klTfSBkDW9eTTUC_EsZfaEOpCcy1cafPmBo4vpw_AA"
+)
+
+func TestNatsAuthConfToOptions(t *testing.T) {
+	conf := auth.New()
+	conf.UserCredentialsFile = "user.creds"
+
+	fs := fstest.MapFS{
+		"user.creds": {
+			Data: []byte(NATSUserCreds),
+		},
+	}
+
+	options := &nats.Options{}
+	optFns := authConfToOptions(conf, service.NewFS(fs))
+	for _, fn := range optFns {
+		err := fn(options)
+		assert.NoError(t, err)
+	}
+
+	jwt, err := options.UserJWT()
+	assert.NoError(t, err)
+	assert.Equal(t, NATSUserJWT, jwt)
+
+	nonce := []byte("that's noncense")
+	kp, err := nkeys.ParseDecoratedNKey([]byte(NATSUserCreds))
+	assert.NoError(t, err)
+
+	sig, err := kp.Sign(nonce)
+	assert.NoError(t, err)
+
+	sigResult, err := options.SignatureCB(nonce)
+	assert.NoError(t, err)
+
+	assert.Equal(t, sig, sigResult)
+}

--- a/internal/impl/nats/input_jetstream.go
+++ b/internal/impl/nats/input_jetstream.go
@@ -86,7 +86,7 @@ func init() {
 	err := service.RegisterInput(
 		"nats_jetstream", natsJetStreamInputConfig(),
 		func(conf *service.ParsedConfig, mgr *service.Resources) (service.Input, error) {
-			return newJetStreamReaderFromConfig(conf, mgr.Logger())
+			return newJetStreamReaderFromConfig(conf, mgr.Logger(), mgr.FS())
 		})
 	if err != nil {
 		panic(err)
@@ -110,6 +110,7 @@ type jetStreamReader struct {
 	tlsConf       *tls.Config
 
 	log *service.Logger
+	fs  *service.FS
 
 	connMut  sync.Mutex
 	natsConn *nats.Conn
@@ -118,9 +119,10 @@ type jetStreamReader struct {
 	shutSig *shutdown.Signaller
 }
 
-func newJetStreamReaderFromConfig(conf *service.ParsedConfig, log *service.Logger) (*jetStreamReader, error) {
+func newJetStreamReaderFromConfig(conf *service.ParsedConfig, log *service.Logger, fs *service.FS) (*jetStreamReader, error) {
 	j := jetStreamReader{
 		log:     log,
+		fs:      fs,
 		shutSig: shutdown.NewSignaller(),
 	}
 
@@ -238,7 +240,7 @@ func (j *jetStreamReader) Connect(ctx context.Context) error {
 	if j.tlsConf != nil {
 		opts = append(opts, nats.Secure(j.tlsConf))
 	}
-	opts = append(opts, authConfToOptions(j.authConf)...)
+	opts = append(opts, authConfToOptions(j.authConf, j.fs)...)
 	if natsConn, err = nats.Connect(j.urls, opts...); err != nil {
 		return err
 	}

--- a/internal/impl/nats/input_jetstream_test.go
+++ b/internal/impl/nats/input_jetstream_test.go
@@ -24,7 +24,7 @@ auth:
 	conf, err := spec.ParseYAML(inputConfig, env)
 	require.NoError(t, err)
 
-	e, err := newJetStreamReaderFromConfig(conf, nil)
+	e, err := newJetStreamReaderFromConfig(conf, nil, nil)
 	require.NoError(t, err)
 
 	assert.Equal(t, "url1,url2", e.urls)

--- a/internal/impl/nats/output_jetstream_test.go
+++ b/internal/impl/nats/output_jetstream_test.go
@@ -27,7 +27,7 @@ auth:
 	conf, err := spec.ParseYAML(outputConfig, env)
 	require.NoError(t, err)
 
-	e, err := newJetStreamWriterFromConfig(conf, nil)
+	e, err := newJetStreamWriterFromConfig(conf, nil, nil)
 	require.NoError(t, err)
 
 	msg := service.NewMessage((nil))

--- a/internal/impl/nats/output_stream.go
+++ b/internal/impl/nats/output_stream.go
@@ -22,6 +22,7 @@ import (
 	"github.com/benthosdev/benthos/v4/internal/log"
 	"github.com/benthosdev/benthos/v4/internal/message"
 	btls "github.com/benthosdev/benthos/v4/internal/tls"
+	"github.com/benthosdev/benthos/v4/public/service"
 )
 
 func init() {
@@ -66,6 +67,7 @@ func newNATSStreamOutput(conf output.Config, mgr bundle.NewManagement) (output.S
 
 type natsStreamWriter struct {
 	log log.Modular
+	fs  *service.FS
 
 	stanConn stan.Conn
 	natsConn *nats.Conn
@@ -88,6 +90,7 @@ func newNATSStreamWriter(conf output.NATSStreamConfig, mgr bundle.NewManagement)
 
 	n := natsStreamWriter{
 		log:  mgr.Logger(),
+		fs:   service.NewFS(mgr.FS()),
 		conf: conf,
 	}
 	n.urls = strings.Join(conf.URLs, ",")
@@ -114,7 +117,7 @@ func (n *natsStreamWriter) Connect(ctx context.Context) error {
 		opts = append(opts, nats.Secure(n.tlsConf))
 	}
 
-	opts = append(opts, authConfToOptions(n.conf.Auth)...)
+	opts = append(opts, authConfToOptions(n.conf.Auth, n.fs)...)
 
 	natsConn, err := nats.Connect(n.urls, opts...)
 	if err != nil {


### PR DESCRIPTION
This PR adds support for loading NATS user credentials via `service.FS`, giving the services API another way to bootstrap itself with NATS credentials without having to put it on the filesystem.

I wanted to get this out of the way before I started a more broad rework of the current NATS components to use the services API.