### PR TITLE
Fix HTML for the `benthos blobl server` command

### DIFF
--- a/internal/cli/blobl/resources/bloglang_editor_page.html
+++ b/internal/cli/blobl/resources/bloglang_editor_page.html
@@ -165,11 +165,14 @@
     execute();
 </script>
 
-<script src="https://pagecdn.io/lib/ace/1.4.12/ace.min.js" crossorigin="anonymous"
-        integrity="sha256-T5QdmsCQO5z8tBAXMrCZ4f3RX8wVdiA0Fu17FGnU1vU="></script>
-<script src="https://pagecdn.io/lib/ace/1.4.12/theme-monokai.min.js" crossorigin="anonymous"></script>
-<script src="https://pagecdn.io/lib/ace/1.4.12/mode-coffee.min.js" crossorigin="anonymous"></script>
-<script src="https://pagecdn.io/lib/ace/1.4.12/mode-json.min.js" crossorigin="anonymous"></script>
+<script src="https://cdn.jsdelivr.net/npm/ace-builds@1.15.0/src-min-noconflict/ace.js"
+    integrity="sha256-LDAbbBwaA1DWzagfX4uwqj9iddOjEYwTiV1xQeKVdEg=" crossorigin="anonymous"></script>
+<script src="https://cdn.jsdelivr.net/npm/ace-builds@1.15.0/src-min-noconflict/theme-monokai.js"
+    integrity="sha256-eBZhzA3IYQvEVQnnT67zSIZegWYQdXDJoLr6IAOXY4M=" crossorigin="anonymous"></script>
+<script src="https://cdn.jsdelivr.net/npm/ace-builds@1.15.0/src-min-noconflict/mode-coffee.js"
+    integrity="sha256-KfNo+n6fdx9+bT4hbsyp+2n4XDp8gRIqYFdDjVRHlNQ=" crossorigin="anonymous"></script>
+<script src="https://cdn.jsdelivr.net/npm/ace-builds@1.15.0/src-min-noconflict/mode-json.js"
+    integrity="sha256-NRrS1x8Lu3yntlnkoj1sViPUV/Tyahtm7i1g4llyRYQ=" crossorigin="anonymous"></script>
 <script>
     currentMapping = getMapping();
     aceMappingEditor = ace.edit("ace-mapping");


### PR DESCRIPTION
Use the [recommended CDN](https://ace.c9.io/#nav=embedding) for the Ace library and update it to the latest version.

Unfortunately, the existing links from `pagecdn.io` don't work any more.