### PR TITLE
Enhance integer parsing methods

### DIFF
--- a/internal/bloblang/query/type_helpers.go
+++ b/internal/bloblang/query/type_helpers.go
@@ -422,9 +422,9 @@ func IToInt(v any) (int64, error) {
 	case json.Number:
 		return t.Int64()
 	case []byte:
-		return strconv.ParseInt(string(t), 10, 64)
+		return strconv.ParseInt(string(t), 0, 64)
 	case string:
-		return strconv.ParseInt(t, 10, 64)
+		return strconv.ParseInt(t, 0, 64)
 	}
 	return 0, NewTypeError(v, ValueNumber)
 }
@@ -488,9 +488,9 @@ func IToUint(v any) (uint64, error) {
 		}
 		return uint64(i), nil
 	case []byte:
-		return strconv.ParseUint(string(t), 10, 64)
+		return strconv.ParseUint(string(t), 0, 64)
 	case string:
-		return strconv.ParseUint(t, 10, 64)
+		return strconv.ParseUint(t, 0, 64)
 	}
 	return 0, NewTypeError(v, ValueNumber)
 }

--- a/internal/impl/pure/bloblang_numbers.go
+++ b/internal/impl/pure/bloblang_numbers.go
@@ -12,7 +12,7 @@ func init() {
 			Description(`
 Converts a numerical type into a 64-bit signed integer, this is for advanced use cases where a specific data type is needed for a given component (such as the ClickHouse SQL driver).
 
-If the value is a string then an attempt will be made to parse it as a 64-bit integer. If the target value exceeds the capacity of an integer or contains decimal values then this method will throw an error. In order to convert a floating point number containing decimals first use `+"[`.round()`](#round)"+` on the value first.`).
+If the value is a string then an attempt will be made to parse it as a 64-bit integer. If the target value exceeds the capacity of an integer or contains decimal values then this method will throw an error. In order to convert a floating point number containing decimals first use `+"[`.round()`](#round)"+` on the value first. Please refer to the [`+"`strconv.ParseInt`"+` documentation](https://pkg.go.dev/strconv#ParseInt) for details regarding the supported formats.`).
 			Example("", `
 root.a = this.a.int64()
 root.b = this.b.round().int64()
@@ -21,6 +21,14 @@ root.c = this.c.int64()
 				[2]string{
 					`{"a":12,"b":12.34,"c":"12"}`,
 					`{"a":12,"b":12,"c":12}`,
+				},
+			).
+			Example("", `
+root = this.int64()
+`,
+				[2]string{
+					`"0xDEADBEEF"`,
+					`3735928559`,
 				},
 			),
 		func(args *bloblang.ParsedParams) (bloblang.Method, error) {
@@ -37,7 +45,7 @@ root.c = this.c.int64()
 			Description(`
 Converts a numerical type into a 32-bit signed integer, this is for advanced use cases where a specific data type is needed for a given component (such as the ClickHouse SQL driver).
 
-If the value is a string then an attempt will be made to parse it as a 32-bit integer. If the target value exceeds the capacity of an integer or contains decimal values then this method will throw an error. In order to convert a floating point number containing decimals first use `+"[`.round()`](#round)"+` on the value first.`).
+If the value is a string then an attempt will be made to parse it as a 32-bit integer. If the target value exceeds the capacity of an integer or contains decimal values then this method will throw an error. In order to convert a floating point number containing decimals first use `+"[`.round()`](#round)"+` on the value first. Please refer to the [`+"`strconv.ParseInt`"+` documentation](https://pkg.go.dev/strconv#ParseInt) for details regarding the supported formats.`).
 			Example("", `
 root.a = this.a.int32()
 root.b = this.b.round().int32()
@@ -46,6 +54,14 @@ root.c = this.c.int32()
 				[2]string{
 					`{"a":12,"b":12.34,"c":"12"}`,
 					`{"a":12,"b":12,"c":12}`,
+				},
+			).
+			Example("", `
+root = this.int32()
+`,
+				[2]string{
+					`"0xB70B"`,
+					`46859`,
 				},
 			),
 		func(args *bloblang.ParsedParams) (bloblang.Method, error) {
@@ -62,7 +78,7 @@ root.c = this.c.int32()
 			Description(`
 Converts a numerical type into a 64-bit unsigned integer, this is for advanced use cases where a specific data type is needed for a given component (such as the ClickHouse SQL driver).
 
-If the value is a string then an attempt will be made to parse it as a 64-bit unsigned integer. If the target value exceeds the capacity of an integer or contains decimal values then this method will throw an error. In order to convert a floating point number containing decimals first use `+"[`.round()`](#round)"+` on the value first.`).
+If the value is a string then an attempt will be made to parse it as a 64-bit unsigned integer. If the target value exceeds the capacity of an integer or contains decimal values then this method will throw an error. In order to convert a floating point number containing decimals first use `+"[`.round()`](#round)"+` on the value first. Please refer to the [`+"`strconv.ParseInt`"+` documentation](https://pkg.go.dev/strconv#ParseInt) for details regarding the supported formats.`).
 			Example("", `
 root.a = this.a.uint64()
 root.b = this.b.round().uint64()
@@ -72,6 +88,14 @@ root.d = this.d.uint64().catch(0)
 				[2]string{
 					`{"a":12,"b":12.34,"c":"12","d":-12}`,
 					`{"a":12,"b":12,"c":12,"d":0}`,
+				},
+			).
+			Example("", `
+root = this.uint64()
+`,
+				[2]string{
+					`"0xDEADBEEF"`,
+					`3735928559`,
 				},
 			),
 		func(args *bloblang.ParsedParams) (bloblang.Method, error) {
@@ -88,7 +112,7 @@ root.d = this.d.uint64().catch(0)
 			Description(`
 Converts a numerical type into a 32-bit unsigned integer, this is for advanced use cases where a specific data type is needed for a given component (such as the ClickHouse SQL driver).
 
-If the value is a string then an attempt will be made to parse it as a 32-bit unsigned integer. If the target value exceeds the capacity of an integer or contains decimal values then this method will throw an error. In order to convert a floating point number containing decimals first use `+"[`.round()`](#round)"+` on the value first.`).
+If the value is a string then an attempt will be made to parse it as a 32-bit unsigned integer. If the target value exceeds the capacity of an integer or contains decimal values then this method will throw an error. In order to convert a floating point number containing decimals first use `+"[`.round()`](#round)"+` on the value first. Please refer to the [`+"`strconv.ParseInt`"+` documentation](https://pkg.go.dev/strconv#ParseInt) for details regarding the supported formats.`).
 			Example("", `
 root.a = this.a.uint32()
 root.b = this.b.round().uint32()
@@ -98,6 +122,14 @@ root.d = this.d.uint32().catch(0)
 				[2]string{
 					`{"a":12,"b":12.34,"c":"12","d":-12}`,
 					`{"a":12,"b":12,"c":12,"d":0}`,
+				},
+			).
+			Example("", `
+root = this.uint32()
+`,
+				[2]string{
+					`"0xB70B"`,
+					`46859`,
 				},
 			),
 		func(args *bloblang.ParsedParams) (bloblang.Method, error) {

--- a/website/docs/guides/bloblang/methods.md
+++ b/website/docs/guides/bloblang/methods.md
@@ -823,7 +823,7 @@ root.new_value = this.value.floor()
 
 Converts a numerical type into a 32-bit signed integer, this is for advanced use cases where a specific data type is needed for a given component (such as the ClickHouse SQL driver).
 
-If the value is a string then an attempt will be made to parse it as a 32-bit integer. If the target value exceeds the capacity of an integer or contains decimal values then this method will throw an error. In order to convert a floating point number containing decimals first use [`.round()`](#round) on the value first.
+If the value is a string then an attempt will be made to parse it as a 32-bit integer. If the target value exceeds the capacity of an integer or contains decimal values then this method will throw an error. In order to convert a floating point number containing decimals first use [`.round()`](#round) on the value first. Please refer to the [`strconv.ParseInt` documentation](https://pkg.go.dev/strconv#ParseInt) for details regarding the supported formats.
 
 #### Examples
 
@@ -839,12 +839,21 @@ root.c = this.c.int32()
 # Out: {"a":12,"b":12,"c":12}
 ```
 
+```coffee
+
+root = this.int32()
+
+
+# In:  "0xB70B"
+# Out: 46859
+```
+
 ### `int64`
 
 
 Converts a numerical type into a 64-bit signed integer, this is for advanced use cases where a specific data type is needed for a given component (such as the ClickHouse SQL driver).
 
-If the value is a string then an attempt will be made to parse it as a 64-bit integer. If the target value exceeds the capacity of an integer or contains decimal values then this method will throw an error. In order to convert a floating point number containing decimals first use [`.round()`](#round) on the value first.
+If the value is a string then an attempt will be made to parse it as a 64-bit integer. If the target value exceeds the capacity of an integer or contains decimal values then this method will throw an error. In order to convert a floating point number containing decimals first use [`.round()`](#round) on the value first. Please refer to the [`strconv.ParseInt` documentation](https://pkg.go.dev/strconv#ParseInt) for details regarding the supported formats.
 
 #### Examples
 
@@ -858,6 +867,15 @@ root.c = this.c.int64()
 
 # In:  {"a":12,"b":12.34,"c":"12"}
 # Out: {"a":12,"b":12,"c":12}
+```
+
+```coffee
+
+root = this.int64()
+
+
+# In:  "0xDEADBEEF"
+# Out: 3735928559
 ```
 
 ### `log`
@@ -964,7 +982,7 @@ root.new_value = this.value.round()
 
 Converts a numerical type into a 32-bit unsigned integer, this is for advanced use cases where a specific data type is needed for a given component (such as the ClickHouse SQL driver).
 
-If the value is a string then an attempt will be made to parse it as a 32-bit unsigned integer. If the target value exceeds the capacity of an integer or contains decimal values then this method will throw an error. In order to convert a floating point number containing decimals first use [`.round()`](#round) on the value first.
+If the value is a string then an attempt will be made to parse it as a 32-bit unsigned integer. If the target value exceeds the capacity of an integer or contains decimal values then this method will throw an error. In order to convert a floating point number containing decimals first use [`.round()`](#round) on the value first. Please refer to the [`strconv.ParseInt` documentation](https://pkg.go.dev/strconv#ParseInt) for details regarding the supported formats.
 
 #### Examples
 
@@ -981,12 +999,21 @@ root.d = this.d.uint32().catch(0)
 # Out: {"a":12,"b":12,"c":12,"d":0}
 ```
 
+```coffee
+
+root = this.uint32()
+
+
+# In:  "0xB70B"
+# Out: 46859
+```
+
 ### `uint64`
 
 
 Converts a numerical type into a 64-bit unsigned integer, this is for advanced use cases where a specific data type is needed for a given component (such as the ClickHouse SQL driver).
 
-If the value is a string then an attempt will be made to parse it as a 64-bit unsigned integer. If the target value exceeds the capacity of an integer or contains decimal values then this method will throw an error. In order to convert a floating point number containing decimals first use [`.round()`](#round) on the value first.
+If the value is a string then an attempt will be made to parse it as a 64-bit unsigned integer. If the target value exceeds the capacity of an integer or contains decimal values then this method will throw an error. In order to convert a floating point number containing decimals first use [`.round()`](#round) on the value first. Please refer to the [`strconv.ParseInt` documentation](https://pkg.go.dev/strconv#ParseInt) for details regarding the supported formats.
 
 #### Examples
 
@@ -1001,6 +1028,15 @@ root.d = this.d.uint64().catch(0)
 
 # In:  {"a":12,"b":12.34,"c":"12","d":-12}
 # Out: {"a":12,"b":12,"c":12,"d":0}
+```
+
+```coffee
+
+root = this.uint64()
+
+
+# In:  "0xDEADBEEF"
+# Out: 3735928559
 ```
 
 ## Timestamp Manipulation


### PR DESCRIPTION
Allow the `int64()`, `int32()`, `uint64()` and `uint32()` bloblang methods to infer the number base when parsing strings.