### PR TITLE
Fix the type of the messages returned by the sequence input

### DIFF
--- a/internal/impl/pure/input_sequence.go
+++ b/internal/impl/pure/input_sequence.go
@@ -177,7 +177,7 @@ type joinedMessage struct {
 
 func (j *joinedMessage) ToMsg() message.Batch {
 	part := message.NewPart(nil)
-	part.SetStructuredMut(message.CopyJSON(j.fields))
+	part.SetStructuredMut(message.CopyJSON(j.fields.Data()))
 	for k, v := range j.metadata {
 		part.MetaSetMut(k, v)
 	}

--- a/internal/impl/pure/input_sequence_test.go
+++ b/internal/impl/pure/input_sequence_test.go
@@ -255,7 +255,11 @@ func TestSequenceJoinsMergeStrategies(t *testing.T) {
 						break consumeLoop
 					}
 					assert.Equal(t, 1, tran.Payload.Len())
-					act = append(act, string(tran.Payload.Get(0).AsBytes()))
+					m := tran.Payload.Get(0)
+					payload, err := m.AsStructured()
+					require.NoError(t, err)
+					require.IsType(t, map[string]interface{}{}, payload)
+					act = append(act, string(m.AsBytes()))
 					require.NoError(t, tran.Ack(ctx, nil))
 				case <-time.After(time.Minute):
 					t.Fatalf("Failed to consume message after: %v", act)


### PR DESCRIPTION
The code needs to return the underlying Gabs container object.

Fixes #1775.