### PR TITLE
Add support for `x-death` AMQP headers

### DIFF
--- a/internal/impl/amqp09/input.go
+++ b/internal/impl/amqp09/input.go
@@ -301,6 +301,11 @@ func amqpSetMetadata(p *message.Part, k string, v any) {
 			amqpSetMetadata(p, metaKey+"_"+key, value)
 		}
 		return
+	case []interface{}:
+		for key, value := range v {
+			amqpSetMetadata(p, fmt.Sprintf("%s_%v", metaKey, key), value)
+		}
+		return
 	default:
 		metaValue = ""
 	}


### PR DESCRIPTION
This is a quick solution for handling `x-death` headers.

[Official doc](https://www.rabbitmq.com/dlx.html#effects):
![image](https://user-images.githubusercontent.com/17311943/214087186-d78fdbbd-659f-4ef0-815c-702a4d9d4173.png)

It will be available in meta: `meta("x_death_0_count")`

Please let me know if I can add any more details.