### PR TITLE
deps: updates wazero to 1.0.0-pre.8

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -89,7 +89,7 @@ require (
 	github.com/smira/go-statsd v1.3.2
 	github.com/snowflakedb/gosnowflake v1.6.6
 	github.com/stretchr/testify v1.8.0
-	github.com/tetratelabs/wazero v1.0.0-pre.4
+	github.com/tetratelabs/wazero v1.0.0-pre.8
 	github.com/tilinna/z85 v1.0.0
 	github.com/twmb/franz-go v1.9.0
 	github.com/twmb/franz-go/pkg/kmsg v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -1042,8 +1042,8 @@ github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PK
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
-github.com/tetratelabs/wazero v1.0.0-pre.4 h1:RBJQT5OzmORkSp6MmZDWoFEr0zXjk4pmvMKAdeUnsaI=
-github.com/tetratelabs/wazero v1.0.0-pre.4/go.mod h1:u8wrFmpdrykiFK0DFPiFm5a4+0RzsdmXYVtijBKqUVo=
+github.com/tetratelabs/wazero v1.0.0-pre.8 h1:Ir82PWj79WCppH+9ny73eGY2qv+oCnE3VwMY92cBSyI=
+github.com/tetratelabs/wazero v1.0.0-pre.8/go.mod h1:u8wrFmpdrykiFK0DFPiFm5a4+0RzsdmXYVtijBKqUVo=
 github.com/tidwall/pretty v1.0.0 h1:HsD+QiTn7sK6flMKIvNmpqz1qrpP3Ps6jOKIKMooyg4=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
 github.com/tilinna/z85 v1.0.0 h1:uqFnJBlD01dosSeo5sK1G1YGbPuwqVHqR+12OJDRjUw=

--- a/internal/impl/wasm/processor_wazero.go
+++ b/internal/impl/wasm/processor_wazero.go
@@ -115,7 +115,7 @@ func (p *wazeroAllocProcessor) newModule() (mod *moduleRunner, err error) {
 	for name, ctor := range moduleRunnerFunctionCtors {
 		builder = builder.NewFunctionBuilder().WithFunc(ctor(mod)).Export(name)
 	}
-	if _, err = builder.Instantiate(ctx, r); err != nil {
+	if _, err = builder.Instantiate(ctx); err != nil {
 		return
 	}
 
@@ -234,7 +234,7 @@ func (r *moduleRunner) allocateBytesInbound(ctx context.Context, data []byte) (c
 	})
 
 	// The pointer is a linear memory offset, which is where we write the name.
-	if !r.mod.Memory().Write(ctx, uint32(contentPtr), data) {
+	if !r.mod.Memory().Write(uint32(contentPtr), data) {
 		err = errors.New("failed to write in-bound memory")
 		return
 	}
@@ -243,7 +243,7 @@ func (r *moduleRunner) allocateBytesInbound(ctx context.Context, data []byte) (c
 
 // Deallocate memory that's out bound from the WASM module.
 func (r *moduleRunner) readBytesOutbound(ctx context.Context, contentPtr, contentSize uint32) ([]byte, error) {
-	bytes, ok := r.mod.Memory().Read(ctx, contentPtr, contentSize)
+	bytes, ok := r.mod.Memory().Read(contentPtr, contentSize)
 	if !ok {
 		return nil, errors.New("prevented read")
 	}


### PR DESCRIPTION
This updates [wazero](https://wazero.io/) to [1.0.0-pre.8](https://github.com/tetratelabs/wazero/releases/tag/v1.0.0-pre.8) which notably
* Better supports WASI including third-party integrated tests
* Adds support for writeable filesystems via FSConfig
* Improves observability with LogScopes, e.g. filesystem.
* Obviates Namespace in favor of cheaper Runtimes sharing a CompilationCache

Signed-off-by: Edoardo Vacchi <evacchi@users.noreply.github.com>
