### PR TITLE
feat: add ability to skip a UTF BOM in files

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -34,6 +34,7 @@ require (
 	github.com/couchbase/gocb/v2 v2.6.0
 	github.com/denisenkom/go-mssqldb v0.12.3
 	github.com/dgraph-io/ristretto v0.1.1
+	github.com/dimchansky/utfbom v1.1.1
 	github.com/dustin/go-humanize v1.0.1
 	github.com/eclipse/paho.mqtt.golang v1.4.2
 	github.com/fatih/color v1.14.1

--- a/go.sum
+++ b/go.sum
@@ -350,6 +350,8 @@ github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2/go.mod h1:SqUrOPUn
 github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f h1:lO4WD4F/rVNCu3HqELle0jiPLLBs70cWOduZpkS1E78=
 github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f/go.mod h1:cuUVRXasLTGF7a8hSLbxyZXjz+1KgoB3wDUb6vlszIc=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
+github.com/dimchansky/utfbom v1.1.1 h1:vV6w1AhK4VMnhBno/TPVCoK9U/LP0PkLCS9tbxHdi/U=
+github.com/dimchansky/utfbom v1.1.1/go.mod h1:SxdoEBH5qIqFocHMyGOXVAybYJdr71b1Q/j0mACtrfE=
 github.com/dimfeld/httptreemux v5.0.1+incompatible h1:Qj3gVcDNoOthBAqftuD596rm4wg/adLLz5xh5CmpiCA=
 github.com/dimfeld/httptreemux v5.0.1+incompatible/go.mod h1:rbUlSV+CCpv/SuqUTP/8Bk2O3LyUV436/yaRGkhP6Z0=
 github.com/dnaeon/go-vcr v1.2.0 h1:zHCHvJYTMh1N7xnV7zf1m1GPBF9Ad0Jk/whtQ1663qI=

--- a/internal/codec/reader.go
+++ b/internal/codec/reader.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/dimchansky/utfbom"
 	"github.com/klauspost/compress/gzip"
 
 	goavro "github.com/linkedin/goavro/v2"
@@ -39,6 +40,7 @@ var ReaderDocs = docs.FieldString(
 	"lines", "Consume the file in segments divided by linebreaks.",
 	"multipart", "Consumes the output of another codec and batches messages together. A batch ends when an empty message is consumed. For example, the codec `lines/multipart` could be used to consume multipart messages where an empty line indicates the end of each batch.",
 	"regex:(?m)^\\d\\d:\\d\\d:\\d\\d", "Consume the file in segments divided by regular expression.",
+	"skipbom", "Skip a byte order mark",
 	"tar", "Parse the file as a tar archive, and consume each file of the archive as a message.",
 )
 
@@ -192,7 +194,14 @@ func ioReader(codec string, conf ReaderConfig) (ioReaderConstructor, bool) {
 				r.Close()
 				return nil, err
 			}
-			return g, nil
+			unzipped := ioReadCloserWrapper{Reader: g, underlying: r}
+			return &unzipped, nil
+		}, true
+	}
+	if codec == "skipbom" {
+		return func(_ string, r io.ReadCloser) (io.ReadCloser, error) {
+			skipBom := ioReadCloserWrapper{Reader: utfbom.SkipOnly(r), underlying: r}
+			return &skipBom, nil
 		}, true
 	}
 	return nil, false
@@ -335,6 +344,21 @@ func autoCodec(conf ReaderConfig) ReaderConstructor {
 		}
 		return ctor(path, r, fn)
 	}
+}
+
+// ioReadCloserWrapper is a helper that closes both the upper and underlying reader
+// when you are creating some sort of wrapped reader where you want to ensure both
+// are closed.
+type ioReadCloserWrapper struct {
+	io.Reader
+	underlying io.ReadCloser
+}
+
+func (w ioReadCloserWrapper) Close() error {
+	if rc, ok := w.Reader.(io.Closer); ok {
+		rc.Close()
+	}
+	return w.underlying.Close()
 }
 
 //------------------------------------------------------------------------------

--- a/internal/codec/reader_test.go
+++ b/internal/codec/reader_test.go
@@ -401,6 +401,21 @@ func TestCSVGzipReaderOld(t *testing.T) {
 	)
 }
 
+func TestCSVSkipBOMReader(t *testing.T) {
+	// https://en.wikipedia.org/wiki/Byte_order_mark
+	bom := []byte{0xef, 0xbb, 0xbf}
+	data := append(bom, []byte("col1,col2,col3\nfoo1,bar1,baz1\nfoo2,bar2,baz2\nfoo3,bar3,baz3")...)
+	testReaderSuite(
+		t, "skipbom/csv", "", data,
+		`{"col1":"foo1","col2":"bar1","col3":"baz1"}`,
+		`{"col1":"foo2","col2":"bar2","col3":"baz2"}`,
+		`{"col1":"foo3","col2":"bar3","col3":"baz3"}`,
+	)
+
+	data = []byte("col1,col2,col3")
+	testReaderSuite(t, "csv", "", data)
+}
+
 func TestAllBytesReader(t *testing.T) {
 	data := []byte("foo\nbar\nbaz")
 	testReaderSuite(t, "all-bytes", "", data, "foo\nbar\nbaz")


### PR DESCRIPTION
BOMs are difficult to track down and annoying to deal with, especially when dealing with structured data.

Instead of doing this in our benthos configurations:
```
...
          - label: strip_bom
            bloblang: |
              # Some CSVs we get have a UTF-8 byte order mark, which screws up one column header.
              # This will strip byte order marks, and should have no effect if there wasn't one.
              let bom = "EFBBBF".decode("hex")
              root = this.map_each_key(key -> key.replace($bom, ""))
...
```

We preferred to have it handled at the codec level and happily process our files without any ticking time bombs lurking in our bytes