### PR TITLE
bloblang: add `compare_bcrypt` string method

### DIFF
--- a/internal/impl/crypto/bcrypt.go
+++ b/internal/impl/crypto/bcrypt.go
@@ -1,0 +1,52 @@
+package crypto
+
+import (
+	"errors"
+
+	"github.com/benthosdev/benthos/v4/internal/bloblang/query"
+	"github.com/benthosdev/benthos/v4/public/bloblang"
+	"golang.org/x/crypto/bcrypt"
+)
+
+func registerCompareBCryptMethod() error {
+	spec := bloblang.NewPluginSpec().
+		Category(query.MethodCategoryStrings).
+		Description("Checks whether a string matches a hashed secret using bcrypt.").
+		Param(bloblang.NewStringParam("hashed_secret").Description("The hashed secret value to compare with the input.")).
+		Example("", `root.match = this.secret.compare_bcrypt("$2y$10$Dtnt5NNzVtMCOZONT705tOcS8It6krJX8bEjnDJnwxiFKsz1C.3Ay")`, [2]string{
+			`{"secret":"there-are-many-blobs-in-the-sea"}`,
+			`{"match":true}`,
+		}).
+		Example("", `root.match = this.secret.compare_bcrypt("$2y$10$Dtnt5NNzVtMCOZONT705tOcS8It6krJX8bEjnDJnwxiFKsz1C.3Ay")`, [2]string{
+			`{"secret":"will-i-ever-find-love"}`,
+			`{"match":false}`,
+		})
+
+	return bloblang.RegisterMethodV2("compare_bcrypt", spec, func(args *bloblang.ParsedParams) (bloblang.Method, error) {
+		hashedSecret, err := args.GetString("hashed_secret")
+		if err != nil {
+			return nil, err
+		}
+
+		return bloblang.StringMethod(func(source string) (interface{}, error) {
+			input := []byte(source)
+			expected := []byte(hashedSecret)
+
+			err := bcrypt.CompareHashAndPassword(expected, input)
+			if errors.Is(err, bcrypt.ErrMismatchedHashAndPassword) {
+				return false, nil
+			}
+			if err != nil {
+				return nil, err
+			}
+
+			return true, nil
+		}), nil
+	})
+}
+
+func init() {
+	if err := registerCompareBCryptMethod(); err != nil {
+		panic(err)
+	}
+}

--- a/internal/impl/crypto/bcrypt_test.go
+++ b/internal/impl/crypto/bcrypt_test.go
@@ -1,0 +1,44 @@
+package crypto
+
+import (
+	"testing"
+
+	"github.com/benthosdev/benthos/v4/public/bloblang"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBloblangCompareBCrypt(t *testing.T) {
+	// "some-fancy-secret" (cost: 10)
+	hashedPassword := "$2y$10$ywv67wCBlpSVu.M7WrZwxuivaNrY.8fe4OF0YzQPtPomk7RS.W9aq"
+
+	mapping := `
+    root = this.user_input.compare_bcrypt(this.hashed_password)
+  `
+	exe, err := bloblang.Parse(mapping)
+	require.NoError(t, err)
+
+	testCases := []struct {
+		title    string
+		input    map[string]any
+		expected bool
+	}{
+		{
+			title:    "same values",
+			input:    map[string]any{"hashed_password": hashedPassword, "user_input": "some-fancy-secret"},
+			expected: true,
+		},
+		{
+			title:    "different values",
+			input:    map[string]any{"hashed_password": hashedPassword, "user_input": "a-blobs-tale"},
+			expected: false,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.title, func(t *testing.T) {
+			res, err := exe.Query(testCase.input)
+			require.NoError(t, err)
+			require.Equal(t, res, testCase.expected)
+		})
+	}
+}

--- a/public/components/all/package.go
+++ b/public/components/all/package.go
@@ -14,6 +14,7 @@ import (
 	_ "github.com/benthosdev/benthos/v4/public/components/cassandra"
 	_ "github.com/benthosdev/benthos/v4/public/components/confluent"
 	_ "github.com/benthosdev/benthos/v4/public/components/couchbase"
+	_ "github.com/benthosdev/benthos/v4/public/components/crypto"
 	_ "github.com/benthosdev/benthos/v4/public/components/dgraph"
 	_ "github.com/benthosdev/benthos/v4/public/components/elasticsearch"
 	_ "github.com/benthosdev/benthos/v4/public/components/gcp"

--- a/public/components/crypto/package.go
+++ b/public/components/crypto/package.go
@@ -1,0 +1,6 @@
+package crypto
+
+import (
+	// Bring in the internal plugin definitions.
+	_ "github.com/benthosdev/benthos/v4/internal/impl/crypto"
+)

--- a/website/docs/guides/bloblang/methods.md
+++ b/website/docs/guides/bloblang/methods.md
@@ -193,6 +193,31 @@ root.title = this.title.capitalize()
 # Out: {"title":"The Foo Bar"}
 ```
 
+### `compare_bcrypt`
+
+Checks whether a string matches a hashed secret using bcrypt.
+
+#### Parameters
+
+**`hashed_secret`** &lt;string&gt; The hashed secret value to compare with the input.  
+
+#### Examples
+
+
+```coffee
+root.match = this.secret.compare_bcrypt("$2y$10$Dtnt5NNzVtMCOZONT705tOcS8It6krJX8bEjnDJnwxiFKsz1C.3Ay")
+
+# In:  {"secret":"there-are-many-blobs-in-the-sea"}
+# Out: {"match":true}
+```
+
+```coffee
+root.match = this.secret.compare_bcrypt("$2y$10$Dtnt5NNzVtMCOZONT705tOcS8It6krJX8bEjnDJnwxiFKsz1C.3Ay")
+
+# In:  {"secret":"will-i-ever-find-love"}
+# Out: {"match":false}
+```
+
 ### `contains`
 
 Checks whether a string contains a substring and returns a boolean result.


### PR DESCRIPTION
This method is useful for checking input strings against bcrypt-hashed secrets. Equivalent methods for scrypt and argon2 may be useful in the future as well.