### PR TITLE
Add OTLP tracer default tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ All notable changes to this project will be documented in this file.
 - New bloblang method `ts_unix_milli`.
 - JWT based HTTP authentication now supports `EdDSA`.
 - New `flow_control` fields added to the `gcp_pubsub` output.
+- The `open_telemetry_collector` tracer now automatically sets the `service.name` and `service.version` tags if they are not configured by the user.
 
 ### Fixed
 
@@ -38,6 +39,7 @@ to the [`database/sql` docs](https://pkg.go.dev/database/sql#DB.SetMaxIdleConns)
 - Unit test linting no longer incorrectly expects the `json_contains` predicate to contain a string value only.
 - Config component initialisation errors should no longer show nested path annotations.
 - Prevented panics from the `jq` processor when querying invalid types.
+- The `jaeger` tracer no longer emits the `service.version` tag automatically if the user sets the `service.name` tag explicitly.
 
 ## 4.11.0 - 2022-12-21
 

--- a/internal/impl/jaeger/tracer_jaeger.go
+++ b/internal/impl/jaeger/tracer_jaeger.go
@@ -90,10 +90,12 @@ func NewJaeger(config tracer.Config, _ bundle.NewManagement) (trace.TracerProvid
 
 	if _, ok := config.Jaeger.Tags[string(semconv.ServiceNameKey)]; !ok {
 		attrs = append(attrs, semconv.ServiceNameKey.String("benthos"))
-	}
 
-	if _, ok := config.Jaeger.Tags[string(semconv.ServiceVersionKey)]; !ok {
-		attrs = append(attrs, semconv.ServiceVersionKey.String(cli.Version))
+		// Only set the default service version tag if the user doesn't provide
+		// a custom service name tag.
+		if _, ok := config.Jaeger.Tags[string(semconv.ServiceVersionKey)]; !ok {
+			attrs = append(attrs, semconv.ServiceVersionKey.String(cli.Version))
+		}
 	}
 
 	var batchOpts []tracesdk.BatchSpanProcessorOption

--- a/internal/impl/otlp/tracer_otlp.go
+++ b/internal/impl/otlp/tracer_otlp.go
@@ -15,6 +15,7 @@ import (
 	tracesdk "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/trace"
 
+	"github.com/benthosdev/benthos/v4/internal/cli"
 	"github.com/benthosdev/benthos/v4/public/service"
 )
 
@@ -120,6 +121,16 @@ func newOtlp(config *otlp) (trace.TracerProvider, error) {
 
 	for k, v := range config.tags {
 		attrs = append(attrs, attribute.String(k, v))
+	}
+
+	if _, ok := config.tags[string(semconv.ServiceNameKey)]; !ok {
+		attrs = append(attrs, semconv.ServiceNameKey.String("benthos"))
+
+		// Only set the default service version tag if the user doesn't provide
+		// a custom service name tag.
+		if _, ok := config.tags[string(semconv.ServiceVersionKey)]; !ok {
+			attrs = append(attrs, semconv.ServiceVersionKey.String(cli.Version))
+		}
 	}
 
 	opts = append(opts, tracesdk.WithResource(resource.NewWithAttributes(semconv.SchemaURL, attrs...)))


### PR DESCRIPTION
Fixes #1695.

This adds 2 default tags to the `open_telemetry_collector` tracer: `service.name` and `service.version` (which can still be overridden via the open_telemetry_collector.tags configuration field.

Based on `jaeger` tracer fix from #1410.