### PR TITLE
Add interpolated fields to JWT claims for http auth

### DIFF
--- a/internal/httpclient/auth_config.go
+++ b/internal/httpclient/auth_config.go
@@ -90,6 +90,10 @@ type JWTConfig struct {
 	rsaKey   **rsa.PrivateKey
 }
 
+type jwtSignerWithClaims interface {
+	SignWithClaims(f ifs.FS, req *http.Request, claims jwt.MapClaims) error
+}
+
 // NewJWTConfig returns a new JWTConfig with default values.
 func NewJWTConfig() JWTConfig {
 	var privKey *rsa.PrivateKey
@@ -106,6 +110,11 @@ func NewJWTConfig() JWTConfig {
 
 // Sign method to sign an HTTP request for an JWT exchange.
 func (j JWTConfig) Sign(f ifs.FS, req *http.Request) error {
+	return j.SignWithClaims(f, req, j.Claims)
+}
+
+// SignWithClaims method to sign an HTTP request for an JWT exchange with custom Claims map
+func (j JWTConfig) SignWithClaims(f ifs.FS, req *http.Request, claims jwt.MapClaims) error {
 	if !j.Enabled {
 		return nil
 	}
@@ -117,11 +126,11 @@ func (j JWTConfig) Sign(f ifs.FS, req *http.Request) error {
 	var token *jwt.Token
 	switch j.SigningMethod {
 	case "RS256":
-		token = jwt.NewWithClaims(jwt.SigningMethodRS256, j.Claims)
+		token = jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
 	case "RS384":
-		token = jwt.NewWithClaims(jwt.SigningMethodRS384, j.Claims)
+		token = jwt.NewWithClaims(jwt.SigningMethodRS384, claims)
 	case "RS512":
-		token = jwt.NewWithClaims(jwt.SigningMethodRS512, j.Claims)
+		token = jwt.NewWithClaims(jwt.SigningMethodRS512, claims)
 	default:
 		return fmt.Errorf("jwt signing method %s not acepted. Try with RS256, RS384 or RS512", j.SigningMethod)
 	}

--- a/internal/httpclient/request_test.go
+++ b/internal/httpclient/request_test.go
@@ -1,11 +1,14 @@
 package httpclient
 
 import (
+	"net/http"
 	"testing"
 
+	"github.com/benthosdev/benthos/v4/internal/filepath/ifs"
 	"github.com/benthosdev/benthos/v4/internal/manager/mock"
 	"github.com/benthosdev/benthos/v4/internal/message"
 
+	"github.com/golang-jwt/jwt"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -30,4 +33,52 @@ func TestSingleMessageHeaders(t *testing.T) {
 	assert.Equal(t, []string{"foo"}, req.Header.Values("Content-Type"))
 	assert.Equal(t, []string{"barvalue"}, req.Header.Values("more_bar"))
 	assert.Equal(t, []string(nil), req.Header.Values("ignore_baz"))
+}
+
+type jwtDynamicClaimsTester struct {
+	JWTConfig
+	resolvedClaims map[string]any
+}
+
+func (t *jwtDynamicClaimsTester) SignWithClaims(_ ifs.FS, _ *http.Request, claims jwt.MapClaims) error {
+	for k, v := range claims {
+		t.resolvedClaims[k] = v
+	}
+	return nil
+}
+
+func TestDynamicJWTClaims(t *testing.T) {
+	mockJWTConf := jwtDynamicClaimsTester{
+		JWTConfig:      NewJWTConfig(),
+		resolvedClaims: map[string]any{},
+	}
+
+	oldConf := NewOldConfig()
+	oldConf.AuthConfig.JWT = mockJWTConf.JWTConfig
+	oldConf.AuthConfig.JWT.Enabled = true
+	oldConf.AuthConfig.JWT.Claims["static_string"] = "abc"
+	oldConf.AuthConfig.JWT.Claims["static_number"] = 123
+	oldConf.AuthConfig.JWT.Claims["dynamic_string"] = "test-${! meta(\"foo\")}"
+	oldConf.AuthConfig.JWT.Claims["dynamic_number"] = "${! meta(\"foo\")}"
+
+	reqCreator, err := RequestCreatorFromOldConfig(oldConf, mock.NewManager())
+	require.NoError(t, err)
+	reqCreator.jwtSigner = &mockJWTConf
+
+	part := message.NewPart([]byte("hello world"))
+	part.MetaSetMut("foo", 456)
+
+	b := message.Batch{part}
+
+	_, err = reqCreator.Create(b)
+	require.NoError(t, err)
+
+	// Validate that the claims are interpolated as expected.
+	assert.Equal(t, len(mockJWTConf.resolvedClaims), len(oldConf.JWT.Claims))
+	assert.Equal(t, mockJWTConf.resolvedClaims, map[string]any{
+		"static_string":  "abc",
+		"static_number":  123,
+		"dynamic_string": "test-456",
+		"dynamic_number": 456.0, // should interpolate to a float64
+	})
 }


### PR DESCRIPTION
In this PR I'm adding support for interpolated fields for JWT claims. This is more or less necessary to make this usable in many current scenarios because some common claims are dynamic (`iat` and `exp` use timestamps; `jti` needs to be unique; it's also possible to need to set the `sub` dynamically). 

This is a very cautious implementation, careful to preserve existing semantics: it will only look at fields of string type. It will attempt to interpolate them only if `NumDynamicExpressions()` says there is an interpolation. If no fields are interpolated it will just fallback to the existing implementation. If only SOME of the fields are interpolated, it will only attempt to interpolate those and preserve the current logic for the others. 


NOTES:
* The current `http` processor is in the middle of a refactor from the old config to the new one, which is a much larger change and I'm struggling to wrap my head around it. Possibly other reactors might be needed (OAuth2 is completely different from everything else). I've tried to keep the logic the same as before to avoid getting in the way of a refactor.
* The general `auth` code is shared between multiple components (websocket, confluent schema registry). I've left those untouched, as they're much more static (don't work with batches, for example) and I'm not sure if interpolated fields make sense there. 
* I've *NOT* updated the documentation since it seems shared between all the components. I'm not sure what to do here, looking for guidance. 
