### PR TITLE
Add JWT signing support for EdDSA

### DIFF
--- a/internal/httpclient/auth.go
+++ b/internal/httpclient/auth.go
@@ -108,7 +108,7 @@ func jwtFieldSpec() *service.ConfigField {
 			Default(""),
 
 		service.NewStringField("signing_method").
-			Description("A method used to sign the token such as RS256, RS384 or RS512.").
+			Description("A method used to sign the token such as RS256, RS384, RS512 or EdDSA.").
 			Default(""),
 
 		service.NewAnyMapField("claims").

--- a/website/docs/components/inputs/http_client.md
+++ b/website/docs/components/inputs/http_client.md
@@ -419,7 +419,7 @@ Default: `""`
 
 ### `jwt.signing_method`
 
-A method used to sign the token such as RS256, RS384 or RS512.
+A method used to sign the token such as RS256, RS384, RS512 or EdDSA.
 
 
 Type: `string`  

--- a/website/docs/components/inputs/websocket.md
+++ b/website/docs/components/inputs/websocket.md
@@ -360,7 +360,7 @@ Default: `""`
 
 ### `jwt.signing_method`
 
-A method used to sign the token such as RS256, RS384 or RS512.
+A method used to sign the token such as RS256, RS384, RS512 or EdDSA.
 
 
 Type: `string`  

--- a/website/docs/components/outputs/http_client.md
+++ b/website/docs/components/outputs/http_client.md
@@ -398,7 +398,7 @@ Default: `""`
 
 ### `jwt.signing_method`
 
-A method used to sign the token such as RS256, RS384 or RS512.
+A method used to sign the token such as RS256, RS384, RS512 or EdDSA.
 
 
 Type: `string`  

--- a/website/docs/components/outputs/websocket.md
+++ b/website/docs/components/outputs/websocket.md
@@ -329,7 +329,7 @@ Default: `""`
 
 ### `jwt.signing_method`
 
-A method used to sign the token such as RS256, RS384 or RS512.
+A method used to sign the token such as RS256, RS384, RS512 or EdDSA.
 
 
 Type: `string`  

--- a/website/docs/components/processors/http.md
+++ b/website/docs/components/processors/http.md
@@ -412,7 +412,7 @@ Default: `""`
 
 ### `jwt.signing_method`
 
-A method used to sign the token such as RS256, RS384 or RS512.
+A method used to sign the token such as RS256, RS384, RS512 or EdDSA.
 
 
 Type: `string`  

--- a/website/docs/components/processors/schema_registry_decode.md
+++ b/website/docs/components/processors/schema_registry_decode.md
@@ -221,7 +221,7 @@ Default: `""`
 
 ### `jwt.signing_method`
 
-A method used to sign the token such as RS256, RS384 or RS512.
+A method used to sign the token such as RS256, RS384, RS512 or EdDSA.
 
 
 Type: `string`  

--- a/website/docs/components/processors/schema_registry_encode.md
+++ b/website/docs/components/processors/schema_registry_encode.md
@@ -267,7 +267,7 @@ Default: `""`
 
 ### `jwt.signing_method`
 
-A method used to sign the token such as RS256, RS384 or RS512.
+A method used to sign the token such as RS256, RS384, RS512 or EdDSA.
 
 
 Type: `string`  


### PR DESCRIPTION
This PR is adding another algorithm to the list of JWT signing algorithms, EdDSA. Slight refactor to use the more generic key type `crypto.PrivateKey`. 