### PR TITLE
feat: support configuring flow control for pubsub

### DIFF
--- a/internal/component/output/config_gcp_pubsub.go
+++ b/internal/component/output/config_gcp_pubsub.go
@@ -4,6 +4,25 @@ import (
 	"github.com/benthosdev/benthos/v4/internal/metadata"
 )
 
+// GCPPubSubFlowControlConfig configures a flow control policy of the PubSub
+// client. This affects the internal buffering mechanism that the client manages
+// for each topic when publishing messages.
+type GCPPubSubFlowControlConfig struct {
+	MaxOutstandingMessages int    `json:"max_outstanding_messages" yaml:"max_outstanding_messages"`
+	MaxOutstandingBytes    int    `json:"max_outstanding_bytes" yaml:"max_outstanding_bytes"`
+	LimitExceededBehavior  string `json:"limit_exceeded_behavior" yaml:"limit_exceeded_behavior"`
+}
+
+// NewGCPPubSubFlowControlConfig creates a new flow control policy with default
+// values.
+func NewGCPPubSubFlowControlConfig() GCPPubSubFlowControlConfig {
+	return GCPPubSubFlowControlConfig{
+		MaxOutstandingMessages: 1000,
+		MaxOutstandingBytes:    -1,
+		LimitExceededBehavior:  "ignore",
+	}
+}
+
 // GCPPubSubConfig contains configuration fields for the output GCPPubSub type.
 type GCPPubSubConfig struct {
 	ProjectID      string                       `json:"project" yaml:"project"`
@@ -13,6 +32,7 @@ type GCPPubSubConfig struct {
 	Metadata       metadata.ExcludeFilterConfig `json:"metadata" yaml:"metadata"`
 	OrderingKey    string                       `json:"ordering_key" yaml:"ordering_key"`
 	Endpoint       string                       `json:"endpoint" yaml:"endpoint"`
+	FlowControl    GCPPubSubFlowControlConfig   `json:"flow_control" yaml:"flow_control"`
 }
 
 // NewGCPPubSubConfig creates a new Config with default values.
@@ -25,5 +45,6 @@ func NewGCPPubSubConfig() GCPPubSubConfig {
 		Metadata:       metadata.NewExcludeFilterConfig(),
 		OrderingKey:    "",
 		Endpoint:       "",
+		FlowControl:    NewGCPPubSubFlowControlConfig(),
 	}
 }

--- a/internal/impl/gcp/output_pubsub.go
+++ b/internal/impl/gcp/output_pubsub.go
@@ -61,6 +61,14 @@ pipeline:
 			docs.FieldString("ordering_key", "The ordering key to use for publishing messages.").IsInterpolated().Advanced(),
 			docs.FieldString("endpoint", "An optional endpoint to override the default of `pubsub.googleapis.com:443`. This can be used to connect to a region specific pubsub endpoint. For a list of valid values check out [this document.](https://cloud.google.com/pubsub/docs/reference/service_apis_overview#list_of_regional_endpoints)", "us-central1-pubsub.googleapis.com:443", "us-west3-pubsub.googleapis.com:443").HasDefault(""),
 			docs.FieldObject("metadata", "Specify criteria for which metadata values are sent as attributes.").WithChildren(metadata.ExcludeFilterFields()...),
+			docs.FieldObject("flow_control", "For a given topic, configures the PubSub client's internal buffer for messages to be published.").
+				WithChildren(
+					docs.FieldInt("max_outstanding_messages", "Maximum number of buffered messages to be published. If less than or equal to zero, this is disabled.").HasDefault(1000),
+					docs.FieldInt("max_outstanding_bytes", "Maximum size of buffered messages to be published. If less than or equal to zero, this is disabled.").HasDefault(-1),
+					docs.FieldString("limit_exceeded_behavior", "Configures the behavior when trying to publish additional messages while the flow controller is full. The available options are ignore (disable, default), block, and signal_error (publish results will return an error).").
+						HasDefault("ignore").
+						HasOptions("ignore", "block", "signal_error"),
+				).Advanced(),
 		).ChildDefaultAndTypesFromStruct(output.NewGCPPubSubConfig()),
 		Categories: []string{
 			"Services",
@@ -98,6 +106,8 @@ type gcpPubSubWriter struct {
 	topics   map[string]*pubsub.Topic
 	topicMut sync.Mutex
 
+	flowControl pubsub.FlowControlSettings
+
 	log log.Modular
 }
 
@@ -127,6 +137,22 @@ func newGCPPubSubWriter(conf output.GCPPubSubConfig, mgr bundle.NewManagement, l
 	if err != nil {
 		return nil, fmt.Errorf("failed to construct metadata filter: %w", err)
 	}
+
+	flowControl := pubsub.FlowControlSettings{
+		MaxOutstandingMessages: conf.FlowControl.MaxOutstandingMessages,
+		MaxOutstandingBytes:    conf.FlowControl.MaxOutstandingBytes,
+	}
+	switch conf.FlowControl.LimitExceededBehavior {
+	case "ignore":
+		flowControl.LimitExceededBehavior = pubsub.FlowControlIgnore
+	case "block":
+		flowControl.LimitExceededBehavior = pubsub.FlowControlBlock
+	case "signal_error":
+		flowControl.LimitExceededBehavior = pubsub.FlowControlSignalError
+	default:
+		return nil, fmt.Errorf("unrecognized flow control setting: %s", conf.FlowControl.LimitExceededBehavior)
+	}
+
 	return &gcpPubSubWriter{
 		conf:            conf,
 		log:             log,
@@ -136,6 +162,7 @@ func newGCPPubSubWriter(conf output.GCPPubSubConfig, mgr bundle.NewManagement, l
 		topicID:         topic,
 		orderingKey:     orderingKey,
 		orderingEnabled: len(conf.OrderingKey) > 0,
+		flowControl:     flowControl,
 	}, nil
 }
 
@@ -170,6 +197,7 @@ func (c *gcpPubSubWriter) getTopic(ctx context.Context, t string) (*pubsub.Topic
 		return nil, fmt.Errorf("topic '%v' does not exist", t)
 	}
 	topic.PublishSettings.Timeout = c.publishTimeout
+	topic.PublishSettings.FlowControlSettings = c.flowControl
 	topic.EnableMessageOrdering = c.orderingEnabled
 	c.topics[t] = topic
 	return topic, nil

--- a/website/docs/components/outputs/gcp_pubsub.md
+++ b/website/docs/components/outputs/gcp_pubsub.md
@@ -53,6 +53,10 @@ output:
     endpoint: ""
     metadata:
       exclude_prefixes: []
+    flow_control:
+      max_outstanding_messages: 1000
+      max_outstanding_bytes: -1
+      limit_exceeded_behavior: ignore
 ```
 
 </TabItem>
@@ -171,5 +175,37 @@ Provide a list of explicit metadata key prefixes to be excluded when adding meta
 
 Type: `array`  
 Default: `[]`  
+
+### `flow_control`
+
+For a given topic, configures the PubSub client's internal buffer for messages to be published.
+
+
+Type: `object`  
+
+### `flow_control.max_outstanding_messages`
+
+Maximum number of buffered messages to be published. If less than or equal to zero, this is disabled.
+
+
+Type: `int`  
+Default: `1000`  
+
+### `flow_control.max_outstanding_bytes`
+
+Maximum size of buffered messages to be published. If less than or equal to zero, this is disabled.
+
+
+Type: `int`  
+Default: `-1`  
+
+### `flow_control.limit_exceeded_behavior`
+
+Configures the behavior when trying to publish additional messages while the flow controller is full. The available options are ignore (disable, default), block, and signal_error (publish results will return an error).
+
+
+Type: `string`  
+Default: `"ignore"`  
+Options: `ignore`, `block`, `signal_error`.
 
 


### PR DESCRIPTION
The PubSub publisher client maintains an internal message buffer for each topic whose capacity is controlled by flow control settings. This change exposes these as Benthos config fields on the gcp_pubsub output.