### PR TITLE
feat: add `*ConfigSpec.Fields` method

### DIFF
--- a/public/service/config.go
+++ b/public/service/config.go
@@ -399,6 +399,23 @@ func (c *ConfigSpec) Field(f *ConfigField) *ConfigSpec {
 	return c
 }
 
+// Fields sets the specification of multiple field within the config spec, used
+// for linting and generating documentation for the component.
+//
+// If the provided any of the fields have an empty name then they are registered
+// as the value at the root of the config spec.
+//
+// When creating a spec with a struct constructor the fields from that struct
+// will already be inferred. However, setting fields explicitly is sometimes
+// useful for enriching their documentation with more information.
+func (c *ConfigSpec) Fields(fs ...*ConfigField) *ConfigSpec {
+	spec := c
+	for _, f := range fs {
+		spec = c.Field(f)
+	}
+	return spec
+}
+
 // Example adds an example to the plugin configuration spec that demonstrates
 // how the component can be used. An example has a title, summary, and a YAML
 // configuration showing a real use case.

--- a/public/service/config_test.go
+++ b/public/service/config_test.go
@@ -387,3 +387,40 @@ b:
 	res = iConf["d"].String(NewMessage([]byte("hello world")))
 	assert.Equal(t, "xyzzy hello world baz", res)
 }
+
+func TestConfigFields(t *testing.T) {
+	spec := NewConfigSpec().
+		Fields(
+			NewStringField("a"),
+			NewIntField("b").Default(11),
+			NewObjectField("c",
+				NewBoolField("d").Default(true),
+				NewStringField("e").Default("evalue"),
+			),
+		)
+
+	parsed, err := spec.ParseYAML(`
+      a: sample value
+      c:
+        d: false
+    `, nil)
+	require.NoError(t, err)
+
+	a, err := parsed.FieldString("a")
+	require.NoError(t, err)
+	assert.Equal(t, a, "sample value")
+
+	b, err := parsed.FieldInt("b")
+	require.NoError(t, err)
+	assert.Equal(t, b, 11)
+
+	c := parsed.Namespace("c")
+
+	d, err := c.FieldBool("d")
+	require.NoError(t, err)
+	assert.Equal(t, d, false)
+
+	e, err := c.FieldString("e")
+	require.NoError(t, err)
+	assert.Equal(t, e, "evalue")
+}


### PR DESCRIPTION
This method is syntactic sugar for declaring multiple fields with one method call and allows for _subjectively_ nicer code formatting compared to a chain of Field calls.

**Before:**

```go
service.NewConfigSpec().
  Field(
    service.NewStringField("a").
      Description("description for field a"),
  ).
  Field(
    service.NewIntField("b").
      Description("description for field b").
      Default(11),
  ).
  Field(
    service.NewObjectField("c",
      service.NewBoolField("d").
        Description("description for field d").
        Default(true),
      service.NewStringField("e").
        Description("description for field e").
        Default("evalue"),
    ).
      Description("description for field c"),
  ).
  Field(
    service.NewInterpolatedStringField("f").
      Description("description for field f f").Advanced(),
  )
```

**After:**

```go
service.NewConfigSpec().
  Fields(
    service.NewStringField("a").
      Description("description for field a"),

    service.NewIntField("b").
      Description("description for field b").
      Default(11),

    service.NewObjectField("c",
      service.NewBoolField("d").
        Description("description for field d").
        Default(true),
      service.NewStringField("e").
        Description("description for field e").
        Default("evalue"),
    ).
      Description("description for field c"),

    service.NewInterpolatedStringField("f").
      Description("description for field f").
      Advanced(),
  )
```