### PR TITLE
Disable gocritic and re-enable wastedassign

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -35,22 +35,21 @@ linters-settings:
 linters:
   disable-all: true
   enable:
-    # Default linters reported by `golangci-lint help linters` in v1.41.1
-    # Disabled for Go 1.18
-    - gosimple
-    - staticcheck
-    - unused
+    # Default linters reported by `golangci-lint help linters` in v1.52.0
     - errcheck
+    - gosimple
     - govet
     - ineffassign
+    - staticcheck
     - typecheck
+    - unused
     # Extra linters:
-    # Disabled for Go 1.18
-    # - wastedassign
+    - wastedassign
     - stylecheck
     - gofmt
     - goimports
-    - gocritic
+    # gocritic is very slow (golangci-lint v1.52.0)
+    # - gocritic
     # - revive
     - unconvert
     - durationcheck


### PR DESCRIPTION
- gogritic is very slow (golangci-lint v1.52.0)
- wastedassign received support for generics: https://github.com/golangci/golangci-lint/pull/3689

LE: Looks like the PR liniting time went down from 7 to 2 minutes