### PR TITLE
fix service.BatchError implementation

### DIFF
--- a/internal/message/sort_group.go
+++ b/internal/message/sort_group.go
@@ -38,7 +38,8 @@ func NewSortGroupParts(parts []*Part) (*SortGroup, []*Part) {
 	return g, newParts
 }
 
-// NewSortGroup creates a new sort group to be associated with a.
+// NewSortGroup creates a new sort group to be associated with messages in a
+// batch.
 func NewSortGroup(m Batch) (*SortGroup, Batch) {
 	inParts := make([]*Part, len(m))
 	_ = m.Iter(func(i int, part *Part) error {

--- a/public/service/errors.go
+++ b/public/service/errors.go
@@ -64,6 +64,10 @@ func (err *BatchError) Error() string {
 	return err.wrapped.Error()
 }
 
+func (err *BatchError) Unwrap() error {
+	return err.wrapped
+}
+
 // If the provided error is not nil and can be cast to an internal batch error
 // we return a public batch error.
 func toPublicBatchError(err error) error {

--- a/public/service/errors.go
+++ b/public/service/errors.go
@@ -11,6 +11,7 @@ import (
 // collection (usually a batch) of messages and provides methods to iterate
 // over these errors.
 type BatchError struct {
+	group   *message.SortGroup
 	wrapped *batch.Error
 }
 
@@ -21,13 +22,15 @@ type BatchError struct {
 // A headline error must be supplied which will be exposed when upstream
 // components do not support granular batch errors.
 func NewBatchError(b MessageBatch, headline error) *BatchError {
-	ibatch := make(message.Batch, len(b))
+	ib := make(message.Batch, len(b))
 	for i, m := range b {
-		ibatch[i] = m.part
+		ib[i] = m.part
 	}
 
+	group, ibatch := message.NewSortGroup(ib)
 	batchErr := batch.NewError(ibatch, headline)
-	return &BatchError{wrapped: batchErr}
+
+	return &BatchError{group: group, wrapped: batchErr}
 }
 
 // Failed stores an error state for a particular message of a batch. Returns a
@@ -47,8 +50,8 @@ func (err *BatchError) Failed(i int, merr error) *BatchError {
 // itself was processed successfully. The closure should return a bool which
 // indicates whether the iteration should be continued.
 func (err *BatchError) WalkMessages(fn func(int, *Message, error) bool) {
-	sortGroup, iBatch := message.NewSortGroup(err.wrapped.XErroredBatch())
-	err.wrapped.WalkParts(sortGroup, iBatch, func(i int, p *message.Part, err error) bool {
+	b := err.wrapped.XErroredBatch()
+	err.wrapped.WalkParts(err.group, b, func(i int, p *message.Part, err error) bool {
 		return fn(i, &Message{part: p}, err)
 	})
 }

--- a/public/service/errors_test.go
+++ b/public/service/errors_test.go
@@ -23,12 +23,18 @@ func TestMockWalkableError(t *testing.T) {
 
 	require.Equal(t, err.IndexedErrors(), len(batch), "indexed errors did not match size of batch")
 	require.ErrorIs(t, err, batchError, "headline error is not propagated")
+
+	runs := 0
 	err.WalkMessages(func(i int, m *Message, err error) bool {
+		runs++
+
 		bs, berr := m.AsBytes()
 		require.NoErrorf(t, berr, "could not get bytes from message at %d", i)
 		require.Equal(t, err.Error(), fmt.Sprintf("%s error", bs))
 		return true
 	})
+
+	require.Equal(t, len(batch), runs, "WalkMessages did not iterate the whole batch")
 }
 
 func TestMockWalkableError_ExcessErrors(t *testing.T) {

--- a/public/service/errors_test.go
+++ b/public/service/errors_test.go
@@ -22,7 +22,7 @@ func TestMockWalkableError(t *testing.T) {
 		Failed(2, errors.New("c error"))
 
 	require.Equal(t, err.IndexedErrors(), len(batch), "indexed errors did not match size of batch")
-	require.Equal(t, err.Error(), batchError.Error(), "headline error is not propagated")
+	require.ErrorIs(t, err, batchError, "headline error is not propagated")
 	err.WalkMessages(func(i int, m *Message, err error) bool {
 		bs, berr := m.AsBytes()
 		require.NoErrorf(t, berr, "could not get bytes from message at %d", i)


### PR DESCRIPTION
* Implementing Unwrap on *service.BatchError
* Fixing bug where (*service.BatchError).WalkMessages does not iterate any messages in a batch