### PR TITLE
Add support for inline NATS user creds in the configuration

### DIFF
--- a/internal/impl/nats/auth.go
+++ b/internal/impl/nats/auth.go
@@ -38,6 +38,12 @@ func authConfToOptions(auth auth.Config, fs *service.FS) []nats.Option {
 		))
 	}
 
+	if auth.UserJWT != "" && auth.UserNkeySeed != "" {
+		opts = append(opts, nats.UserJWTAndSeed(
+			auth.UserJWT, auth.UserNkeySeed,
+		))
+	}
+
 	return opts
 }
 
@@ -51,6 +57,22 @@ func AuthFromParsedConfig(p *service.ParsedConfig) (c auth.Config, err error) {
 	}
 	if p.Contains("user_credentials_file") {
 		if c.UserCredentialsFile, err = p.FieldString("user_credentials_file"); err != nil {
+			return
+		}
+	}
+	if p.Contains("user_jwt") || p.Contains("user_nkey_seed") {
+		if !p.Contains("user_jwt") {
+			err = errors.New("missing auth.user_jwt config field")
+			return
+		}
+		if !p.Contains("user_nkey_seed") {
+			err = errors.New("missing auth.user_nkey_seed config field")
+			return
+		}
+		if c.UserJWT, err = p.FieldString("user_jwt"); err != nil {
+			return
+		}
+		if c.UserNkeySeed, err = p.FieldString("user_nkey_seed"); err != nil {
 			return
 		}
 	}

--- a/internal/impl/nats/auth/docs.go
+++ b/internal/impl/nats/auth/docs.go
@@ -20,7 +20,7 @@ configured in the ` + "`nkey_file`" + ` field.
 
 More details [here](https://docs.nats.io/developing-with-nats/security/nkey).
 
-#### User Credentials file
+#### User Credentials
 
 NATS server supports decentralized authentication based on JSON Web Tokens (JWT). Clients need an [user JWT](https://docs.nats.io/nats-server/configuration/securing_nats/jwt#json-web-tokens)
 and a corresponding [NKey secret](https://docs.nats.io/developing-with-nats/security/nkey) when connecting to a server
@@ -28,6 +28,9 @@ which is configured to use this authentication scheme.
 
 The ` + "`user_credentials_file`" + ` field should point to a file containing both the private key and the JWT and can be
 generated with the [nsc tool](https://docs.nats.io/nats-tools/nsc).
+
+Alternatively, the ` + "`user_jwt`" + ` field can contain a plain text JWT and the ` + "`user_nkey_seed`" + `can contain
+the plain text NKey Seed.
 
 More details [here](https://docs.nats.io/developing-with-nats/security/creds).`
 }
@@ -37,5 +40,7 @@ func FieldSpec() docs.FieldSpec {
 	return docs.FieldObject("auth", "Optional configuration of NATS authentication parameters.").WithChildren(
 		docs.FieldString("nkey_file", "An optional file containing a NKey seed.", "./seed.nk").Optional(),
 		docs.FieldString("user_credentials_file", "An optional file containing user credentials which consist of an user JWT and corresponding NKey seed.", "./user.creds").Optional(),
+		docs.FieldString("user_jwt", "An optional plain text user JWT (given along with the corresponding user NKey Seed).").Secret().Optional(),
+		docs.FieldString("user_nkey_seed", "An optional plain text user NKey Seed (given along with the corresponding user JWT).").Secret().Optional(),
 	).Advanced()
 }

--- a/internal/impl/nats/auth/type.go
+++ b/internal/impl/nats/auth/type.go
@@ -4,6 +4,8 @@ package auth
 type Config struct {
 	NKeyFile            string `json:"nkey_file" yaml:"nkey_file"`
 	UserCredentialsFile string `json:"user_credentials_file" yaml:"user_credentials_file"`
+	UserJWT             string `json:"user_jwt" yaml:"user_jwt"`
+	UserNkeySeed        string `json:"user_nkey_seed" yaml:"user_nkey_seed"`
 }
 
 // New creates a new Config instance.
@@ -11,5 +13,7 @@ func New() Config {
 	return Config{
 		NKeyFile:            "",
 		UserCredentialsFile: "",
+		UserJWT:             "",
+		UserNkeySeed:        "",
 	}
 }

--- a/internal/impl/nats/input_jetstream_test.go
+++ b/internal/impl/nats/input_jetstream_test.go
@@ -13,22 +13,58 @@ func TestInputJetStreamConfigParse(t *testing.T) {
 	spec := natsJetStreamInputConfig()
 	env := service.NewEnvironment()
 
-	inputConfig := `
+	t.Run("Successful config parsing", func(t *testing.T) {
+		inputConfig := `
 urls: [ url1, url2 ]
 subject: testsubject
 auth:
   nkey_file: test auth n key file
   user_credentials_file: test auth user creds file
+  user_jwt: test auth inline user JWT
+  user_nkey_seed: test auth inline user NKey Seed
 `
 
-	conf, err := spec.ParseYAML(inputConfig, env)
-	require.NoError(t, err)
+		conf, err := spec.ParseYAML(inputConfig, env)
+		require.NoError(t, err)
 
-	e, err := newJetStreamReaderFromConfig(conf, nil, nil)
-	require.NoError(t, err)
+		e, err := newJetStreamReaderFromConfig(conf, nil, nil)
+		require.NoError(t, err)
 
-	assert.Equal(t, "url1,url2", e.urls)
-	assert.Equal(t, "testsubject", e.subject)
-	assert.Equal(t, "test auth n key file", e.authConf.NKeyFile)
-	assert.Equal(t, "test auth user creds file", e.authConf.UserCredentialsFile)
+		assert.Equal(t, "url1,url2", e.urls)
+		assert.Equal(t, "testsubject", e.subject)
+		assert.Equal(t, "test auth n key file", e.authConf.NKeyFile)
+		assert.Equal(t, "test auth user creds file", e.authConf.UserCredentialsFile)
+		assert.Equal(t, "test auth inline user JWT", e.authConf.UserJWT)
+		assert.Equal(t, "test auth inline user NKey Seed", e.authConf.UserNkeySeed)
+	})
+
+	t.Run("Missing user_nkey_seed", func(t *testing.T) {
+		inputConfig := `
+urls: [ url1, url2 ]
+subject: testsubject
+auth:
+  user_jwt: test auth inline user JWT
+`
+
+		conf, err := spec.ParseYAML(inputConfig, env)
+		require.NoError(t, err)
+
+		_, err = newJetStreamReaderFromConfig(conf, nil, nil)
+		require.Error(t, err)
+	})
+
+	t.Run("Missing user_jwt", func(t *testing.T) {
+		inputConfig := `
+urls: [ url1, url2 ]
+subject: testsubject
+auth:
+  user_jwt: test auth inline user JWT
+`
+
+		conf, err := spec.ParseYAML(inputConfig, env)
+		require.NoError(t, err)
+
+		_, err = newJetStreamReaderFromConfig(conf, nil, nil)
+		require.Error(t, err)
+	})
 }

--- a/internal/impl/nats/input_kv_test.go
+++ b/internal/impl/nats/input_kv_test.go
@@ -13,7 +13,8 @@ func TestTestInputKVParse(t *testing.T) {
 	spec := natsKVInputConfig()
 	env := service.NewEnvironment()
 
-	inputConfig := `
+	t.Run("Successful config parsing", func(t *testing.T) {
+		inputConfig := `
 urls: [ url1, url2 ]
 bucket: testbucket
 key: testkey
@@ -23,20 +24,63 @@ meta_only: true
 auth:
   nkey_file: test auth n key file
   user_credentials_file: test auth user creds file
+  user_jwt: test auth inline user JWT
+  user_nkey_seed: test auth inline user NKey Seed
 `
 
-	conf, err := spec.ParseYAML(inputConfig, env)
-	require.NoError(t, err)
+		conf, err := spec.ParseYAML(inputConfig, env)
+		require.NoError(t, err)
 
-	e, err := newKVReader(conf, service.MockResources())
-	require.NoError(t, err)
+		e, err := newKVReader(conf, service.MockResources())
+		require.NoError(t, err)
 
-	assert.Equal(t, "url1,url2", e.urls)
-	assert.Equal(t, "testbucket", e.bucket)
-	assert.Equal(t, "testkey", e.key)
-	assert.Equal(t, true, e.ignoreDeletes)
-	assert.Equal(t, true, e.includeHistory)
-	assert.Equal(t, true, e.metaOnly)
-	assert.Equal(t, "test auth n key file", e.authConf.NKeyFile)
-	assert.Equal(t, "test auth user creds file", e.authConf.UserCredentialsFile)
+		assert.Equal(t, "url1,url2", e.urls)
+		assert.Equal(t, "testbucket", e.bucket)
+		assert.Equal(t, "testkey", e.key)
+		assert.Equal(t, true, e.ignoreDeletes)
+		assert.Equal(t, true, e.includeHistory)
+		assert.Equal(t, true, e.metaOnly)
+		assert.Equal(t, "test auth n key file", e.authConf.NKeyFile)
+		assert.Equal(t, "test auth user creds file", e.authConf.UserCredentialsFile)
+		assert.Equal(t, "test auth inline user JWT", e.authConf.UserJWT)
+		assert.Equal(t, "test auth inline user NKey Seed", e.authConf.UserNkeySeed)
+	})
+
+	t.Run("Missing user_nkey_seed", func(t *testing.T) {
+		inputConfig := `
+urls: [ url1, url2 ]
+bucket: testbucket
+key: testkey
+ignore_deletes: true
+include_history: true
+meta_only: true
+auth:
+  user_jwt: test auth inline user JWT
+`
+
+		conf, err := spec.ParseYAML(inputConfig, env)
+		require.NoError(t, err)
+
+		_, err = newJetStreamReaderFromConfig(conf, nil, nil)
+		require.Error(t, err)
+	})
+
+	t.Run("Missing user_jwt", func(t *testing.T) {
+		inputConfig := `
+urls: [ url1, url2 ]
+bucket: testbucket
+key: testkey
+ignore_deletes: true
+include_history: true
+meta_only: true
+auth:
+  user_jwt: test auth inline user JWT
+`
+
+		conf, err := spec.ParseYAML(inputConfig, env)
+		require.NoError(t, err)
+
+		_, err = newJetStreamReaderFromConfig(conf, nil, nil)
+		require.Error(t, err)
+	})
 }

--- a/internal/impl/nats/output_jetstream_test.go
+++ b/internal/impl/nats/output_jetstream_test.go
@@ -13,7 +13,8 @@ func TestOutputJetStreamConfigParse(t *testing.T) {
 	spec := natsJetStreamOutputConfig()
 	env := service.NewEnvironment()
 
-	outputConfig := `
+	t.Run("Successful config parsing", func(t *testing.T) {
+		outputConfig := `
 urls: [ url1, url2 ]
 subject: testsubject
 headers:
@@ -22,20 +23,55 @@ headers:
 auth:
   nkey_file: test auth n key file
   user_credentials_file: test auth user creds file
+  user_jwt: test auth inline user JWT
+  user_nkey_seed: test auth inline user NKey Seed
 `
 
-	conf, err := spec.ParseYAML(outputConfig, env)
-	require.NoError(t, err)
+		conf, err := spec.ParseYAML(outputConfig, env)
+		require.NoError(t, err)
 
-	e, err := newJetStreamWriterFromConfig(conf, nil, nil)
-	require.NoError(t, err)
+		e, err := newJetStreamWriterFromConfig(conf, nil, nil)
+		require.NoError(t, err)
 
-	msg := service.NewMessage((nil))
-	msg.MetaSet("Timestamp", "1651485106")
-	assert.Equal(t, "url1,url2", e.urls)
-	assert.Equal(t, "testsubject", e.subjectStr.String(msg))
-	assert.Equal(t, "application/json", e.headers["Content-Type"].String(msg))
-	assert.Equal(t, "1651485106", e.headers["Timestamp"].String(msg))
-	assert.Equal(t, "test auth n key file", e.authConf.NKeyFile)
-	assert.Equal(t, "test auth user creds file", e.authConf.UserCredentialsFile)
+		msg := service.NewMessage((nil))
+		msg.MetaSet("Timestamp", "1651485106")
+		assert.Equal(t, "url1,url2", e.urls)
+		assert.Equal(t, "testsubject", e.subjectStr.String(msg))
+		assert.Equal(t, "application/json", e.headers["Content-Type"].String(msg))
+		assert.Equal(t, "1651485106", e.headers["Timestamp"].String(msg))
+		assert.Equal(t, "test auth n key file", e.authConf.NKeyFile)
+		assert.Equal(t, "test auth user creds file", e.authConf.UserCredentialsFile)
+		assert.Equal(t, "test auth inline user JWT", e.authConf.UserJWT)
+		assert.Equal(t, "test auth inline user NKey Seed", e.authConf.UserNkeySeed)
+	})
+
+	t.Run("Missing user_nkey_seed", func(t *testing.T) {
+		inputConfig := `
+urls: [ url1, url2 ]
+subject: testsubject
+auth:
+  user_jwt: test auth inline user JWT
+`
+
+		conf, err := spec.ParseYAML(inputConfig, env)
+		require.NoError(t, err)
+
+		_, err = newJetStreamReaderFromConfig(conf, nil, nil)
+		require.Error(t, err)
+	})
+
+	t.Run("Missing user_jwt", func(t *testing.T) {
+		inputConfig := `
+urls: [ url1, url2 ]
+subject: testsubject
+auth:
+  user_jwt: test auth inline user JWT
+`
+
+		conf, err := spec.ParseYAML(inputConfig, env)
+		require.NoError(t, err)
+
+		_, err = newJetStreamReaderFromConfig(conf, nil, nil)
+		require.Error(t, err)
+	})
 }

--- a/website/docs/components/inputs/nats.md
+++ b/website/docs/components/inputs/nats.md
@@ -56,6 +56,8 @@ input:
     auth:
       nkey_file: ""
       user_credentials_file: ""
+      user_jwt: ""
+      user_nkey_seed: ""
 ```
 
 </TabItem>
@@ -88,7 +90,7 @@ configured in the `nkey_file` field.
 
 More details [here](https://docs.nats.io/developing-with-nats/security/nkey).
 
-#### User Credentials file
+#### User Credentials
 
 NATS server supports decentralized authentication based on JSON Web Tokens (JWT). Clients need an [user JWT](https://docs.nats.io/nats-server/configuration/securing_nats/jwt#json-web-tokens)
 and a corresponding [NKey secret](https://docs.nats.io/developing-with-nats/security/nkey) when connecting to a server
@@ -96,6 +98,9 @@ which is configured to use this authentication scheme.
 
 The `user_credentials_file` field should point to a file containing both the private key and the JWT and can be
 generated with the [nsc tool](https://docs.nats.io/nats-tools/nsc).
+
+Alternatively, the `user_jwt` field can contain a plain text JWT and the `user_nkey_seed`can contain
+the plain text NKey Seed.
 
 More details [here](https://docs.nats.io/developing-with-nats/security/creds).
 
@@ -323,5 +328,25 @@ Type: `string`
 
 user_credentials_file: ./user.creds
 ```
+
+### `auth.user_jwt`
+
+An optional plain text user JWT (given along with the corresponding user NKey Seed).
+:::warning Secret
+This field contains sensitive information that usually shouldn't be added to a config directly, read our [secrets page for more info](/docs/configuration/secrets).
+:::
+
+
+Type: `string`  
+
+### `auth.user_nkey_seed`
+
+An optional plain text user NKey Seed (given along with the corresponding user JWT).
+:::warning Secret
+This field contains sensitive information that usually shouldn't be added to a config directly, read our [secrets page for more info](/docs/configuration/secrets).
+:::
+
+
+Type: `string`  
 
 

--- a/website/docs/components/inputs/nats_jetstream.md
+++ b/website/docs/components/inputs/nats_jetstream.md
@@ -70,6 +70,8 @@ input:
     auth:
       nkey_file: ""
       user_credentials_file: ""
+      user_jwt: ""
+      user_nkey_seed: ""
 ```
 
 </TabItem>
@@ -108,7 +110,7 @@ configured in the `nkey_file` field.
 
 More details [here](https://docs.nats.io/developing-with-nats/security/nkey).
 
-#### User Credentials file
+#### User Credentials
 
 NATS server supports decentralized authentication based on JSON Web Tokens (JWT). Clients need an [user JWT](https://docs.nats.io/nats-server/configuration/securing_nats/jwt#json-web-tokens)
 and a corresponding [NKey secret](https://docs.nats.io/developing-with-nats/security/nkey) when connecting to a server
@@ -116,6 +118,9 @@ which is configured to use this authentication scheme.
 
 The `user_credentials_file` field should point to a file containing both the private key and the JWT and can be
 generated with the [nsc tool](https://docs.nats.io/nats-tools/nsc).
+
+Alternatively, the `user_jwt` field can contain a plain text JWT and the `user_nkey_seed`can contain
+the plain text NKey Seed.
 
 More details [here](https://docs.nats.io/developing-with-nats/security/creds).
 
@@ -394,5 +399,25 @@ Type: `string`
 
 user_credentials_file: ./user.creds
 ```
+
+### `auth.user_jwt`
+
+An optional plain text user JWT (given along with the corresponding user NKey Seed).
+:::warning Secret
+This field contains sensitive information that usually shouldn't be added to a config directly, read our [secrets page for more info](/docs/configuration/secrets).
+:::
+
+
+Type: `string`  
+
+### `auth.user_nkey_seed`
+
+An optional plain text user NKey Seed (given along with the corresponding user JWT).
+:::warning Secret
+This field contains sensitive information that usually shouldn't be added to a config directly, read our [secrets page for more info](/docs/configuration/secrets).
+:::
+
+
+Type: `string`  
 
 

--- a/website/docs/components/inputs/nats_kv.md
+++ b/website/docs/components/inputs/nats_kv.md
@@ -63,6 +63,8 @@ input:
     auth:
       nkey_file: ""
       user_credentials_file: ""
+      user_jwt: ""
+      user_nkey_seed: ""
 ```
 
 </TabItem>
@@ -97,7 +99,7 @@ configured in the `nkey_file` field.
 
 More details [here](https://docs.nats.io/developing-with-nats/security/nkey).
 
-#### User Credentials file
+#### User Credentials
 
 NATS server supports decentralized authentication based on JSON Web Tokens (JWT). Clients need an [user JWT](https://docs.nats.io/nats-server/configuration/securing_nats/jwt#json-web-tokens)
 and a corresponding [NKey secret](https://docs.nats.io/developing-with-nats/security/nkey) when connecting to a server
@@ -105,6 +107,9 @@ which is configured to use this authentication scheme.
 
 The `user_credentials_file` field should point to a file containing both the private key and the JWT and can be
 generated with the [nsc tool](https://docs.nats.io/nats-tools/nsc).
+
+Alternatively, the `user_jwt` field can contain a plain text JWT and the `user_nkey_seed`can contain
+the plain text NKey Seed.
 
 More details [here](https://docs.nats.io/developing-with-nats/security/creds).
 
@@ -355,5 +360,25 @@ Type: `string`
 
 user_credentials_file: ./user.creds
 ```
+
+### `auth.user_jwt`
+
+An optional plain text user JWT (given along with the corresponding user NKey Seed).
+:::warning Secret
+This field contains sensitive information that usually shouldn't be added to a config directly, read our [secrets page for more info](/docs/configuration/secrets).
+:::
+
+
+Type: `string`  
+
+### `auth.user_nkey_seed`
+
+An optional plain text user NKey Seed (given along with the corresponding user JWT).
+:::warning Secret
+This field contains sensitive information that usually shouldn't be added to a config directly, read our [secrets page for more info](/docs/configuration/secrets).
+:::
+
+
+Type: `string`  
 
 

--- a/website/docs/components/inputs/nats_stream.md
+++ b/website/docs/components/inputs/nats_stream.md
@@ -66,6 +66,8 @@ input:
     auth:
       nkey_file: ""
       user_credentials_file: ""
+      user_jwt: ""
+      user_nkey_seed: ""
 ```
 
 </TabItem>
@@ -102,7 +104,7 @@ configured in the `nkey_file` field.
 
 More details [here](https://docs.nats.io/developing-with-nats/security/nkey).
 
-#### User Credentials file
+#### User Credentials
 
 NATS server supports decentralized authentication based on JSON Web Tokens (JWT). Clients need an [user JWT](https://docs.nats.io/nats-server/configuration/securing_nats/jwt#json-web-tokens)
 and a corresponding [NKey secret](https://docs.nats.io/developing-with-nats/security/nkey) when connecting to a server
@@ -110,6 +112,9 @@ which is configured to use this authentication scheme.
 
 The `user_credentials_file` field should point to a file containing both the private key and the JWT and can be
 generated with the [nsc tool](https://docs.nats.io/nats-tools/nsc).
+
+Alternatively, the `user_jwt` field can contain a plain text JWT and the `user_nkey_seed`can contain
+the plain text NKey Seed.
 
 More details [here](https://docs.nats.io/developing-with-nats/security/creds).
 
@@ -379,5 +384,27 @@ Default: `""`
 
 user_credentials_file: ./user.creds
 ```
+
+### `auth.user_jwt`
+
+An optional plain text user JWT (given along with the corresponding user NKey Seed).
+:::warning Secret
+This field contains sensitive information that usually shouldn't be added to a config directly, read our [secrets page for more info](/docs/configuration/secrets).
+:::
+
+
+Type: `string`  
+Default: `""`  
+
+### `auth.user_nkey_seed`
+
+An optional plain text user NKey Seed (given along with the corresponding user JWT).
+:::warning Secret
+This field contains sensitive information that usually shouldn't be added to a config directly, read our [secrets page for more info](/docs/configuration/secrets).
+:::
+
+
+Type: `string`  
+Default: `""`  
 
 

--- a/website/docs/components/outputs/nats.md
+++ b/website/docs/components/outputs/nats.md
@@ -57,6 +57,8 @@ output:
     auth:
       nkey_file: ""
       user_credentials_file: ""
+      user_jwt: ""
+      user_nkey_seed: ""
 ```
 
 </TabItem>
@@ -80,7 +82,7 @@ configured in the `nkey_file` field.
 
 More details [here](https://docs.nats.io/developing-with-nats/security/nkey).
 
-#### User Credentials file
+#### User Credentials
 
 NATS server supports decentralized authentication based on JSON Web Tokens (JWT). Clients need an [user JWT](https://docs.nats.io/nats-server/configuration/securing_nats/jwt#json-web-tokens)
 and a corresponding [NKey secret](https://docs.nats.io/developing-with-nats/security/nkey) when connecting to a server
@@ -88,6 +90,9 @@ which is configured to use this authentication scheme.
 
 The `user_credentials_file` field should point to a file containing both the private key and the JWT and can be
 generated with the [nsc tool](https://docs.nats.io/nats-tools/nsc).
+
+Alternatively, the `user_jwt` field can contain a plain text JWT and the `user_nkey_seed`can contain
+the plain text NKey Seed.
 
 More details [here](https://docs.nats.io/developing-with-nats/security/creds).
 
@@ -320,5 +325,25 @@ Type: `string`
 
 user_credentials_file: ./user.creds
 ```
+
+### `auth.user_jwt`
+
+An optional plain text user JWT (given along with the corresponding user NKey Seed).
+:::warning Secret
+This field contains sensitive information that usually shouldn't be added to a config directly, read our [secrets page for more info](/docs/configuration/secrets).
+:::
+
+
+Type: `string`  
+
+### `auth.user_nkey_seed`
+
+An optional plain text user NKey Seed (given along with the corresponding user JWT).
+:::warning Secret
+This field contains sensitive information that usually shouldn't be added to a config directly, read our [secrets page for more info](/docs/configuration/secrets).
+:::
+
+
+Type: `string`  
 
 

--- a/website/docs/components/outputs/nats_jetstream.md
+++ b/website/docs/components/outputs/nats_jetstream.md
@@ -62,6 +62,8 @@ output:
     auth:
       nkey_file: ""
       user_credentials_file: ""
+      user_jwt: ""
+      user_nkey_seed: ""
 ```
 
 </TabItem>
@@ -83,7 +85,7 @@ configured in the `nkey_file` field.
 
 More details [here](https://docs.nats.io/developing-with-nats/security/nkey).
 
-#### User Credentials file
+#### User Credentials
 
 NATS server supports decentralized authentication based on JSON Web Tokens (JWT). Clients need an [user JWT](https://docs.nats.io/nats-server/configuration/securing_nats/jwt#json-web-tokens)
 and a corresponding [NKey secret](https://docs.nats.io/developing-with-nats/security/nkey) when connecting to a server
@@ -91,6 +93,9 @@ which is configured to use this authentication scheme.
 
 The `user_credentials_file` field should point to a file containing both the private key and the JWT and can be
 generated with the [nsc tool](https://docs.nats.io/nats-tools/nsc).
+
+Alternatively, the `user_jwt` field can contain a plain text JWT and the `user_nkey_seed`can contain
+the plain text NKey Seed.
 
 More details [here](https://docs.nats.io/developing-with-nats/security/creds).
 
@@ -328,5 +333,25 @@ Type: `string`
 
 user_credentials_file: ./user.creds
 ```
+
+### `auth.user_jwt`
+
+An optional plain text user JWT (given along with the corresponding user NKey Seed).
+:::warning Secret
+This field contains sensitive information that usually shouldn't be added to a config directly, read our [secrets page for more info](/docs/configuration/secrets).
+:::
+
+
+Type: `string`  
+
+### `auth.user_nkey_seed`
+
+An optional plain text user NKey Seed (given along with the corresponding user JWT).
+:::warning Secret
+This field contains sensitive information that usually shouldn't be added to a config directly, read our [secrets page for more info](/docs/configuration/secrets).
+:::
+
+
+Type: `string`  
 
 

--- a/website/docs/components/outputs/nats_kv.md
+++ b/website/docs/components/outputs/nats_kv.md
@@ -62,6 +62,8 @@ output:
     auth:
       nkey_file: ""
       user_credentials_file: ""
+      user_jwt: ""
+      user_nkey_seed: ""
 ```
 
 </TabItem>
@@ -87,7 +89,7 @@ configured in the `nkey_file` field.
 
 More details [here](https://docs.nats.io/developing-with-nats/security/nkey).
 
-#### User Credentials file
+#### User Credentials
 
 NATS server supports decentralized authentication based on JSON Web Tokens (JWT). Clients need an [user JWT](https://docs.nats.io/nats-server/configuration/securing_nats/jwt#json-web-tokens)
 and a corresponding [NKey secret](https://docs.nats.io/developing-with-nats/security/nkey) when connecting to a server
@@ -95,6 +97,9 @@ which is configured to use this authentication scheme.
 
 The `user_credentials_file` field should point to a file containing both the private key and the JWT and can be
 generated with the [nsc tool](https://docs.nats.io/nats-tools/nsc).
+
+Alternatively, the `user_jwt` field can contain a plain text JWT and the `user_nkey_seed`can contain
+the plain text NKey Seed.
 
 More details [here](https://docs.nats.io/developing-with-nats/security/creds).
 
@@ -327,5 +332,25 @@ Type: `string`
 
 user_credentials_file: ./user.creds
 ```
+
+### `auth.user_jwt`
+
+An optional plain text user JWT (given along with the corresponding user NKey Seed).
+:::warning Secret
+This field contains sensitive information that usually shouldn't be added to a config directly, read our [secrets page for more info](/docs/configuration/secrets).
+:::
+
+
+Type: `string`  
+
+### `auth.user_nkey_seed`
+
+An optional plain text user NKey Seed (given along with the corresponding user JWT).
+:::warning Secret
+This field contains sensitive information that usually shouldn't be added to a config directly, read our [secrets page for more info](/docs/configuration/secrets).
+:::
+
+
+Type: `string`  
 
 

--- a/website/docs/components/outputs/nats_stream.md
+++ b/website/docs/components/outputs/nats_stream.md
@@ -59,6 +59,8 @@ output:
     auth:
       nkey_file: ""
       user_credentials_file: ""
+      user_jwt: ""
+      user_nkey_seed: ""
 ```
 
 </TabItem>
@@ -80,7 +82,7 @@ configured in the `nkey_file` field.
 
 More details [here](https://docs.nats.io/developing-with-nats/security/nkey).
 
-#### User Credentials file
+#### User Credentials
 
 NATS server supports decentralized authentication based on JSON Web Tokens (JWT). Clients need an [user JWT](https://docs.nats.io/nats-server/configuration/securing_nats/jwt#json-web-tokens)
 and a corresponding [NKey secret](https://docs.nats.io/developing-with-nats/security/nkey) when connecting to a server
@@ -88,6 +90,9 @@ which is configured to use this authentication scheme.
 
 The `user_credentials_file` field should point to a file containing both the private key and the JWT and can be
 generated with the [nsc tool](https://docs.nats.io/nats-tools/nsc).
+
+Alternatively, the `user_jwt` field can contain a plain text JWT and the `user_nkey_seed`can contain
+the plain text NKey Seed.
 
 More details [here](https://docs.nats.io/developing-with-nats/security/creds).
 
@@ -323,5 +328,27 @@ Default: `""`
 
 user_credentials_file: ./user.creds
 ```
+
+### `auth.user_jwt`
+
+An optional plain text user JWT (given along with the corresponding user NKey Seed).
+:::warning Secret
+This field contains sensitive information that usually shouldn't be added to a config directly, read our [secrets page for more info](/docs/configuration/secrets).
+:::
+
+
+Type: `string`  
+Default: `""`  
+
+### `auth.user_nkey_seed`
+
+An optional plain text user NKey Seed (given along with the corresponding user JWT).
+:::warning Secret
+This field contains sensitive information that usually shouldn't be added to a config directly, read our [secrets page for more info](/docs/configuration/secrets).
+:::
+
+
+Type: `string`  
+Default: `""`  
 
 

--- a/website/docs/components/processors/nats_kv.md
+++ b/website/docs/components/processors/nats_kv.md
@@ -61,6 +61,8 @@ nats_kv:
   auth:
     nkey_file: ""
     user_credentials_file: ""
+    user_jwt: ""
+    user_nkey_seed: ""
 ```
 
 </TabItem>
@@ -113,7 +115,7 @@ configured in the `nkey_file` field.
 
 More details [here](https://docs.nats.io/developing-with-nats/security/nkey).
 
-#### User Credentials file
+#### User Credentials
 
 NATS server supports decentralized authentication based on JSON Web Tokens (JWT). Clients need an [user JWT](https://docs.nats.io/nats-server/configuration/securing_nats/jwt#json-web-tokens)
 and a corresponding [NKey secret](https://docs.nats.io/developing-with-nats/security/nkey) when connecting to a server
@@ -121,6 +123,9 @@ which is configured to use this authentication scheme.
 
 The `user_credentials_file` field should point to a file containing both the private key and the JWT and can be
 generated with the [nsc tool](https://docs.nats.io/nats-tools/nsc).
+
+Alternatively, the `user_jwt` field can contain a plain text JWT and the `user_nkey_seed`can contain
+the plain text NKey Seed.
 
 More details [here](https://docs.nats.io/developing-with-nats/security/creds).
 
@@ -382,5 +387,25 @@ Type: `string`
 
 user_credentials_file: ./user.creds
 ```
+
+### `auth.user_jwt`
+
+An optional plain text user JWT (given along with the corresponding user NKey Seed).
+:::warning Secret
+This field contains sensitive information that usually shouldn't be added to a config directly, read our [secrets page for more info](/docs/configuration/secrets).
+:::
+
+
+Type: `string`  
+
+### `auth.user_nkey_seed`
+
+An optional plain text user NKey Seed (given along with the corresponding user JWT).
+:::warning Secret
+This field contains sensitive information that usually shouldn't be added to a config directly, read our [secrets page for more info](/docs/configuration/secrets).
+:::
+
+
+Type: `string`  
 
 


### PR DESCRIPTION
This PR allows for the NATS user credentials to be given in the Benthos stream configuration (User JWT + User NKey Seed).

Example:

```yaml
input:
  nats_jetstream:
    urls:
      - "nats://nats.mycloud.tld"
    stream: "input"
    subject: "input"
    auth:
      user_jwt: ""
      user_nkey_seed: ""
output:
  nats_jetstream:
    urls:
      - "nats://nats.mycloud.tld"
    subject: "output"
    auth:
      user_jwt: ""
      user_nkey_seed: ""
```

This is very convenient not to rely on local storage. Please comment if the code needs improvements :smiley: