### PR TITLE
small refactory on cache memory

### DIFF
--- a/internal/impl/pure/cache_memory.go
+++ b/internal/impl/pure/cache_memory.go
@@ -177,9 +177,8 @@ func (m *memoryCache) getShard(key string) *shard {
 	if len(m.shards) == 1 {
 		return m.shards[0]
 	}
-	h := xxhash.New64()
-	_, _ = h.WriteString(key)
-	return m.shards[h.Sum64()%uint64(len(m.shards))]
+
+	return m.shards[xxhash.ChecksumString64(key)%uint64(len(m.shards))]
 }
 
 func (m *memoryCache) Get(_ context.Context, key string) ([]byte, error) {


### PR DESCRIPTION
use `xxhash.ChecksumString64` function call instead create an object and call methods

this is consistent with ./internal/impl/pure/input_sequence.go

benchmark impact:

```
name               old time/op    new time/op    delta
MemoryShards1-8      1.73µs ± 0%    1.82µs ± 0%   ~     (p=1.000 n=1+1)
MemoryShards10-8     1.96µs ± 0%    1.88µs ± 0%   ~     (p=1.000 n=1+1)
MemoryShards100-8    2.27µs ± 0%    1.89µs ± 0%   ~     (p=1.000 n=1+1)

name               old alloc/op   new alloc/op   delta
MemoryShards1-8        322B ± 0%      310B ± 0%   ~     (p=1.000 n=1+1)
MemoryShards10-8       358B ± 0%      356B ± 0%   ~     (p=1.000 n=1+1)
MemoryShards100-8      384B ± 0%      361B ± 0%   ~     (p=1.000 n=1+1)

name               old allocs/op  new allocs/op  delta
MemoryShards1-8        7.00 ± 0%      7.00 ± 0%   ~     (all equal)
MemoryShards10-8       7.00 ± 0%      7.00 ± 0%   ~     (all equal)
MemoryShards100-8      7.00 ± 0%      7.00 ± 0%   ~     (all equal)
```
