### PR TITLE
treat path config as prefix in http_server input

### DIFF
--- a/internal/impl/io/input_http_server.go
+++ b/internal/impl/io/input_http_server.go
@@ -222,10 +222,10 @@ func newHTTPServerInput(conf input.Config, mgr bundle.NewManagement) (input.Stre
 	wsHdlr := gzipHandler(h.wsHandler)
 	if gMux != nil {
 		if len(h.conf.Path) > 0 {
-			gMux.HandleFunc(h.conf.Path, postHdlr)
+			gMux.PathPrefix(h.conf.Path).Handler(postHdlr)
 		}
 		if len(h.conf.WSPath) > 0 {
-			gMux.HandleFunc(h.conf.WSPath, wsHdlr)
+			gMux.PathPrefix(h.conf.Path).Handler(wsHdlr)
 		}
 	} else {
 		if len(h.conf.Path) > 0 {

--- a/internal/impl/io/input_http_server_test.go
+++ b/internal/impl/io/input_http_server_test.go
@@ -420,6 +420,73 @@ func TestHTTPtServerPathParameters(t *testing.T) {
 	assert.Equal(t, "will go on", part.MetaGetStr("mylove"))
 }
 
+func TestHTTPtServerPathIsPrefix(t *testing.T) {
+	tCtx, done := context.WithTimeout(context.Background(), time.Minute)
+	defer done()
+
+	reg := apiRegGorillaMutWrapper{mut: mux.NewRouter()}
+	mgr, err := manager.New(manager.NewResourceConfig(), manager.OptSetAPIReg(reg))
+	require.NoError(t, err)
+
+	conf := input.NewConfig()
+	conf.Type = "http_server"
+	conf.HTTPServer.Path = "/test/{foo}/{bar}"
+	conf.HTTPServer.AllowedVerbs = append(conf.HTTPServer.AllowedVerbs, "PUT")
+
+	server, err := mgr.NewInput(conf)
+	require.NoError(t, err)
+
+	defer func() {
+		server.TriggerStopConsuming()
+		assert.NoError(t, server.WaitForClose(tCtx))
+	}()
+
+	testServer := httptest.NewServer(reg.mut)
+	defer testServer.Close()
+
+	dummyPath := "/test/foo1/bar1/baz1"
+	dummyQuery := url.Values{"mylove": []string{"will go on"}}
+	serverURL, err := url.Parse(testServer.URL)
+	require.NoError(t, err)
+
+	serverURL.Path = dummyPath
+	serverURL.RawQuery = dummyQuery.Encode()
+
+	dummyData := []byte("a bunch of jolly leprechauns await")
+	go func() {
+		fmt.Println(serverURL.String())
+		req, cerr := http.NewRequest("PUT", serverURL.String(), bytes.NewReader(dummyData))
+		require.NoError(t, cerr)
+		req.Header.Set("Content-Type", "text/plain")
+		resp, cerr := http.DefaultClient.Do(req)
+		require.NoError(t, cerr)
+		defer resp.Body.Close()
+	}()
+
+	readNextMsg := func() (message.Batch, error) {
+		var tran message.Transaction
+		select {
+		case tran = <-server.TransactionChan():
+			require.NoError(t, tran.Ack(tCtx, nil))
+		case <-time.After(time.Second):
+			return nil, errors.New("timed out")
+		}
+		return tran.Payload, nil
+	}
+
+	msg, err := readNextMsg()
+	require.NoError(t, err)
+	assert.Equal(t, dummyData, message.GetAllBytes(msg)[0])
+
+	part := msg.Get(0)
+
+	assert.Equal(t, dummyPath, part.MetaGetStr("http_server_request_path"))
+	assert.Equal(t, "PUT", part.MetaGetStr("http_server_verb"))
+	assert.Equal(t, "foo1", part.MetaGetStr("foo"))
+	assert.Equal(t, "bar1", part.MetaGetStr("bar"))
+	assert.Equal(t, "will go on", part.MetaGetStr("mylove"))
+}
+
 func TestHTTPtServerPathParametersCustomServer(t *testing.T) {
 	tCtx, done := context.WithTimeout(context.Background(), time.Minute)
 	defer done()


### PR DESCRIPTION
This change restores the path matching behaviour of the http_server input from Benthos 4.12.1 and prior where the path config was treated as a prefix.

Closes #1813