### PR TITLE
feat(streams-manager): make streams manager available from a plugin

### DIFF
--- a/internal/stream/manager/type.go
+++ b/internal/stream/manager/type.go
@@ -92,6 +92,9 @@ type Type struct {
 	lock sync.Mutex
 }
 
+// TODO: make this read-only / thread-safe.
+var Singleton *Type
+
 // New creates a new stream manager.Type.
 func New(mgr bundle.NewManagement, opts ...func(*Type)) *Type {
 	t := &Type{
@@ -103,6 +106,9 @@ func New(mgr bundle.NewManagement, opts ...func(*Type)) *Type {
 		opt(t)
 	}
 	t.registerEndpoints(t.apiEnabled)
+
+	Singleton = t
+
 	return t
 }
 

--- a/public/service/stream_manager.go
+++ b/public/service/stream_manager.go
@@ -1,0 +1,25 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/benthosdev/benthos/v4/internal/stream/manager"
+)
+
+var ErrStreamManagerNotReady = errors.New("Stream Manager is not ready")
+
+func IsStreamManagerReady() bool {
+	return manager.Singleton != nil
+}
+
+func HandleStreamCRUD(method, id, streamConfig string, timeout time.Duration) error {
+	if !IsStreamManagerReady() {
+		return ErrStreamManagerNotReady
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	return manager.Singleton.HandleDirectStreamCRUD(ctx, method, id, streamConfig)
+}


### PR DESCRIPTION
Hello,

This PR a way to go further on  #1345 idea to make plugable interface to add streams, 

This implements a public interface to a copy of the code used to process the stream API on HTTP but not using the http objects.

This code is probably not ideal and not ready to be merged as is but we would like your feedback before going further in the polishing of this implementation.

Best regards