### PR TITLE
allow --env-file flag multiple times

### DIFF
--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -126,10 +126,10 @@ func Run() {
 			Value:   false,
 			Usage:   "display version info, then exit",
 		},
-		&cli.StringFlag{
+		&cli.StringSliceFlag{
 			Name:    "env-file",
 			Aliases: []string{"e"},
-			Value:   "",
+			Value:   cli.NewStringSlice(),
 			Usage:   "import environment variables from a dotenv file",
 		},
 		&cli.StringFlag{
@@ -186,7 +186,7 @@ Either run Benthos as a stream processor or choose a command:
   benthos -r "./production/*.yaml" -c ./config.yaml`[1:],
 		Flags: flags,
 		Before: func(c *cli.Context) error {
-			if dotEnvFile := c.String("env-file"); dotEnvFile != "" {
+			for _, dotEnvFile := range c.StringSlice("env-file") {
 				dotEnvBytes, err := ifs.ReadFile(ifs.OS(), dotEnvFile)
 				if err != nil {
 					fmt.Printf("Failed to read dotenv file: %v\n", err)


### PR DESCRIPTION
This change updates to the --env-file flag definition so that it can be repeated multiple times. This is useful in settings where benthos is supplied with multiple files containing environment variables. For example, a container orchestration framework can inject one file containing application secrets, another file containing database access credentials and there may be a file included in the repository of a benthos project. These can be loaded like so:

```
benthos \
  --env-file ./.env.production \
  --env-file /tmpfs/secrets.env \
  --env-file /tmpfs/db.env \
  --config config.yml
```