### PR TITLE
Fix dump_request_log_level in http components

### DIFF
--- a/internal/httpclient/client.go
+++ b/internal/httpclient/client.go
@@ -76,11 +76,6 @@ func NewClientFromOldConfig(conf OldConfig, mgr bundle.NewManagement, opts ...Re
 	h.clientCtx, h.clientCancel = context.WithCancel(context.Background())
 	h.client = conf.OAuth2.Client(h.clientCtx)
 
-	h.client.Transport, err = newRequestLog(h.client.Transport, h.log, conf.DumpRequestLogLevel)
-	if err != nil {
-		return nil, fmt.Errorf("failed to config logger for request dump: %v", err)
-	}
-
 	if tout := conf.Timeout; len(tout) > 0 {
 		var err error
 		if h.client.Timeout, err = time.ParseDuration(tout); err != nil {
@@ -122,6 +117,11 @@ func NewClientFromOldConfig(conf OldConfig, mgr bundle.NewManagement, opts ...Re
 				Proxy: http.ProxyURL(proxyURL),
 			}
 		}
+	}
+
+	h.client.Transport, err = newRequestLog(h.client.Transport, h.log, conf.DumpRequestLogLevel)
+	if err != nil {
+		return nil, fmt.Errorf("failed to config logger for request dump: %v", err)
 	}
 
 	for _, c := range conf.BackoffOn {


### PR DESCRIPTION
Prevent the logger `roundTripper` from getting overwritten when applying TLS and proxy settings.

This came up on Discord. For both TLS and proxy settings we perform a type assertion for `*http.Transport`, which isn't going to work if the underlying type is `roundTripper`.