### PR TITLE
improve error message in methods and functions

### DIFF
--- a/internal/bloblang/query/function_set.go
+++ b/internal/bloblang/query/function_set.go
@@ -197,7 +197,7 @@ func wrapCtorWithDynamicArgs(name string, args *ParsedParams, fn FunctionCtor) (
 	return ClosureFunction("function "+name, func(ctx FunctionContext) (any, error) {
 		newArgs, err := args.ResolveDynamic(ctx)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("function '%s': %w", name, err)
 		}
 		dynFunc, err := fn(newArgs)
 		if err != nil {

--- a/internal/bloblang/query/method_set.go
+++ b/internal/bloblang/query/method_set.go
@@ -170,7 +170,7 @@ func wrapMethodCtorWithDynamicArgs(name string, target Function, args *ParsedPar
 	return ClosureFunction("method "+name, func(ctx FunctionContext) (any, error) {
 		newArgs, err := args.ResolveDynamic(ctx)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("method '%s': %w", name, err)
 		}
 		dynFunc, err := fn(target, newArgs)
 		if err != nil {

--- a/internal/bloblang/query/params.go
+++ b/internal/bloblang/query/params.go
@@ -453,10 +453,10 @@ func (p *ParsedParams) ResolveDynamic(ctx FunctionContext) (*ParsedParams, error
 		}
 		tmpValue, err := dyn.fn.Exec(ctx)
 		if err != nil {
-			return nil, fmt.Errorf("failed to extract input arg %v: %w", sourceDef.Name, err)
+			return nil, fmt.Errorf("failed to extract input arg '%v': %w", sourceDef.Name, err)
 		}
 		if newValues[dyn.index], err = sourceDef.parseArgValue(tmpValue); err != nil {
-			return nil, fmt.Errorf("failed to extract input arg %v: %w", sourceDef.Name, err)
+			return nil, fmt.Errorf("failed to extract input arg '%v': %w", sourceDef.Name, err)
 		}
 	}
 	return &ParsedParams{

--- a/internal/bloblang/query/params_test.go
+++ b/internal/bloblang/query/params_test.go
@@ -611,7 +611,7 @@ func TestParsedParamsDynamicErrors(t *testing.T) {
 					"bar": "not a bool",
 				},
 			},
-			errContains: "first: wrong argument type",
+			errContains: "'first': wrong argument type",
 		},
 	}
 


### PR DESCRIPTION
This change improves error messages in methods and functions particularly when invoked with dynamic arguments. Previously the error message did not highlight the affect method/function name and the argument name didn't quote stand out in the message.

Before:

```
failed to extract input arg path:
  wrong argument type, expected string, got null
```

After:

```
method 'get':
  failed to extract input arg 'path':
    wrong argument type, expected string, got null
```