### PR TITLE
otlp: open_telemetry_collector add insecure options for http and grpc

### DIFF
--- a/website/docs/components/tracers/open_telemetry_collector.md
+++ b/website/docs/components/tracers/open_telemetry_collector.md
@@ -66,6 +66,14 @@ The URL of a collector to send tracing events to.
 Type: `string`  
 Default: `"localhost:4318"`  
 
+### `http[].insecure`
+
+Use HTTP instead of HTTPS.
+
+
+Type: `bool`  
+Default: `false`  
+
 ### `grpc`
 
 A list of grpc collectors.
@@ -80,6 +88,14 @@ The URL of a collector to send tracing events to.
 
 Type: `string`  
 Default: `"localhost:4317"`  
+
+### `grpc[].insecure`
+
+Disables client transport security for gRPC.
+
+
+Type: `bool`  
+Default: `false`  
 
 ### `tags`
 


### PR DESCRIPTION
There is some use-cases where you have secure otel collector. To allow for this a new 'insecure' option was added to both the 'http' and 'grpc' configs in 'open_telemetry_collector'.