### PR TITLE
Add `ts_unix_milli` method

### DIFF
--- a/internal/impl/pure/bloblang_time.go
+++ b/internal/impl/pure/bloblang_time.go
@@ -451,6 +451,37 @@ The output format is defined by showing how the reference time, defined to be Mo
 		panic(err)
 	}
 
+	formatTSUnixMilliSpec := bloblang.NewPluginSpec().
+		Category(query.MethodCategoryTime).
+		Beta().
+		Static().
+		Description("Attempts to format a timestamp value as a unix timestamp with millisecond precision. Timestamp values can either be a numerical unix time in seconds (with up to nanosecond precision via decimals), or a string in RFC 3339 format. The [`ts_parse`](#ts_parse) method can be used in order to parse different timestamp formats.")
+
+	formatTSUnixMilliSpecDep := asDeprecated(formatTSUnixMilliSpec)
+
+	formatTSUnixMilliSpec = formatTSUnixMilliSpec.
+		Example("",
+			`root.created_at_unix = this.created_at.ts_unix_milli()`,
+			[2]string{
+				`{"created_at":"2009-11-10T23:00:00Z"}`,
+				`{"created_at_unix":1257894000000}`,
+			},
+		)
+
+	formatTSUnixMilliCtor := func(args *bloblang.ParsedParams) (bloblang.Method, error) {
+		return bloblang.TimestampMethod(func(target time.Time) (any, error) {
+			return target.UnixMilli(), nil
+		}), nil
+	}
+
+	if err := bloblang.RegisterMethodV2("ts_unix_milli", formatTSUnixMilliSpec, formatTSUnixMilliCtor); err != nil {
+		panic(err)
+	}
+
+	if err := bloblang.RegisterMethodV2("format_timestamp_unix_milli", formatTSUnixMilliSpecDep, formatTSUnixMilliCtor); err != nil {
+		panic(err)
+	}
+
 	formatTSUnixNanoSpec := bloblang.NewPluginSpec().
 		Category(query.MethodCategoryTime).
 		Beta().

--- a/internal/impl/pure/bloblang_time_test.go
+++ b/internal/impl/pure/bloblang_time_test.go
@@ -113,6 +113,11 @@ func TestTimestampMethods(t *testing.T) {
 			output:  int64(1257894000),
 		},
 		{
+			name:    "check ts_unix_milli",
+			mapping: `root = "2009-11-10T23:00:00Z".ts_unix_milli()`,
+			output:  int64(1257894000000),
+		},
+		{
 			name:    "check ts_unix_nano",
 			mapping: `root = "2009-11-10T23:00:00Z".ts_unix_nano()`,
 			output:  int64(1257894000000000000),

--- a/website/docs/guides/bloblang/methods.md
+++ b/website/docs/guides/bloblang/methods.md
@@ -1281,6 +1281,23 @@ root.created_at_unix = this.created_at.ts_unix()
 # Out: {"created_at_unix":1257894000}
 ```
 
+### `ts_unix_milli`
+
+:::caution BETA
+This method is mostly stable but breaking changes could still be made outside of major version releases if a fundamental problem with it is found.
+:::
+Attempts to format a timestamp value as a unix timestamp with millisecond precision. Timestamp values can either be a numerical unix time in seconds (with up to nanosecond precision via decimals), or a string in RFC 3339 format. The [`ts_parse`](#ts_parse) method can be used in order to parse different timestamp formats.
+
+#### Examples
+
+
+```coffee
+root.created_at_unix = this.created_at.ts_unix_milli()
+
+# In:  {"created_at":"2009-11-10T23:00:00Z"}
+# Out: {"created_at_unix":1257894000000}
+```
+
 ### `ts_unix_nano`
 
 :::caution BETA
@@ -2915,6 +2932,10 @@ Attempts to format a timestamp value as a string according to a specified strfti
 ### `format_timestamp_unix`
 
 Attempts to format a timestamp value as a unix timestamp. Timestamp values can either be a numerical unix time in seconds (with up to nanosecond precision via decimals), or a string in RFC 3339 format. The [`ts_parse`](#ts_parse) method can be used in order to parse different timestamp formats.
+
+### `format_timestamp_unix_milli`
+
+Attempts to format a timestamp value as a unix timestamp with millisecond precision. Timestamp values can either be a numerical unix time in seconds (with up to nanosecond precision via decimals), or a string in RFC 3339 format. The [`ts_parse`](#ts_parse) method can be used in order to parse different timestamp formats.
 
 ### `format_timestamp_unix_nano`
 


### PR DESCRIPTION
I've added the `ts_unix_milli` method to allow us to get the unix timestamp with millisecond precision without needing to perform any additional operation.