### PR TITLE
Support a nak_delay on NATS input

### DIFF
--- a/website/docs/components/inputs/nats.md
+++ b/website/docs/components/inputs/nats.md
@@ -45,6 +45,7 @@ input:
     urls: []
     subject: ""
     queue: ""
+    nak_delay: ""
     prefetch_count: 32
     tls:
       enabled: false
@@ -143,6 +144,19 @@ An optional queue group to consume as.
 
 
 Type: `string`  
+
+### `nak_delay`
+
+An optional delay duration on redelivering a message when negatively acknowledged.
+
+
+Type: `string`  
+
+```yml
+# Examples
+
+nak_delay: 1m
+```
 
 ### `prefetch_count`
 


### PR DESCRIPTION
Add an optional parameter to make NATS to delay the redelivery of a message when negatively acknowledged. It can be used as a retry mechanism when a transient error occurs.

Example:

```yml
input:
  broker:
    inputs:
    - nats:
        urls:
        - ${NATS_ADDRESS:"localhost:4222"}
        subject: ${NATS_SUBJECT}
        queue: ${NATS_QUEUE_GROUP}
        nak_delay: 5m

pipeline:
  processors:
  -  . . . 

output:
  switch:
    cases:
    - check: 'errored()'
      output:
        reject: "rejecting due to processing error: ${! error() }"
    - output:
        resource: output_ok
```