### PR TITLE
Use optimized compression module (klauspost/compress)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -45,7 +45,6 @@ require (
 	github.com/gofrs/uuid v4.2.0+incompatible
 	github.com/golang-jwt/jwt v3.2.2+incompatible
 	github.com/golang/protobuf v1.5.2
-	github.com/golang/snappy v0.0.4
 	github.com/google/go-cmp v0.5.9
 	github.com/gorilla/handlers v1.5.1
 	github.com/gorilla/mux v1.8.0
@@ -192,6 +191,7 @@ require (
 	github.com/golang-sql/civil v0.0.0-20190719163853-cb61b32ac6fe // indirect
 	github.com/golang/glog v1.0.0 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
+	github.com/golang/snappy v0.0.4 // indirect
 	github.com/google/flatbuffers v2.0.8+incompatible // indirect
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 // indirect
 	github.com/google/uuid v1.3.0 // indirect

--- a/internal/codec/reader.go
+++ b/internal/codec/reader.go
@@ -4,7 +4,6 @@ import (
 	"archive/tar"
 	"bufio"
 	"bytes"
-	"compress/gzip"
 	"context"
 	"encoding/csv"
 	"errors"
@@ -15,6 +14,8 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+
+	"github.com/klauspost/compress/gzip"
 
 	goavro "github.com/linkedin/goavro/v2"
 

--- a/internal/codec/reader_test.go
+++ b/internal/codec/reader_test.go
@@ -3,13 +3,14 @@ package codec
 import (
 	"archive/tar"
 	"bytes"
-	"compress/gzip"
 	"context"
 	"errors"
 	"fmt"
 	"io"
 	"sync"
 	"testing"
+
+	"github.com/klauspost/compress/gzip"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/internal/impl/io/input_http_server.go
+++ b/internal/impl/io/input_http_server.go
@@ -2,7 +2,6 @@ package io
 
 import (
 	"bytes"
-	"compress/gzip"
 	"context"
 	"crypto/tls"
 	"errors"
@@ -17,6 +16,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/klauspost/compress/gzip"
 
 	"github.com/gorilla/mux"
 	"github.com/gorilla/websocket"

--- a/internal/impl/pure/bloblang_encoding.go
+++ b/internal/impl/pure/bloblang_encoding.go
@@ -31,7 +31,7 @@ root.b_len = $long_content.compress("gzip").length()
 `,
 				[2]string{
 					`hello world this is some content`,
-					`{"a_len":32999,"b_len":164}`,
+					`{"a_len":32999,"b_len":161}`,
 				},
 			).
 			Example("", `root.compressed = content().compress("lz4").encode("base64")`,

--- a/internal/impl/pure/bloblang_encoding.go
+++ b/internal/impl/pure/bloblang_encoding.go
@@ -3,14 +3,15 @@ package pure
 import (
 	"bytes"
 	"compress/bzip2"
-	"compress/flate"
-	"compress/gzip"
-	"compress/zlib"
 	"fmt"
 	"io"
 	"sync"
 
-	"github.com/golang/snappy"
+	"github.com/klauspost/compress/flate"
+	"github.com/klauspost/compress/gzip"
+	"github.com/klauspost/compress/snappy"
+	"github.com/klauspost/compress/zlib"
+
 	"github.com/pierrec/lz4/v4"
 
 	"github.com/benthosdev/benthos/v4/internal/bloblang/query"

--- a/internal/impl/pure/processor_compress_test.go
+++ b/internal/impl/pure/processor_compress_test.go
@@ -2,14 +2,14 @@ package pure_test
 
 import (
 	"bytes"
-	"compress/flate"
-	"compress/gzip"
-	"compress/zlib"
 	"context"
 	"reflect"
 	"testing"
 
-	"github.com/golang/snappy"
+	"github.com/klauspost/compress/flate"
+	"github.com/klauspost/compress/gzip"
+	"github.com/klauspost/compress/snappy"
+	"github.com/klauspost/compress/zlib"
 	"github.com/pierrec/lz4/v4"
 
 	"github.com/benthosdev/benthos/v4/internal/component/processor"

--- a/internal/impl/pure/processor_decompress_test.go
+++ b/internal/impl/pure/processor_decompress_test.go
@@ -2,14 +2,14 @@ package pure_test
 
 import (
 	"bytes"
-	"compress/flate"
-	"compress/gzip"
-	"compress/zlib"
 	"context"
 	"reflect"
 	"testing"
 
-	"github.com/golang/snappy"
+	"github.com/klauspost/compress/flate"
+	"github.com/klauspost/compress/gzip"
+	"github.com/klauspost/compress/snappy"
+	"github.com/klauspost/compress/zlib"
 	"github.com/pierrec/lz4/v4"
 
 	"github.com/benthosdev/benthos/v4/internal/component/processor"

--- a/website/docs/guides/bloblang/methods.md
+++ b/website/docs/guides/bloblang/methods.md
@@ -2663,7 +2663,7 @@ root.b_len = $long_content.compress("gzip").length()
 
 
 # In:  hello world this is some content
-# Out: {"a_len":32999,"b_len":164}
+# Out: {"a_len":32999,"b_len":161}
 ```
 
 ```coffee


### PR DESCRIPTION
Use klauspost/compress drop-in replacements for:

- snappy
- gzip
- flate
- zlib

Benchmarks for gzip comparing compress/gzip to implementation in klauspost/compress:
![image](https://user-images.githubusercontent.com/38172634/218258431-2c22dfbb-3389-4c36-aa82-abba062e4b8e.png)
