### PR TITLE
Add `timestamp_unix_milli` function

### DIFF
--- a/internal/bloblang/query/functions.go
+++ b/internal/bloblang/query/functions.go
@@ -734,6 +734,19 @@ var _ = registerSimpleFunction(
 
 var _ = registerSimpleFunction(
 	NewFunctionSpec(
+		FunctionCategoryEnvironment, "timestamp_unix_milli",
+		"Returns the current unix timestamp in milliseconds.",
+		NewExampleSpec("",
+			`root.received_at = timestamp_unix_milli()`,
+		),
+	),
+	func(_ FunctionContext) (any, error) {
+		return time.Now().UnixMilli(), nil
+	},
+)
+
+var _ = registerSimpleFunction(
+	NewFunctionSpec(
 		FunctionCategoryEnvironment, "timestamp_unix_nano",
 		"Returns the current unix timestamp in nanoseconds.",
 		NewExampleSpec("",

--- a/internal/bloblang/query/functions_test.go
+++ b/internal/bloblang/query/functions_test.go
@@ -375,6 +375,32 @@ func TestRandomIntDynamic(t *testing.T) {
 	assert.Equal(t, tallies, thirdTallies)
 }
 
+func TestRandomIntMilliDynamicParallel(t *testing.T) {
+	tsFn, err := InitFunctionHelper("timestamp_unix_milli")
+	require.NoError(t, err)
+
+	e, err := InitFunctionHelper("random_int", tsFn)
+	require.NoError(t, err)
+
+	startChan := make(chan struct{})
+	wg := sync.WaitGroup{}
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-startChan
+			for j := 0; j < 100; j++ {
+				res, err := e.Exec(FunctionContext{})
+				require.NoError(t, err)
+				require.IsType(t, int64(0), res)
+			}
+		}()
+	}
+
+	close(startChan)
+	wg.Wait()
+}
+
 func TestRandomIntDynamicParallel(t *testing.T) {
 	tsFn, err := InitFunctionHelper("timestamp_unix_nano")
 	require.NoError(t, err)

--- a/website/docs/guides/bloblang/functions.md
+++ b/website/docs/guides/bloblang/functions.md
@@ -461,6 +461,17 @@ Returns the current unix timestamp in seconds.
 root.received_at = timestamp_unix()
 ```
 
+### `timestamp_unix_milli`
+
+Returns the current unix timestamp in milliseconds.
+
+#### Examples
+
+
+```coffee
+root.received_at = timestamp_unix_milli()
+```
+
 ### `timestamp_unix_nano`
 
 Returns the current unix timestamp in nanoseconds.


### PR DESCRIPTION
I've added the function `timestamp_unix_milli` to allow us to have the current unix timestamp in milliseconds.