### PR TITLE
add a new metadata entry to kafka input

### DIFF
--- a/internal/impl/kafka/input_kafka_franz.go
+++ b/internal/impl/kafka/input_kafka_franz.go
@@ -44,6 +44,7 @@ This input adds the following metadata fields to each message:
 - kafka_partition
 - kafka_offset
 - kafka_timestamp_unix
+- kafka_tombstone_message
 - All record headers
 ` + "```" + `
 `).
@@ -466,6 +467,7 @@ func recordToMessage(record *kgo.Record, multiHeader bool) *service.Message {
 	msg.MetaSet("kafka_partition", strconv.Itoa(int(record.Partition)))
 	msg.MetaSet("kafka_offset", strconv.Itoa(int(record.Offset)))
 	msg.MetaSet("kafka_timestamp_unix", strconv.FormatInt(record.Timestamp.Unix(), 10))
+	msg.MetaSet("kafka_tombstone_message", strconv.FormatBool(record.Value == nil))
 	if multiHeader {
 		// in multi header mode we gather headers so we can encode them as lists
 		var headers = map[string][]any{}

--- a/internal/impl/kafka/input_sarama_kafka.go
+++ b/internal/impl/kafka/input_sarama_kafka.go
@@ -51,6 +51,7 @@ This input adds the following metadata fields to each message:
 - kafka_offset
 - kafka_lag
 - kafka_timestamp_unix
+- kafka_tombstone_message
 - All existing message headers (version 0.11+)
 ` + "```" + `
 
@@ -416,6 +417,7 @@ func dataToPart(highestOffset int64, data *sarama.ConsumerMessage, multiHeader b
 	part.MetaSetMut("kafka_offset", int(data.Offset))
 	part.MetaSetMut("kafka_lag", lag)
 	part.MetaSetMut("kafka_timestamp_unix", data.Timestamp.Unix())
+	part.MetaSetMut("kafka_tombstone_message", data.Value == nil)
 
 	return part
 }

--- a/website/docs/components/inputs/kafka.md
+++ b/website/docs/components/inputs/kafka.md
@@ -103,6 +103,7 @@ This input adds the following metadata fields to each message:
 - kafka_offset
 - kafka_lag
 - kafka_timestamp_unix
+- kafka_tombstone_message
 - All existing message headers (version 0.11+)
 ```
 

--- a/website/docs/components/inputs/kafka_franz.md
+++ b/website/docs/components/inputs/kafka_franz.md
@@ -87,6 +87,7 @@ This input adds the following metadata fields to each message:
 - kafka_partition
 - kafka_offset
 - kafka_timestamp_unix
+- kafka_tombstone_message
 - All record headers
 ```
 


### PR DESCRIPTION
# Context

In a Kafka topic that is configured with a cleanup policy of `compact`, a producer can produce message with a `null` value to flag that on the next topic compaction, this message will be deleted from the topic.

# Description

By adding this new metadata, one does not have to check in the pipeline if the `content().length() == 0` to be able to determine if a message is a tombstone message or not. This tidies thing a tad bit

