### PR TITLE
feat: add csv-safe codec

### DIFF
--- a/internal/codec/reader_test.go
+++ b/internal/codec/reader_test.go
@@ -347,6 +347,79 @@ func TestCSVReader(t *testing.T) {
 	testReaderSuite(t, "csv", "", data)
 }
 
+func TestCSVSafeReader(t *testing.T) {
+	data := []byte("col1,col2,col3\nfoo1,bar1,baz1\nfoo2,bar2,baz2\nfoo3,bar3,baz3")
+	testReaderSuite(
+		t, "csv-safe", "", data,
+		`{"col1":"foo1","col2":"bar1","col3":"baz1"}`,
+		`{"col1":"foo2","col2":"bar2","col3":"baz2"}`,
+		`{"col1":"foo3","col2":"bar3","col3":"baz3"}`,
+	)
+
+	data = []byte("col1,col2,col3")
+	testReaderSuite(t, "csv-safe", "", data)
+
+	data = []byte("col1,col2,col3\nfoo1,bar1\nfoo2,bar2,baz2\nfoo3,bar3,baz3")
+	testReaderSuite(
+		t, "csv-safe", "", data,
+		`{}`,
+		`{"col1":"foo2","col2":"bar2","col3":"baz2"}`,
+		`{"col1":"foo3","col2":"bar3","col3":"baz3"}`,
+	)
+}
+
+func assertPartMetadataEqual[T any](t *testing.T, p *message.Part, key string, value T) {
+	rawVal, ok := p.MetaGetMut(key)
+	assert.True(t, ok)
+	typedVal, ok := rawVal.(T)
+	assert.True(t, ok)
+	assert.Equal(t, value, typedVal)
+}
+
+func TestCsvSafeReaderMetadata(t *testing.T) {
+	data := []byte("col1,col2,col3\nfoo1,bar1,baz1\n \nfoo2,bar2\n")
+	expected := []string{
+		`{"col1":"foo1","col2":"bar1","col3":"baz1"}`, // valid line
+		`{}`, // empty line
+		`{}`, // missing a column
+	}
+	buf := noopCloser{bytes.NewReader(data), false}
+
+	ctor, err := GetReader("csv-safe", NewReaderConfig())
+	require.NoError(t, err)
+
+	ack := errors.New("default err")
+
+	r, err := ctor("", buf, func(ctx context.Context, err error) error {
+		ack = err
+		return nil
+	})
+	require.NoError(t, err)
+
+	allReads := map[string][]byte{}
+
+	for i, exp := range expected {
+		p, ackFn, err := r.Next(context.Background())
+		require.NoError(t, err)
+		require.NoError(t, ackFn(context.Background(), nil))
+		require.Len(t, p, 1)
+		assert.Equal(t, exp, string(p[0].AsBytes()))
+		assertPartMetadataEqual(t, p[0], "row_number", int32(i+2)) // header row is row 1, and compensate for index-0 range
+		allReads[string(p[0].AsBytes())] = p[0].AsBytes()
+		if i == 1 { // empty row
+			assertPartMetadataEqual(t, p[0], "row_empty", true)
+		} else if i == 2 { // row with missing column
+			assertPartMetadataEqual(t, p[0], "row_parse_error", "record on line 4: wrong number of fields")
+		}
+	}
+
+	_, _, err = r.Next(context.Background())
+	assert.EqualError(t, err, "EOF")
+
+	assert.NoError(t, r.Close(context.Background()))
+	assert.NoError(t, ack)
+}
+
 func TestPSVReader(t *testing.T) {
 	data := []byte("col1|col2|col3\nfoo1|bar1|baz1\nfoo2|bar2|baz2\nfoo3|bar3|baz3")
 	testReaderSuite(


### PR DESCRIPTION
Our use case requires a lot of error handling and tracking of file intake - so we needed a bit more resiliency for parsing failures in the csv codec. While this may or may not be desirable upstream, I still wanted to share our use case and solicit feedback. If it is helpful, even better!

- Adds 'row_number' metadata (starting at 2 for 
- Adds 'row_parse_error' metadata on any error returned from `scanner.Read()`
- Adds 'row_empty' metadata

Errors will not short-circuit this codec which is our intent, the payload in the message part will be an empty `map[string]any` with the relevant metadata so downstream configurations can handle as appropriate