### PR TITLE
Use AMQP message value if data is empty

### DIFF
--- a/internal/impl/amqp1/input.go
+++ b/internal/impl/amqp1/input.go
@@ -239,6 +239,7 @@ func (a *amqp1Reader) ReadBatch(ctx context.Context) (message.Batch, input.Async
 	}
 
 	part := message.NewPart(amqpMsg.GetData())
+	amqpSetMetadata(part, "amqp_value", amqpMsg.Value)
 	if amqpMsg.Properties != nil {
 		amqpSetMetadata(part, "amqp_content_type", amqpMsg.Properties.ContentType)
 		amqpSetMetadata(part, "amqp_content_encoding", amqpMsg.Properties.ContentEncoding)

--- a/internal/impl/amqp1/input.go
+++ b/internal/impl/amqp1/input.go
@@ -238,7 +238,16 @@ func (a *amqp1Reader) ReadBatch(ctx context.Context) (message.Batch, input.Async
 		return nil, nil, err
 	}
 
-	part := message.NewPart(amqpMsg.GetData())
+	var part *message.Part
+
+	if data := amqpMsg.GetData(); data != nil {
+		part = message.NewPart(data)
+	} else if value, ok := amqpMsg.Value.(string); ok {
+		part = message.NewPart([]byte(value))
+	} else {
+		part = message.NewPart(nil)
+	}
+
 	amqpSetMetadata(part, "amqp_value", amqpMsg.Value)
 	if amqpMsg.Properties != nil {
 		amqpSetMetadata(part, "amqp_content_type", amqpMsg.Properties.ContentType)

--- a/website/docs/components/inputs/amqp_1.md
+++ b/website/docs/components/inputs/amqp_1.md
@@ -68,7 +68,6 @@ This input adds the following metadata fields to each message:
 - amqp_content_type
 - amqp_content_encoding
 - amqp_creation_time
-- amqp_value
 - All string typed message annotations
 ```
 

--- a/website/docs/components/inputs/amqp_1.md
+++ b/website/docs/components/inputs/amqp_1.md
@@ -68,6 +68,7 @@ This input adds the following metadata fields to each message:
 - amqp_content_type
 - amqp_content_encoding
 - amqp_creation_time
+- amqp_value
 - All string typed message annotations
 ```
 


### PR DESCRIPTION
I couldn't get the integration test to run locally. I tried editing the test to run against my local ActiveMQ instance but had no luck. Hopefully it'll run in CI.

As I mentioned on Discord, sometimes there's data in the `Message.value` attribute. This change pulls that out into message metadata.

I have limited experience with Go so I hope this is ok 😅 