### PR TITLE
docs: fix typo in bloblang json_schema method

### DIFF
--- a/cmd/tools/benthos_docs_gen/bloblang_test.go
+++ b/cmd/tools/benthos_docs_gen/bloblang_test.go
@@ -75,6 +75,7 @@ func TestMethodExamples(t *testing.T) {
 	})
 
 	_, err = tmpJSONFile.WriteString(`
+{
   "type":"object",
   "properties":{
     "foo":{

--- a/internal/bloblang/query/methods_structured.go
+++ b/internal/bloblang/query/methods_structured.go
@@ -706,7 +706,7 @@ var _ = registerSimpleMethod(
 		),
 		NewExampleSpec(
 			"In order to load a schema from a file use the `file` function.",
-			`root = this.json_schema(file(var("BENTHOS_TEST_BLOBLANG_SCHEMA_FILE")))`,
+			`root = this.json_schema(file(env("BENTHOS_TEST_BLOBLANG_SCHEMA_FILE")))`,
 		),
 	).Beta().Param(ParamString("schema", "The schema to check values against.")),
 	func(args *ParsedParams) (simpleMethod, error) {

--- a/website/docs/guides/bloblang/methods.md
+++ b/website/docs/guides/bloblang/methods.md
@@ -1941,7 +1941,7 @@ root = this.json_schema("""{
 In order to load a schema from a file use the `file` function.
 
 ```coffee
-root = this.json_schema(file(var("BENTHOS_TEST_BLOBLANG_SCHEMA_FILE")))
+root = this.json_schema(file(env("BENTHOS_TEST_BLOBLANG_SCHEMA_FILE")))
 ```
 
 ### `key_values`


### PR DESCRIPTION
Docs were referring to a non-existent `var` bloblang function. It was meant to be `env`.