### PR TITLE
rewrite gcp_pubsub output

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -93,6 +93,7 @@ require (
 	github.com/sirupsen/logrus v1.9.0
 	github.com/smira/go-statsd v1.3.2
 	github.com/snowflakedb/gosnowflake v1.6.16
+	github.com/sourcegraph/conc v0.3.0
 	github.com/stretchr/testify v1.8.1
 	github.com/tetratelabs/wazero v1.0.1
 	github.com/tilinna/z85 v1.0.0
@@ -256,7 +257,6 @@ require (
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
 	github.com/rickb777/plural v1.4.1 // indirect
 	github.com/rivo/uniseg v0.3.4 // indirect
-	github.com/rogpeppe/go-internal v1.9.0 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/segmentio/asm v1.2.0 // indirect
 	github.com/segmentio/encoding v0.3.5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -951,7 +951,6 @@ github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFR
 github.com/rogpeppe/go-internal v1.6.1/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTEfhy4qGm1nDQc=
 github.com/rogpeppe/go-internal v1.8.0/go.mod h1:WmiCO8CzOY8rg0OYDC4/i/2WRWAB6poM+XZ2dLUbcbE=
 github.com/rogpeppe/go-internal v1.9.0 h1:73kH8U+JUqXU8lRuOHeVHaa/SZPifC7BkcraZVejAe8=
-github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
@@ -991,6 +990,8 @@ github.com/smira/go-statsd v1.3.2/go.mod h1:1srXJ9/pbnN04G8f4F1jUzsGOnwkPKXciyqp
 github.com/snowflakedb/gosnowflake v1.6.16 h1:R9NrID/trYxXUChdOKXxTHUGDDZkfWV0w9hEYRuABhU=
 github.com/snowflakedb/gosnowflake v1.6.16/go.mod h1:rcAsyMje5e2aN0uhzbUYkpNSnkNyEDa8w8ScOsiHsBc=
 github.com/soheilhy/cmux v0.1.4/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4kGIyLM=
+github.com/sourcegraph/conc v0.3.0 h1:OQTbbt6P72L20UqAkXXuLOj79LfEanQ+YQFNpLA9ySo=
+github.com/sourcegraph/conc v0.3.0/go.mod h1:Sdozi7LEKbFPqYX2/J+iBAM6HpqSLTASQIKqDmF7Mt0=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spaolacci/murmur3 v1.1.0 h1:7c1g84S4BPRrfL5Xrdp6fOJ206sU9y293DDHaoy0bLI=
 github.com/spaolacci/murmur3 v1.1.0/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=

--- a/internal/impl/gcp/output_pubsub.go
+++ b/internal/impl/gcp/output_pubsub.go
@@ -3,34 +3,22 @@ package gcp
 import (
 	"context"
 	"fmt"
-	"strings"
 	"sync"
-	"time"
-
-	"google.golang.org/api/option"
 
 	"cloud.google.com/go/pubsub"
-
-	"github.com/benthosdev/benthos/v4/internal/batch"
-	"github.com/benthosdev/benthos/v4/internal/bloblang/field"
-	"github.com/benthosdev/benthos/v4/internal/bundle"
-	"github.com/benthosdev/benthos/v4/internal/component"
-	"github.com/benthosdev/benthos/v4/internal/component/metrics"
-	"github.com/benthosdev/benthos/v4/internal/component/output"
-	"github.com/benthosdev/benthos/v4/internal/component/output/processors"
-	"github.com/benthosdev/benthos/v4/internal/docs"
-	"github.com/benthosdev/benthos/v4/internal/log"
-	"github.com/benthosdev/benthos/v4/internal/message"
-	"github.com/benthosdev/benthos/v4/internal/metadata"
+	"github.com/benthosdev/benthos/v4/public/service"
+	"github.com/sourcegraph/conc/pool"
+	"google.golang.org/api/option"
 )
 
-func init() {
-	err := bundle.AllOutputs.Add(processors.WrapConstructor(func(c output.Config, nm bundle.NewManagement) (output.Streamed, error) {
-		return newGCPPubSubOutput(c, nm, nm.Logger(), nm.Metrics())
-	}), docs.ComponentSpec{
-		Name:    "gcp_pubsub",
-		Summary: `Sends messages to a GCP Cloud Pub/Sub topic. [Metadata](/docs/configuration/metadata) from messages are sent as attributes.`,
-		Description: output.Description(true, false, `
+func newPubSubOutputConfig() *service.ConfigSpec {
+	defaults := pubsub.DefaultPublishSettings
+
+	return service.NewConfigSpec().
+		Stable().
+		Categories("Services", "GCP").
+		Summary("Sends messages to a GCP Cloud Pub/Sub topic. [Metadata](/docs/configuration/metadata) from messages are sent as attributes.").
+		Description(`
 For information on how to set up credentials check out [this guide](https://cloud.google.com/docs/authentication/production).
 
 ### Troubleshooting
@@ -52,97 +40,125 @@ Or delete all keys with:
 pipeline:
   processors:
     - mapping: meta = deleted()
-`+"```"+``),
-		Config: docs.FieldComponent().WithChildren(
-			docs.FieldString("project", "The project ID of the topic to publish to."),
-			docs.FieldString("topic", "The topic to publish to.").IsInterpolated(),
-			docs.FieldInt("max_in_flight", "The maximum number of messages to have in flight at a given time. Increase this to improve throughput."),
-			docs.FieldString("publish_timeout", "The maximum length of time to wait before abandoning a publish attempt for a message.", "10s", "5m", "60m").Advanced(),
-			docs.FieldString("ordering_key", "The ordering key to use for publishing messages.").IsInterpolated().Advanced(),
-			docs.FieldString("endpoint", "An optional endpoint to override the default of `pubsub.googleapis.com:443`. This can be used to connect to a region specific pubsub endpoint. For a list of valid values check out [this document.](https://cloud.google.com/pubsub/docs/reference/service_apis_overview#list_of_regional_endpoints)", "us-central1-pubsub.googleapis.com:443", "us-west3-pubsub.googleapis.com:443").HasDefault(""),
-			docs.FieldObject("metadata", "Specify criteria for which metadata values are sent as attributes.").WithChildren(metadata.ExcludeFilterFields()...),
-			docs.FieldObject("flow_control", "For a given topic, configures the PubSub client's internal buffer for messages to be published.").
-				WithChildren(
-					docs.FieldInt("max_outstanding_messages", "Maximum number of buffered messages to be published. If less than or equal to zero, this is disabled.").HasDefault(1000),
-					docs.FieldInt("max_outstanding_bytes", "Maximum size of buffered messages to be published. If less than or equal to zero, this is disabled.").HasDefault(-1),
-					docs.FieldString("limit_exceeded_behavior", "Configures the behavior when trying to publish additional messages while the flow controller is full. The available options are ignore (disable, default), block, and signal_error (publish results will return an error).").
-						HasDefault("ignore").
-						HasOptions("ignore", "block", "signal_error"),
-				).Advanced(),
-		).ChildDefaultAndTypesFromStruct(output.NewGCPPubSubConfig()),
-		Categories: []string{
-			"Services",
-			"GCP",
-		},
-	})
-	if err != nil {
-		panic(err)
-	}
+`+"```"+``).
+		Fields(
+			service.NewStringField("project").Description("The project ID of the topic to publish to."),
+			service.NewInterpolatedStringField("topic").Description("The topic to publish to."),
+			service.NewStringField("endpoint").
+				Default("").
+				Example("us-central1-pubsub.googleapis.com:443").
+				Example("us-west3-pubsub.googleapis.com:443").
+				Description("An optional endpoint to override the default of `pubsub.googleapis.com:443`. This can be used to connect to a region specific pubsub endpoint. For a list of valid values check out [this document.](https://cloud.google.com/pubsub/docs/reference/service_apis_overview#list_of_regional_endpoints)"),
+			service.NewInterpolatedStringField("ordering_key").
+				Optional().
+				Description("The ordering key to use for publishing messages.").
+				Advanced(),
+			service.NewIntField("max_in_flight").Default(64).Description("The maximum number of messages to have in flight at a given time. Increasing this may improve throughput."),
+			service.NewIntField("count_threshold").
+				Default(defaults.CountThreshold).
+				Description("Publish a pubsub buffer when it has this many messages"),
+			service.NewDurationField("delay_threshold").
+				Default(defaults.DelayThreshold.String()).
+				Description("Publish a non-empty pubsub buffer after this delay has passed."),
+			service.NewIntField("byte_threshold").
+				Default(defaults.ByteThreshold).
+				Description("Publish a batch when its size in bytes reaches this value."),
+			service.NewDurationField("publish_timeout").
+				Default(defaults.Timeout.String()).
+				Example("10s").
+				Example("5m").
+				Example("60m").
+				Description("The maximum length of time to wait before abandoning a publish attempt for a message.").
+				Advanced(),
+			service.NewMetadataFilterField("metadata").
+				Optional().
+				Description("Specify criteria for which metadata values are sent as attributes."),
+			service.NewObjectField(
+				"flow_control",
+				service.NewIntField("max_outstanding_bytes").
+					Default(defaults.FlowControlSettings.MaxOutstandingBytes).
+					Description("Maximum size of buffered messages to be published. If less than or equal to zero, this is disabled."),
+				service.NewIntField("max_outstanding_messages").
+					Default(defaults.FlowControlSettings.MaxOutstandingMessages).
+					Description("Maximum number of buffered messages to be published. If less than or equal to zero, this is disabled."),
+				service.NewStringEnumField("limit_exceeded_behavior", "ignore", "block", "signal_error").
+					Default("block").
+					Description("Configures the behavior when trying to publish additional messages while the flow controller is full. The available options are block (default), ignore (disable), and signal_error (publish results will return an error)."),
+			).
+				Description("For a given topic, configures the PubSub client's internal buffer for messages to be published.").
+				Advanced(),
+			service.NewBatchPolicyField("batching").
+				Description("Configures a batching policy on this output. While the PubSub client maintains its own internal buffering mechanism, preparing larger batches of messages can futher trade-off some latency for throughput."),
+		)
 }
 
-func newGCPPubSubOutput(conf output.Config, mgr bundle.NewManagement, log log.Modular, stats metrics.Type) (output.Streamed, error) {
-	a, err := newGCPPubSubWriter(conf.GCPPubSub, mgr, log)
-	if err != nil {
-		return nil, err
-	}
-	w, err := output.NewAsyncWriter("gcp_pubsub", conf.GCPPubSub.MaxInFlight, a, mgr)
-	if err != nil {
-		return nil, err
-	}
-	return output.OnlySinglePayloads(w), nil
-}
-
-type gcpPubSubWriter struct {
-	conf output.GCPPubSubConfig
-
-	client         *pubsub.Client
-	publishTimeout time.Duration
-	metaFilter     *metadata.ExcludeFilter
-
-	orderingEnabled bool
-	orderingKey     *field.Expression
-
-	topicID  *field.Expression
-	topics   map[string]*pubsub.Topic
+type pubsubOutput struct {
 	topicMut sync.Mutex
+	topics   map[string]pubsubTopic
 
-	flowControl pubsub.FlowControlSettings
-
-	log log.Modular
+	project         string
+	clientOpts      []option.ClientOption
+	client          pubsubClient
+	clientCancel    context.CancelFunc
+	publishSettings *pubsub.PublishSettings
+	topicQ          *service.InterpolatedString
+	metaFilter      *service.MetadataFilter
+	orderingKeyQ    *service.InterpolatedString
 }
 
-func newGCPPubSubWriter(conf output.GCPPubSubConfig, mgr bundle.NewManagement, log log.Modular) (*gcpPubSubWriter, error) {
-	var opt []option.ClientOption
-	if len(strings.TrimSpace(conf.Endpoint)) > 0 {
-		opt = []option.ClientOption{option.WithEndpoint(conf.Endpoint)}
-	}
+func newPubSubOutput(conf *service.ParsedConfig) (*pubsubOutput, error) {
+	var settings pubsub.PublishSettings
 
-	client, err := pubsub.NewClient(context.Background(), conf.ProjectID, opt...)
+	project, err := conf.FieldString("project")
 	if err != nil {
 		return nil, err
 	}
-	topic, err := mgr.BloblEnvironment().NewField(conf.TopicID)
+
+	topicQ, err := conf.FieldInterpolatedString("topic")
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse topic expression: %v", err)
-	}
-	orderingKey, err := mgr.BloblEnvironment().NewField(conf.OrderingKey)
-	if err != nil {
-		return nil, fmt.Errorf("failed to parse ordering key: %v", err)
-	}
-	pubTimeout, err := time.ParseDuration(conf.PublishTimeout)
-	if err != nil {
-		return nil, fmt.Errorf("failed to parse publish timeout duration: %w", err)
-	}
-	metaFilter, err := conf.Metadata.Filter()
-	if err != nil {
-		return nil, fmt.Errorf("failed to construct metadata filter: %w", err)
+		return nil, err
 	}
 
-	flowControl := pubsub.FlowControlSettings{
-		MaxOutstandingMessages: conf.FlowControl.MaxOutstandingMessages,
-		MaxOutstandingBytes:    conf.FlowControl.MaxOutstandingBytes,
+	metaFilter, err := conf.FieldMetadataFilter("metadata")
+	if err != nil {
+		return nil, err
 	}
-	switch conf.FlowControl.LimitExceededBehavior {
+
+	var orderingKeyQ *service.InterpolatedString
+	if conf.Contains("ordering_key") {
+		if orderingKeyQ, err = conf.FieldInterpolatedString("ordering_key"); err != nil {
+			return nil, err
+		}
+	}
+
+	if settings.DelayThreshold, err = conf.FieldDuration("delay_threshold"); err != nil {
+		return nil, err
+	}
+	if settings.CountThreshold, err = conf.FieldInt("count_threshold"); err != nil {
+		return nil, err
+	}
+	if settings.ByteThreshold, err = conf.FieldInt("byte_threshold"); err != nil {
+		return nil, err
+	}
+	if settings.Timeout, err = conf.FieldDuration("publish_timeout"); err != nil {
+		return nil, err
+	}
+
+	flowConf := conf.Namespace("flow_control")
+	var flowControl pubsub.FlowControlSettings
+	if flowControl.MaxOutstandingBytes, err = flowConf.FieldInt("max_outstanding_bytes"); err != nil {
+		return nil, err
+	}
+	if flowControl.MaxOutstandingMessages, err = flowConf.FieldInt("max_outstanding_messages"); err != nil {
+		return nil, err
+	}
+
+	var limitBehavior string
+	if limitBehavior, err = flowConf.FieldString("limit_exceeded_behavior"); err != nil {
+		return nil, err
+	}
+
+	switch limitBehavior {
 	case "ignore":
 		flowControl.LimitExceededBehavior = pubsub.FlowControlIgnore
 	case "block":
@@ -150,123 +166,196 @@ func newGCPPubSubWriter(conf output.GCPPubSubConfig, mgr bundle.NewManagement, l
 	case "signal_error":
 		flowControl.LimitExceededBehavior = pubsub.FlowControlSignalError
 	default:
-		return nil, fmt.Errorf("unrecognized flow control setting: %s", conf.FlowControl.LimitExceededBehavior)
+		return nil, fmt.Errorf("unrecognized flow control setting: %s", limitBehavior)
 	}
 
-	return &gcpPubSubWriter{
-		conf:            conf,
-		log:             log,
+	settings.FlowControlSettings = flowControl
+
+	var endpoint string
+	if endpoint, err = conf.FieldString("endpoint"); err != nil {
+		return nil, err
+	}
+
+	var opt []option.ClientOption
+	if len(endpoint) > 0 {
+		opt = []option.ClientOption{option.WithEndpoint(endpoint)}
+	}
+
+	return &pubsubOutput{
+		topics:          make(map[string]pubsubTopic),
+		project:         project,
+		clientOpts:      opt,
+		publishSettings: &settings,
+		topicQ:          topicQ,
 		metaFilter:      metaFilter,
-		client:          client,
-		publishTimeout:  pubTimeout,
-		topicID:         topic,
-		orderingKey:     orderingKey,
-		orderingEnabled: len(conf.OrderingKey) > 0,
-		flowControl:     flowControl,
+		orderingKeyQ:    orderingKeyQ,
 	}, nil
 }
 
-func (c *gcpPubSubWriter) Connect(ctx context.Context) error {
-	c.topicMut.Lock()
-	defer c.topicMut.Unlock()
-	if c.topics != nil {
+func (out *pubsubOutput) Connect(_ context.Context) error {
+	if out.client != nil {
 		return nil
 	}
 
-	c.topics = map[string]*pubsub.Topic{}
-	c.log.Infof("Sending GCP Cloud Pub/Sub messages to project '%v' and topic '%v'\n", c.conf.ProjectID, c.conf.TopicID)
+	clientCtx, clientCancel := context.WithCancel(context.Background())
+	client, err := pubsub.NewClient(clientCtx, out.project, out.clientOpts...)
+	if err != nil {
+		clientCancel()
+		return fmt.Errorf("failed to create pubsub client: %w", err)
+	}
+
+	out.client = &airGappedPubsubClient{client}
+	out.clientCancel = clientCancel
+
 	return nil
 }
 
-func (c *gcpPubSubWriter) getTopic(ctx context.Context, t string) (*pubsub.Topic, error) {
-	c.topicMut.Lock()
-	defer c.topicMut.Unlock()
-	if c.topics == nil {
-		return nil, component.ErrNotConnected
+func (out *pubsubOutput) WriteBatch(ctx context.Context, batch service.MessageBatch) error {
+	topics := make(map[string]pubsubTopic)
+	p := pool.NewWithResults[*serverResult]().WithContext(ctx)
+	batchErr := service.NewBatchError(batch, fmt.Errorf("failed to publish batch"))
+
+	for i, msg := range batch {
+		i := i
+		res, err := out.writeMessage(ctx, topics, msg)
+		if err != nil {
+			batchErr.Failed(i, err)
+			continue
+		}
+
+		p.Go(func(ctx context.Context) (*serverResult, error) {
+			_, err := res.Get(ctx)
+			if err != nil {
+				return &serverResult{batchIndex: i, err: err}, nil
+			}
+
+			return nil, nil
+		})
 	}
-	if t, exists := c.topics[t]; exists {
+
+	getResults, err := p.Wait()
+	if err != nil {
+		return fmt.Errorf("failed to get publish results: %w", err)
+	}
+
+	for _, res := range getResults {
+		if res == nil {
+			continue
+		}
+
+		batchErr.Failed(res.batchIndex, res.err)
+	}
+
+	if batchErr.IndexedErrors() > 0 {
+		return batchErr
+	}
+
+	return nil
+}
+
+func (out *pubsubOutput) Close(_ context.Context) error {
+	out.topicMut.Lock()
+	defer out.topicMut.Unlock()
+
+	for _, t := range out.topics {
+		t.Stop()
+	}
+	out.topics = nil
+
+	if out.clientCancel != nil {
+		out.clientCancel()
+	}
+
+	return nil
+}
+
+func (out *pubsubOutput) writeMessage(ctx context.Context, cachedTopics map[string]pubsubTopic, msg *service.Message) (publishResult, error) {
+	topicName, err := out.topicQ.TryString(msg)
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve topic name: %w", err)
+	}
+
+	topic, found := cachedTopics[topicName]
+
+	if !found {
+		t, err := out.getTopic(ctx, topicName)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get topic: %s: %w", topicName, err)
+		}
+
+		cachedTopics[topicName] = t
+		topic = t
+	}
+
+	attr := make(map[string]string)
+	if err := out.metaFilter.Walk(msg, func(key, value string) error {
+		attr[key] = value
+		return nil
+	}); err != nil {
+		return nil, fmt.Errorf("failed to build message attributes: %w", err)
+	}
+
+	var orderingKey string
+	if out.orderingKeyQ != nil {
+		if orderingKey, err = out.orderingKeyQ.TryString(msg); err != nil {
+			return nil, fmt.Errorf("failed to build ordering key: %w", err)
+		}
+	}
+
+	data, err := msg.AsBytes()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get bytes from message: %w", err)
+	}
+
+	return topic.Publish(ctx, &pubsub.Message{
+		Data:        data,
+		Attributes:  attr,
+		OrderingKey: orderingKey,
+	}), nil
+}
+
+func (out *pubsubOutput) getTopic(ctx context.Context, name string) (pubsubTopic, error) {
+	out.topicMut.Lock()
+	defer out.topicMut.Unlock()
+
+	if t, exists := out.topics[name]; exists {
 		return t, nil
 	}
 
-	topic := c.client.Topic(t)
-	exists, err := topic.Exists(ctx)
+	t := out.client.Topic(name, out.publishSettings)
+	exists, err := t.Exists(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("failed to validate topic '%v': %v", t, err)
+		return nil, fmt.Errorf("failed to validate topic '%v': %v", name, err)
 	}
 	if !exists {
-		return nil, fmt.Errorf("topic '%v' does not exist", t)
+		return nil, fmt.Errorf("topic '%v' does not exist", name)
 	}
-	topic.PublishSettings.Timeout = c.publishTimeout
-	topic.PublishSettings.FlowControlSettings = c.flowControl
-	topic.EnableMessageOrdering = c.orderingEnabled
-	c.topics[t] = topic
-	return topic, nil
+
+	out.topics[name] = t
+	return t, nil
 }
 
-func (c *gcpPubSubWriter) WriteBatch(ctx context.Context, msg message.Batch) error {
-	topics := make([]*pubsub.Topic, msg.Len())
-	if err := msg.Iter(func(i int, _ *message.Part) error {
-		topicStr, tErr := c.topicID.String(i, msg)
-		if tErr != nil {
-			return fmt.Errorf("topic id interpolation error: %w", tErr)
-		}
-		topics[i], tErr = c.getTopic(ctx, topicStr)
-		return tErr
-	}); err != nil {
-		return err
-	}
-
-	results := make([]*pubsub.PublishResult, msg.Len())
-	if err := msg.Iter(func(i int, part *message.Part) error {
-		topic := topics[i]
-		attr := map[string]string{}
-		_ = c.metaFilter.IterStr(part, func(k, v string) error {
-			attr[k] = v
-			return nil
-		})
-		gmsg := &pubsub.Message{
-			Data: part.AsBytes(),
-		}
-		if c.orderingEnabled {
-			var err error
-			if gmsg.OrderingKey, err = c.orderingKey.String(i, msg); err != nil {
-				return fmt.Errorf("ordering key interpolation error: %w", err)
-			}
-		}
-		if len(attr) > 0 {
-			gmsg.Attributes = attr
-		}
-		results[i] = topic.Publish(ctx, gmsg)
-		return nil
-	}); err != nil {
-		return err
-	}
-
-	var batchErr *batch.Error
-	for i, r := range results {
-		if _, err := r.Get(ctx); err != nil {
-			publishErr := fmt.Errorf("failed to publish message: %w", err)
-
-			if batchErr == nil {
-				batchErr = batch.NewError(msg, publishErr)
-			}
-			batchErr.Failed(i, publishErr)
-		}
-	}
-	if batchErr != nil {
-		return batchErr
-	}
-	return nil
+type serverResult struct {
+	batchIndex int
+	err        error
 }
 
-func (c *gcpPubSubWriter) Close(context.Context) error {
-	c.topicMut.Lock()
-	defer c.topicMut.Unlock()
-	if c.topics != nil {
-		for _, t := range c.topics {
-			t.Stop()
+func init() {
+	if err := service.RegisterBatchOutput("gcp_pubsub", newPubSubOutputConfig(), func(conf *service.ParsedConfig, mgr *service.Resources) (out service.BatchOutput, batchPolicy service.BatchPolicy, maxInFlight int, err error) {
+		maxInFlight, err = conf.FieldInt("max_in_flight")
+		if err != nil {
+			return
 		}
-		c.topics = nil
+
+		batchPolicy, err = conf.FieldBatchPolicy("batching")
+		if err != nil {
+			return
+		}
+
+		out, err = newPubSubOutput(conf)
+
+		return
+	}); err != nil {
+		panic(err)
 	}
-	return nil
 }

--- a/internal/impl/gcp/output_pubsub_test.go
+++ b/internal/impl/gcp/output_pubsub_test.go
@@ -1,0 +1,270 @@
+package gcp
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"cloud.google.com/go/pubsub"
+	"github.com/benthosdev/benthos/v4/public/service"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPubSubOutput(t *testing.T) {
+	ctx := context.Background()
+
+	conf, err := newPubSubOutputConfig().ParseYAML(`
+    project: sample-project
+    topic: test_${! content().string().split("_").index(0) }
+    `,
+		nil,
+	)
+	require.NoError(t, err, "bad output config")
+
+	client := &mockPubSubClient{}
+
+	fooTopic := &mockTopic{}
+	fooTopic.On("Exists").Return(true, nil).Once()
+	fooTopic.On("Stop").Return().Once()
+
+	barTopic := &mockTopic{}
+	barTopic.On("Exists").Return(true, nil).Once()
+	barTopic.On("Stop").Return().Once()
+
+	client.On("Topic", "test_foo").Return(fooTopic).Once()
+	client.On("Topic", "test_bar").Return(barTopic).Once()
+
+	fooMsgA := service.NewMessage([]byte("foo_a"))
+	fooResA := &mockPublishResult{}
+	fooResA.On("Get").Return("foo_a", nil).Once()
+	fooTopic.On("Publish", "foo_a", mock.Anything).Return(fooResA).Once()
+
+	fooMsgB := service.NewMessage([]byte("foo_b"))
+	fooResB := &mockPublishResult{}
+	fooResB.On("Get").Return("foo_b", nil).Once()
+	fooTopic.On("Publish", "foo_b", mock.Anything).Return(fooResB).Once()
+
+	barMsg := service.NewMessage([]byte("bar"))
+	barRes := &mockPublishResult{}
+	barRes.On("Get").Return("bar", nil).Once()
+	barTopic.On("Publish", "bar", mock.Anything).Return(barRes).Once()
+
+	out, err := newPubSubOutput(conf)
+	require.NoError(t, err, "failed to create output")
+	out.client = client
+	t.Cleanup(func() {
+		err = out.Close(ctx)
+		require.NoError(t, err, "closing output failed")
+
+		mock.AssertExpectationsForObjects(
+			t,
+			client,
+			fooTopic, barTopic,
+			fooResA, fooResB, barRes,
+		)
+	})
+
+	err = out.Connect(ctx)
+	require.NoError(t, err, "connect failed")
+
+	err = out.WriteBatch(ctx, service.MessageBatch{fooMsgA, fooMsgB, barMsg})
+	require.NoError(t, err, "publish failed")
+}
+
+func TestPubSubOutput_MessageAttr(t *testing.T) {
+	ctx := context.Background()
+
+	conf, err := newPubSubOutputConfig().ParseYAML(`
+    project: sample-project
+    topic: test
+    ordering_key: '${! content().string() }_${! count(content().string()) }'
+    metadata:
+      include_prefixes:
+        - keep_
+    `,
+		nil,
+	)
+	require.NoError(t, err, "bad output config")
+
+	client := &mockPubSubClient{}
+
+	fooTopic := &mockTopic{}
+	fooTopic.On("Exists").Return(true, nil).Once()
+	fooTopic.On("Stop").Return().Once()
+
+	fooMsgA := &mockPublishResult{}
+	fooMsgA.On("Get").Return("foo", nil).Once()
+	fooTopic.On("Publish", "foo", mock.AnythingOfType("*pubsub.Message")).Return(fooMsgA).Once()
+
+	client.On("Topic", "test").Return(fooTopic).Once()
+
+	out, err := newPubSubOutput(conf)
+	require.NoError(t, err, "failed to create output")
+	out.client = client
+	t.Cleanup(func() {
+		err = out.Close(ctx)
+		require.NoError(t, err, "closing output failed")
+
+		mock.AssertExpectationsForObjects(
+			t,
+			client,
+			fooTopic,
+			fooMsgA,
+		)
+	})
+
+	err = out.Connect(ctx)
+	require.NoError(t, err, "connect failed")
+
+	msg := service.NewMessage([]byte("foo"))
+	msg.MetaSet("keep_a", "good stuff")
+	msg.MetaSet("drop_b", "oh well")
+
+	err = out.WriteBatch(ctx, service.MessageBatch{msg})
+	require.NoError(t, err, "publish failed")
+
+	require.Len(t, fooTopic.Calls, 2)
+	require.Equal(t, fooTopic.Calls[1].Method, "Publish")
+	require.Len(t, fooTopic.Calls[1].Arguments, 2)
+	psmsg := fooTopic.Calls[1].Arguments[1].(*pubsub.Message)
+	require.Equal(t, map[string]string{"keep_a": "good stuff"}, psmsg.Attributes)
+	require.Equal(t, "foo_1", psmsg.OrderingKey)
+}
+
+func TestPubSubOutput_MissingTopic(t *testing.T) {
+	ctx := context.Background()
+
+	conf, err := newPubSubOutputConfig().ParseYAML(`
+    project: sample-project
+    topic: 'test_${! content().string() }'
+    `,
+		nil,
+	)
+	require.NoError(t, err, "bad output config")
+
+	client := &mockPubSubClient{}
+
+	fooTopic := &mockTopic{}
+	fooTopic.On("Exists").Return(false, nil).Once()
+
+	barTopic := &mockTopic{}
+	barTopic.On("Exists").Return(false, errors.New("simulated error")).Once()
+
+	client.On("Topic", "test_foo").Return(fooTopic).Once()
+	client.On("Topic", "test_bar").Return(barTopic).Once()
+
+	out, err := newPubSubOutput(conf)
+	require.NoError(t, err, "failed to create output")
+	out.client = client
+	t.Cleanup(func() {
+		err = out.Close(ctx)
+		require.NoError(t, err, "closing output failed")
+
+		mock.AssertExpectationsForObjects(t, client, fooTopic, barTopic)
+	})
+
+	var bErr *service.BatchError
+	errs := []error{}
+
+	err = out.WriteBatch(ctx, service.MessageBatch{service.NewMessage([]byte("foo"))})
+	require.ErrorAsf(t, err, &bErr, "expected a batch error but got: %T: %v", bErr, bErr)
+	require.ErrorContains(t, bErr, "failed to publish batch")
+	bErr.WalkMessages(func(i int, m *service.Message, err error) bool {
+		if err != nil {
+			errs = append(errs, err)
+		}
+		return true
+	})
+	require.Len(t, errs, 1, "expected one error in batch error")
+	require.ErrorContains(t, errs[0], "topic 'test_foo' does not exist")
+
+	bErr = nil
+	errs = []error{}
+
+	err = out.WriteBatch(ctx, service.MessageBatch{service.NewMessage([]byte("bar"))})
+	require.ErrorAsf(t, err, &bErr, "expected a batch error but got: %T: %v", bErr, bErr)
+	require.ErrorContains(t, bErr, "failed to publish batch")
+	bErr.WalkMessages(func(i int, m *service.Message, err error) bool {
+		if err != nil {
+			errs = append(errs, err)
+		}
+		return true
+	})
+	require.Len(t, errs, 1, "expected one error in batch error")
+	require.ErrorContains(t, errs[0], "failed to validate topic 'test_bar': simulated error")
+}
+
+func TestPubSubOutput_PublishErrors(t *testing.T) {
+	ctx := context.Background()
+
+	conf, err := newPubSubOutputConfig().ParseYAML(`
+    project: sample-project
+    topic: test_${! content().string().split("_").index(0) }
+    `,
+		nil,
+	)
+	require.NoError(t, err, "bad output config")
+
+	client := &mockPubSubClient{}
+
+	fooTopic := &mockTopic{}
+	fooTopic.On("Exists").Return(true, nil).Once()
+	fooTopic.On("Stop").Return().Once()
+
+	barTopic := &mockTopic{}
+	barTopic.On("Exists").Return(true, nil).Once()
+	barTopic.On("Stop").Return().Once()
+
+	client.On("Topic", "test_foo").Return(fooTopic).Once()
+	client.On("Topic", "test_bar").Return(barTopic).Once()
+
+	fooMsgA := service.NewMessage([]byte("foo_a"))
+	fooResA := &mockPublishResult{}
+	fooResA.On("Get").Return("", errors.New("simulated foo error")).Once()
+	fooTopic.On("Publish", "foo_a", mock.Anything).Return(fooResA).Once()
+
+	fooMsgB := service.NewMessage([]byte("foo_b"))
+	fooResB := &mockPublishResult{}
+	fooResB.On("Get").Return("foo_b", nil).Once()
+	fooTopic.On("Publish", "foo_b", mock.Anything).Return(fooResB).Once()
+
+	barMsg := service.NewMessage([]byte("bar"))
+	barRes := &mockPublishResult{}
+	barRes.On("Get").Return("", errors.New("simulated bar error")).Once()
+	barTopic.On("Publish", "bar", mock.Anything).Return(barRes).Once()
+
+	out, err := newPubSubOutput(conf)
+	require.NoError(t, err, "failed to create output")
+	out.client = client
+	t.Cleanup(func() {
+		err = out.Close(ctx)
+		require.NoError(t, err, "closing output failed")
+
+		mock.AssertExpectationsForObjects(
+			t,
+			client,
+			fooTopic, barTopic,
+			fooResA, fooResB, barRes,
+		)
+	})
+
+	err = out.Connect(ctx)
+	require.NoError(t, err, "connect failed")
+
+	err = out.WriteBatch(ctx, service.MessageBatch{fooMsgA, fooMsgB, barMsg})
+	require.Error(t, err, "did not get expected publish error")
+
+	var batchErr *service.BatchError
+	require.ErrorAs(t, err, &batchErr, "error is not a batch error")
+	require.Equal(t, 2, batchErr.IndexedErrors(), "did not receive expected number of batch errors")
+
+	var errs []string
+	batchErr.WalkMessages(func(i int, m *service.Message, err error) bool {
+		if err != nil {
+			errs = append(errs, err.Error())
+		}
+		return true
+	})
+	require.ElementsMatch(t, []string{"simulated foo error", "simulated bar error"}, errs)
+}

--- a/internal/impl/gcp/pubsub.go
+++ b/internal/impl/gcp/pubsub.go
@@ -1,0 +1,46 @@
+package gcp
+
+import (
+	"context"
+
+	"cloud.google.com/go/pubsub"
+)
+
+type pubsubClient interface {
+	Topic(id string, settings *pubsub.PublishSettings) pubsubTopic
+}
+
+type pubsubTopic interface {
+	Exists(ctx context.Context) (bool, error)
+	Publish(ctx context.Context, msg *pubsub.Message) publishResult
+	Stop()
+}
+
+type publishResult interface {
+	Get(ctx context.Context) (serverID string, err error)
+}
+
+type airGappedPubsubClient struct {
+	c *pubsub.Client
+}
+
+func (ac *airGappedPubsubClient) Topic(id string, settings *pubsub.PublishSettings) pubsubTopic {
+	t := ac.c.Topic(id)
+	t.PublishSettings = *settings
+
+	return &airGappedTopic{t: t}
+}
+
+type airGappedTopic struct {
+	t *pubsub.Topic
+}
+
+func (at *airGappedTopic) Exists(ctx context.Context) (bool, error) {
+	return at.t.Exists(ctx)
+}
+func (at *airGappedTopic) Publish(ctx context.Context, msg *pubsub.Message) publishResult {
+	return at.t.Publish(ctx, msg)
+}
+func (at *airGappedTopic) Stop() {
+	at.t.Stop()
+}

--- a/internal/impl/gcp/pubsub_mock_test.go
+++ b/internal/impl/gcp/pubsub_mock_test.go
@@ -1,0 +1,47 @@
+package gcp
+
+import (
+	"context"
+
+	"cloud.google.com/go/pubsub"
+	"github.com/stretchr/testify/mock"
+)
+
+type mockPubSubClient struct {
+	mock.Mock
+}
+
+func (c *mockPubSubClient) Topic(id string, _ *pubsub.PublishSettings) pubsubTopic {
+	args := c.Called(id)
+
+	return args.Get(0).(pubsubTopic)
+}
+
+type mockTopic struct {
+	mock.Mock
+}
+
+func (mt *mockTopic) Exists(context.Context) (bool, error) {
+	args := mt.Called()
+	return args.Bool(0), args.Error(1)
+}
+
+func (mt *mockTopic) Publish(ctx context.Context, msg *pubsub.Message) publishResult {
+	args := mt.Called(string(msg.Data), msg)
+
+	return args.Get(0).(publishResult)
+}
+
+func (mt *mockTopic) Stop() {
+	mt.Called()
+}
+
+type mockPublishResult struct {
+	mock.Mock
+}
+
+func (m *mockPublishResult) Get(ctx context.Context) (string, error) {
+	args := m.Called()
+
+	return args.String(0), args.Error(1)
+}

--- a/website/docs/components/outputs/gcp_pubsub.md
+++ b/website/docs/components/outputs/gcp_pubsub.md
@@ -31,10 +31,19 @@ output:
   gcp_pubsub:
     project: ""
     topic: ""
-    max_in_flight: 64
     endpoint: ""
+    max_in_flight: 64
+    count_threshold: 100
+    delay_threshold: 10ms
+    byte_threshold: 1000000
     metadata:
-      exclude_prefixes: []
+      include_prefixes: []
+      include_patterns: []
+    batching:
+      count: 0
+      byte_size: 0
+      period: ""
+      check: ""
 ```
 
 </TabItem>
@@ -47,16 +56,26 @@ output:
   gcp_pubsub:
     project: ""
     topic: ""
-    max_in_flight: 64
-    publish_timeout: 60s
-    ordering_key: ""
     endpoint: ""
+    ordering_key: ""
+    max_in_flight: 64
+    count_threshold: 100
+    delay_threshold: 10ms
+    byte_threshold: 1000000
+    publish_timeout: 1m0s
     metadata:
-      exclude_prefixes: []
+      include_prefixes: []
+      include_patterns: []
     flow_control:
-      max_outstanding_messages: 1000
       max_outstanding_bytes: -1
-      limit_exceeded_behavior: ignore
+      max_outstanding_messages: 1000
+      limit_exceeded_behavior: block
+    batching:
+      count: 0
+      byte_size: 0
+      period: ""
+      check: ""
+      processors: []
 ```
 
 </TabItem>
@@ -85,12 +104,6 @@ pipeline:
     - mapping: meta = deleted()
 ```
 
-## Performance
-
-This output benefits from sending multiple messages in flight in parallel for
-improved performance. You can tune the max number of in flight messages (or
-message batches) with the field `max_in_flight`.
-
 ## Fields
 
 ### `project`
@@ -99,7 +112,6 @@ The project ID of the topic to publish to.
 
 
 Type: `string`  
-Default: `""`  
 
 ### `topic`
 
@@ -108,42 +120,6 @@ This field supports [interpolation functions](/docs/configuration/interpolation#
 
 
 Type: `string`  
-Default: `""`  
-
-### `max_in_flight`
-
-The maximum number of messages to have in flight at a given time. Increase this to improve throughput.
-
-
-Type: `int`  
-Default: `64`  
-
-### `publish_timeout`
-
-The maximum length of time to wait before abandoning a publish attempt for a message.
-
-
-Type: `string`  
-Default: `"60s"`  
-
-```yml
-# Examples
-
-publish_timeout: 10s
-
-publish_timeout: 5m
-
-publish_timeout: 60m
-```
-
-### `ordering_key`
-
-The ordering key to use for publishing messages.
-This field supports [interpolation functions](/docs/configuration/interpolation#bloblang-queries).
-
-
-Type: `string`  
-Default: `""`  
 
 ### `endpoint`
 
@@ -161,6 +137,64 @@ endpoint: us-central1-pubsub.googleapis.com:443
 endpoint: us-west3-pubsub.googleapis.com:443
 ```
 
+### `ordering_key`
+
+The ordering key to use for publishing messages.
+This field supports [interpolation functions](/docs/configuration/interpolation#bloblang-queries).
+
+
+Type: `string`  
+
+### `max_in_flight`
+
+The maximum number of messages to have in flight at a given time. Increasing this may improve throughput.
+
+
+Type: `int`  
+Default: `64`  
+
+### `count_threshold`
+
+Publish a pubsub buffer when it has this many messages
+
+
+Type: `int`  
+Default: `100`  
+
+### `delay_threshold`
+
+Publish a non-empty pubsub buffer after this delay has passed.
+
+
+Type: `string`  
+Default: `"10ms"`  
+
+### `byte_threshold`
+
+Publish a batch when its size in bytes reaches this value.
+
+
+Type: `int`  
+Default: `1000000`  
+
+### `publish_timeout`
+
+The maximum length of time to wait before abandoning a publish attempt for a message.
+
+
+Type: `string`  
+Default: `"1m0s"`  
+
+```yml
+# Examples
+
+publish_timeout: 10s
+
+publish_timeout: 5m
+
+publish_timeout: 60m
+```
+
 ### `metadata`
 
 Specify criteria for which metadata values are sent as attributes.
@@ -168,13 +202,45 @@ Specify criteria for which metadata values are sent as attributes.
 
 Type: `object`  
 
-### `metadata.exclude_prefixes`
+### `metadata.include_prefixes`
 
-Provide a list of explicit metadata key prefixes to be excluded when adding metadata to sent messages.
+Provide a list of explicit metadata key prefixes to match against.
 
 
 Type: `array`  
 Default: `[]`  
+
+```yml
+# Examples
+
+include_prefixes:
+  - foo_
+  - bar_
+
+include_prefixes:
+  - kafka_
+
+include_prefixes:
+  - content-
+```
+
+### `metadata.include_patterns`
+
+Provide a list of explicit metadata key regular expression (re2) patterns to match against.
+
+
+Type: `array`  
+Default: `[]`  
+
+```yml
+# Examples
+
+include_patterns:
+  - .*
+
+include_patterns:
+  - _timestamp_unix$
+```
 
 ### `flow_control`
 
@@ -182,14 +248,6 @@ For a given topic, configures the PubSub client's internal buffer for messages t
 
 
 Type: `object`  
-
-### `flow_control.max_outstanding_messages`
-
-Maximum number of buffered messages to be published. If less than or equal to zero, this is disabled.
-
-
-Type: `int`  
-Default: `1000`  
 
 ### `flow_control.max_outstanding_bytes`
 
@@ -199,13 +257,117 @@ Maximum size of buffered messages to be published. If less than or equal to zero
 Type: `int`  
 Default: `-1`  
 
+### `flow_control.max_outstanding_messages`
+
+Maximum number of buffered messages to be published. If less than or equal to zero, this is disabled.
+
+
+Type: `int`  
+Default: `1000`  
+
 ### `flow_control.limit_exceeded_behavior`
 
-Configures the behavior when trying to publish additional messages while the flow controller is full. The available options are ignore (disable, default), block, and signal_error (publish results will return an error).
+Configures the behavior when trying to publish additional messages while the flow controller is full. The available options are block (default), ignore (disable), and signal_error (publish results will return an error).
 
 
 Type: `string`  
-Default: `"ignore"`  
+Default: `"block"`  
 Options: `ignore`, `block`, `signal_error`.
+
+### `batching`
+
+Configures a batching policy on this output. While the PubSub client maintains its own internal buffering mechanism, preparing larger batches of messages can futher trade-off some latency for throughput.
+
+
+Type: `object`  
+
+```yml
+# Examples
+
+batching:
+  byte_size: 5000
+  count: 0
+  period: 1s
+
+batching:
+  count: 10
+  period: 1s
+
+batching:
+  check: this.contains("END BATCH")
+  count: 0
+  period: 1m
+```
+
+### `batching.count`
+
+A number of messages at which the batch should be flushed. If `0` disables count based batching.
+
+
+Type: `int`  
+Default: `0`  
+
+### `batching.byte_size`
+
+An amount of bytes at which the batch should be flushed. If `0` disables size based batching.
+
+
+Type: `int`  
+Default: `0`  
+
+### `batching.period`
+
+A period in which an incomplete batch should be flushed regardless of its size.
+
+
+Type: `string`  
+Default: `""`  
+
+```yml
+# Examples
+
+period: 1s
+
+period: 1m
+
+period: 500ms
+```
+
+### `batching.check`
+
+A [Bloblang query](/docs/guides/bloblang/about/) that should return a boolean value indicating whether a message should end a batch.
+
+
+Type: `string`  
+Default: `""`  
+
+```yml
+# Examples
+
+check: this.type == "end_of_transaction"
+```
+
+### `batching.processors`
+
+A list of [processors](/docs/components/processors/about) to apply to a batch as it is flushed. This allows you to aggregate and archive the batch however you see fit. Please note that all resulting messages are flushed as a single batch, therefore splitting the batch into smaller batches using these processors is a no-op.
+
+
+Type: `array`  
+
+```yml
+# Examples
+
+processors:
+  - archive:
+      format: concatenate
+
+processors:
+  - archive:
+      format: lines
+
+processors:
+  - archive:
+      format: json_array
+```
 
 


### PR DESCRIPTION
This change rewrites the gcp_pubsub output to use the new config API and to lean on the pubsub client's internal batching mechanism. This is referred to as the "internal buffer" in docs to distinguish it from Benthos' batching mechanism. The rewrite also benefits from added tests and a pubsub mock.

Stress test results on an M1 Pro (8-core, 16GB mem): 

![prometheus metric graph of `rate(output_sent[30s])` for today's gcp_pubsub output, peaking at around 1.7K messages per second, and the new one in this pull request, peaking at around 10K mesages per second](https://user-images.githubusercontent.com/678548/232035132-2202ad57-f798-403f-acfc-1f575fc7fdd5.png)

(`gc_gcp_pubsub` is the working name of the output in this PR that doesn't clash with the existig output)