### PR TITLE
Update NATS client libs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+### Added
+
+### Fixed
+
+- Fixed a regression bug in the `nats` components where panics occur during a flood of messages. This issue was introduced in v4.12.0 (45f785a).
+
 ## 4.12.0 - 2023-02-20
 
 ### Added

--- a/go.mod
+++ b/go.mod
@@ -62,7 +62,7 @@ require (
 	github.com/matoous/go-nanoid/v2 v2.0.0
 	github.com/microcosm-cc/bluemonday v1.0.22
 	github.com/mitchellh/mapstructure v1.4.3
-	github.com/nats-io/nats.go v1.15.0
+	github.com/nats-io/nats.go v1.23.0
 	github.com/nats-io/nkeys v0.3.0
 	github.com/nats-io/stan.go v0.10.2
 	github.com/nsf/jsondiff v0.0.0-20210926074059-1e845ec5d249

--- a/go.sum
+++ b/go.sum
@@ -802,8 +802,9 @@ github.com/nats-io/nats-streaming-server v0.24.6 h1:iIZXuPSznnYkiy0P3L0AP9zEN9Et
 github.com/nats-io/nats-streaming-server v0.24.6/go.mod h1:tdKXltY3XLeBJ21sHiZiaPl+j8sK3vcCKBWVyxeQs10=
 github.com/nats-io/nats.go v1.13.0/go.mod h1:BPko4oXsySz4aSWeFgOHLZs3G4Jq4ZAyE6/zMCxRT6w=
 github.com/nats-io/nats.go v1.14.0/go.mod h1:BPko4oXsySz4aSWeFgOHLZs3G4Jq4ZAyE6/zMCxRT6w=
-github.com/nats-io/nats.go v1.15.0 h1:3IXNBolWrwIUf2soxh6Rla8gPzYWEZQBUBK6RV21s+o=
 github.com/nats-io/nats.go v1.15.0/go.mod h1:BPko4oXsySz4aSWeFgOHLZs3G4Jq4ZAyE6/zMCxRT6w=
+github.com/nats-io/nats.go v1.23.0 h1:lR28r7IX44WjYgdiKz9GmUeW0uh/m33uD3yEjLZ2cOE=
+github.com/nats-io/nats.go v1.23.0/go.mod h1:ki/Scsa23edbh8IRZbCuNXR9TDcbvfaSijKtaqQgw+Q=
 github.com/nats-io/nkeys v0.3.0 h1:cgM5tL53EvYRU+2YLXIK0G2mJtK12Ft9oeooSZMA2G8=
 github.com/nats-io/nkeys v0.3.0/go.mod h1:gvUNGjVcM2IPr5rCsRsC6Wb3Hr2CQAm08dsxtV6A5y4=
 github.com/nats-io/nuid v1.0.1 h1:5iA8DT8V7q8WK2EScv2padNa/rTESc1KdnPw4TC2paw=

--- a/internal/impl/nats/errors.go
+++ b/internal/impl/nats/errors.go
@@ -14,7 +14,7 @@ func errorHandlerOption(logger *service.Logger) nats.Option {
 		}
 		if sub != nil {
 			logger = logger.With("subject", sub.Subject)
-			if c, ok := sub.ConsumerInfo(); ok != nil {
+			if c, err := sub.ConsumerInfo(); err == nil {
 				logger = logger.With("consumer", c.Name)
 			}
 		}
@@ -29,7 +29,7 @@ func errorHandlerOptionFromModularLogger(logger log.Modular) nats.Option {
 		}
 		if sub != nil {
 			logger = logger.With("subject", sub.Subject)
-			if c, ok := sub.ConsumerInfo(); ok != nil {
+			if c, err := sub.ConsumerInfo(); err == nil {
 				logger = logger.With("consumer", c.Name)
 			}
 		}


### PR DESCRIPTION
This fixes the panic reported in #1768 which is caused by a regression introduced in #1687 (45f785a).

#1704 also brings in this updated version of the NATS client libs, so if that can be merged, feel free to ignore this one. I haven't run the integration tests, so I'm not sure if there are any other regressions.