### PR TITLE
run gofumpt on codebase

### DIFF
--- a/internal/api/dynamic_crud.go
+++ b/internal/api/dynamic_crud.go
@@ -32,7 +32,7 @@ func newDynamicConfMgr() *dynamicConfMgr {
 // this hash is different to the previous config.
 func (d *dynamicConfMgr) Set(id string, conf []byte) bool {
 	hasher := sha256.New()
-	hasher.Write(conf)
+	_, _ = hasher.Write(conf)
 	newHash := hex.EncodeToString(hasher.Sum(nil))
 
 	if hash, exists := d.configHashes[id]; exists {
@@ -51,7 +51,7 @@ func (d *dynamicConfMgr) Set(id string, conf []byte) bool {
 func (d *dynamicConfMgr) Matches(id string, conf []byte) bool {
 	if hash, exists := d.configHashes[id]; exists {
 		hasher := sha256.New()
-		hasher.Write(conf)
+		_, _ = hasher.Write(conf)
 		newHash := hex.EncodeToString(hasher.Sum(nil))
 
 		if hash == newHash {

--- a/internal/bloblang/field/expression.go
+++ b/internal/bloblang/field/expression.go
@@ -23,7 +23,7 @@ func NewExpression(resolvers ...Resolver) *Expression {
 	var staticBuf bytes.Buffer
 	for _, r := range resolvers {
 		if s, is := r.(StaticResolver); is {
-			staticBuf.Write([]byte(s))
+			_, _ = staticBuf.Write([]byte(s))
 		} else {
 			e.dynamicExpressions++
 		}
@@ -60,7 +60,7 @@ func (e *Expression) resolve(index int, msg Message, escaped bool) ([]byte, erro
 		if err != nil {
 			return nil, err
 		}
-		buf.Write(b)
+		_, _ = buf.Write(b)
 	}
 	return buf.Bytes(), nil
 }

--- a/internal/bloblang/query/methods_strings.go
+++ b/internal/bloblang/query/methods_strings.go
@@ -747,7 +747,7 @@ root.h2 = this.value.hash(algorithm: "crc32", polynomial: "Koopman").encode("hex
 			}
 			hashFn = func(b []byte) ([]byte, error) {
 				hasher := hmac.New(sha1.New, key)
-				hasher.Write(b)
+				_, _ = hasher.Write(b)
 				return hasher.Sum(nil), nil
 			}
 		case "hmac_sha256", "hmac-sha256":
@@ -756,7 +756,7 @@ root.h2 = this.value.hash(algorithm: "crc32", polynomial: "Koopman").encode("hex
 			}
 			hashFn = func(b []byte) ([]byte, error) {
 				hasher := hmac.New(sha256.New, key)
-				hasher.Write(b)
+				_, _ = hasher.Write(b)
 				return hasher.Sum(nil), nil
 			}
 		case "hmac_sha512", "hmac-sha512":
@@ -765,31 +765,31 @@ root.h2 = this.value.hash(algorithm: "crc32", polynomial: "Koopman").encode("hex
 			}
 			hashFn = func(b []byte) ([]byte, error) {
 				hasher := hmac.New(sha512.New, key)
-				hasher.Write(b)
+				_, _ = hasher.Write(b)
 				return hasher.Sum(nil), nil
 			}
 		case "md5":
 			hashFn = func(b []byte) ([]byte, error) {
 				hasher := md5.New()
-				hasher.Write(b)
+				_, _ = hasher.Write(b)
 				return hasher.Sum(nil), nil
 			}
 		case "sha1":
 			hashFn = func(b []byte) ([]byte, error) {
 				hasher := sha1.New()
-				hasher.Write(b)
+				_, _ = hasher.Write(b)
 				return hasher.Sum(nil), nil
 			}
 		case "sha256":
 			hashFn = func(b []byte) ([]byte, error) {
 				hasher := sha256.New()
-				hasher.Write(b)
+				_, _ = hasher.Write(b)
 				return hasher.Sum(nil), nil
 			}
 		case "sha512":
 			hashFn = func(b []byte) ([]byte, error) {
 				hasher := sha512.New()
-				hasher.Write(b)
+				_, _ = hasher.Write(b)
 				return hasher.Sum(nil), nil
 			}
 		case "xxhash64":
@@ -811,7 +811,7 @@ root.h2 = this.value.hash(algorithm: "crc32", polynomial: "Koopman").encode("hex
 				default:
 					return nil, fmt.Errorf("unsupported crc32 hash key %q", poly)
 				}
-				hasher.Write(b)
+				_, _ = hasher.Write(b)
 				return hasher.Sum(nil), nil
 			}
 		default:
@@ -866,13 +866,13 @@ root.joined_numbers = this.numbers.map_each(this.string()).join(",")`,
 			var buf bytes.Buffer
 			for i, sv := range slice {
 				if i > 0 {
-					buf.WriteString(delim)
+					_, _ = buf.WriteString(delim)
 				}
 				switch t := sv.(type) {
 				case string:
-					buf.WriteString(t)
+					_, _ = buf.WriteString(t)
 				case []byte:
-					buf.Write(t)
+					_, _ = buf.Write(t)
 				default:
 					return nil, fmt.Errorf("failed to join element %v: %w", i, NewTypeError(sv, ValueString))
 				}

--- a/internal/config/resource_reader_test.go
+++ b/internal/config/resource_reader_test.go
@@ -66,7 +66,7 @@ processor_resources:
 	tCtx, done := context.WithTimeout(context.Background(), time.Second*30)
 	defer done()
 
-	testProc := func(name string, input, output string) {
+	testProc := func(name, input, output string) {
 		require.NoError(t, testMgr.AccessProcessor(tCtx, name, func(p processor.V1) {
 			res, err := p.ProcessBatch(tCtx, message.Batch{
 				message.NewPart([]byte(input)),
@@ -168,7 +168,7 @@ processor_resources:
 	tCtx, done := context.WithTimeout(context.Background(), time.Second*30)
 	defer done()
 
-	testProc := func(name string, input, output string) {
+	testProc := func(name, input, output string) {
 		require.NoError(t, testMgr.AccessProcessor(tCtx, name, func(p processor.V1) {
 			res, err := p.ProcessBatch(tCtx, message.Batch{
 				message.NewPart([]byte(input)),

--- a/internal/httpclient/config_test.go
+++ b/internal/httpclient/config_test.go
@@ -121,5 +121,4 @@ oauth2:
 			assert.Equal(t, test.outputConf, conf)
 		})
 	}
-
 }

--- a/internal/impl/aws/integration_kinesis_test.go
+++ b/internal/impl/aws/integration_kinesis_test.go
@@ -151,7 +151,6 @@ input:
 						vars.Var1 += fmt.Sprintf(",%v:%v", streamName, shard)
 					}
 				}
-
 			}),
 			integration.StreamTestOptPort(resource.GetPort("4566/tcp")),
 			integration.StreamTestOptAllowDupes(),

--- a/internal/impl/couchbase/client.go
+++ b/internal/impl/couchbase/client.go
@@ -20,7 +20,6 @@ type couchbaseClient struct {
 }
 
 func getClient(conf *service.ParsedConfig, mgr *service.Resources) (*couchbaseClient, error) {
-
 	// retrieve params
 	url, err := conf.FieldString("url")
 	if err != nil {

--- a/internal/impl/crypto/argon2.go
+++ b/internal/impl/crypto/argon2.go
@@ -14,9 +14,7 @@ import (
 	"github.com/benthosdev/benthos/v4/public/bloblang"
 )
 
-var (
-	errInvalidArgon2Hash = errors.New("invalid argon2 hash")
-)
+var errInvalidArgon2Hash = errors.New("invalid argon2 hash")
 
 type argon2Value struct {
 	format  string

--- a/internal/impl/crypto/jwt_sign.go
+++ b/internal/impl/crypto/jwt_sign.go
@@ -40,7 +40,6 @@ func registerSignJwtHSMethod(name string, signingMethod *jwt.SigningMethodHMAC, 
 		)
 
 	return bloblang.RegisterMethodV2(name, spec, jwtHSSigner(signingMethod))
-
 }
 
 func registerSignJwtHSMethods() error {

--- a/internal/impl/crypto/jwt_sign_test.go
+++ b/internal/impl/crypto/jwt_sign_test.go
@@ -75,5 +75,4 @@ func TestBloblangSignJwtHS(t *testing.T) {
 			require.Equal(t, inClaims, outClaims)
 		})
 	}
-
 }

--- a/internal/impl/gcp/input_pubsub.go
+++ b/internal/impl/gcp/input_pubsub.go
@@ -81,7 +81,6 @@ func newGCPPubSubInput(conf input.Config, mgr bundle.NewManagement, log log.Modu
 
 func createSubscription(conf input.GCPPubSubConfig, client *pubsub.Client, log log.Modular) {
 	subsExists, err := client.Subscription(conf.SubscriptionID).Exists(context.Background())
-
 	if err != nil {
 		log.Errorf("Error checking if subscription exists", err)
 		return

--- a/internal/impl/gcp/output_bigquery.go
+++ b/internal/impl/gcp/output_bigquery.go
@@ -357,7 +357,7 @@ func (g *gcpBigQueryOutput) WriteBatch(ctx context.Context, batch service.Messag
 	var data bytes.Buffer
 
 	if g.csvHeaderBytes != nil {
-		data.Write(g.csvHeaderBytes)
+		_, _ = data.Write(g.csvHeaderBytes)
 	}
 
 	for _, msg := range batch {
@@ -366,9 +366,9 @@ func (g *gcpBigQueryOutput) WriteBatch(ctx context.Context, batch service.Messag
 			return err
 		}
 		if data.Len() > 0 {
-			data.Write(g.newLineBytes)
+			_, _ = data.Write(g.newLineBytes)
 		}
-		data.Write(msgBytes)
+		_, _ = data.Write(msgBytes)
 	}
 
 	dataBytes := data.Bytes()

--- a/internal/impl/io/processor_subprocess.go
+++ b/internal/impl/io/processor_subprocess.go
@@ -418,12 +418,12 @@ func (s *subprocWrapper) Send(prolog, payload, epilog []byte) ([]byte, error) {
 	case errBytes, open = <-errChan:
 		tout := time.After(time.Second)
 		var errBuf bytes.Buffer
-		errBuf.Write(errBytes)
+		_, _ = errBuf.Write(errBytes)
 	flushErrLoop:
 		for open {
 			select {
 			case errBytes, open = <-errChan:
-				errBuf.Write(errBytes)
+				_, _ = errBuf.Write(errBytes)
 			case <-tout:
 				break flushErrLoop
 			}

--- a/internal/impl/kafka/input_kafka_franz.go
+++ b/internal/impl/kafka/input_kafka_franz.go
@@ -474,7 +474,7 @@ func recordToMessage(record *kgo.Record, multiHeader bool) *service.Message {
 	msg.MetaSet("kafka_timestamp_unix", strconv.FormatInt(record.Timestamp.Unix(), 10))
 	if multiHeader {
 		// in multi header mode we gather headers so we can encode them as lists
-		var headers = map[string][]any{}
+		headers := map[string][]any{}
 
 		for _, hdr := range record.Headers {
 			headers[hdr.Key] = append(headers[hdr.Key], string(hdr.Value))

--- a/internal/impl/kafka/input_sarama_kafka.go
+++ b/internal/impl/kafka/input_sarama_kafka.go
@@ -389,10 +389,10 @@ func dataToPart(highestOffset int64, data *sarama.ConsumerMessage, multiHeader b
 
 	if multiHeader {
 		// in multi header mode we gather headers so we can encode them as lists
-		var headers = map[string][]any{}
+		headers := map[string][]any{}
 
 		for _, hdr := range data.Headers {
-			var key = string(hdr.Key)
+			key := string(hdr.Key)
 			headers[key] = append(headers[key], string(hdr.Value))
 		}
 

--- a/internal/impl/nats/processor_kv.go
+++ b/internal/impl/nats/processor_kv.go
@@ -107,7 +107,6 @@ This processor adds the following metadata fields to each message, depending on 
       this.key == "" && this.operation != "keys" => [ "'key' must be set when operation is '" + this.operation + "'" ],
       this.key != "" && this.operation == "keys" => [ "'key' cannot be set when operation is '" + this.operation + "'" ],
     }`)
-
 }
 
 func init() {

--- a/internal/impl/pure/processor_unarchive.go
+++ b/internal/impl/pure/processor_unarchive.go
@@ -38,6 +38,7 @@ For the unarchive formats that contain file information (tar, zip), a metadata f
 			`csv:x`:          `Attempt to parse the message as a csv file (header required) and for each row in the file expands its contents into a json object in a new message using a custom delimiter. The custom delimiter must be a single character, e.g. the format "csv:\t" would consume a tab delimited file.`,
 		}).Description("The unarchiving format to apply."))
 }
+
 func init() {
 	err := service.RegisterProcessor(
 		"unarchive", unarchiveProcConfig(),

--- a/internal/impl/wasm/processor_wazero.go
+++ b/internal/impl/wasm/processor_wazero.go
@@ -44,7 +44,6 @@ func init() {
 		func(conf *service.ParsedConfig, mgr *service.Resources) (service.BatchProcessor, error) {
 			return newWazeroAllocProcessorFromConfig(conf, mgr)
 		})
-
 	if err != nil {
 		panic(err)
 	}

--- a/public/service/config_interpolated_string.go
+++ b/public/service/config_interpolated_string.go
@@ -8,9 +8,7 @@ import (
 	"github.com/benthosdev/benthos/v4/internal/docs"
 )
 
-var (
-	errInvalidInterpolation = errors.New("failed to parse interpolated field")
-)
+var errInvalidInterpolation = errors.New("failed to parse interpolated field")
 
 // NewInterpolatedStringField defines a new config field that describes a
 // dynamic string that supports Bloblang interpolation functions. It is then

--- a/public/wasm/tinygo/tinygo.go
+++ b/public/wasm/tinygo/tinygo.go
@@ -14,7 +14,7 @@ import (
 //
 //go:wasm-module benthos_wasm
 //export v0_msg_set_bytes
-func _v0_msg_set_bytes(ptr uint32, size uint32)
+func _v0_msg_set_bytes(ptr, size uint32)
 
 // SetMsgBytes sets the contents of the message currently being processed to the
 // value provided.
@@ -47,7 +47,7 @@ func GetMsgAsBytes() ([]byte, error) {
 
 // ptrToBytes returns a byte slice from WebAssembly compatible numeric types
 // representing its pointer and length.
-func ptrToBytes(ptr uint32, size uint32) []byte {
+func ptrToBytes(ptr, size uint32) []byte {
 	// Get a slice view of the underlying bytes in the stream. We use SliceHeader, not StringHeader
 	// as it allows us to fix the capacity to what was allocated.
 	return *(*[]byte)(unsafe.Pointer(&reflect.SliceHeader{


### PR DESCRIPTION
Hello

IMHO the [gofumpt](https://github.com/mvdan/gofumpt) is a better tool to format code than `go fmt` and we should consider run it on Makefile.