### PR TITLE
add delivery attempts metadata to gcp_pubsub input

### DIFF
--- a/internal/impl/gcp/input_pubsub.go
+++ b/internal/impl/gcp/input_pubsub.go
@@ -34,7 +34,8 @@ For information on how to set up credentials check out
 This input adds the following metadata fields to each message:
 
 ` + "``` text" + `
-- gcp_pubsub_publish_time_unix
+- gcp_pubsub_publish_time_unix - The time at which the message was published to the topic.
+- gcp_pubsub_delivery_attempt - When dead lettering is enabled, this is set to the number of times PubSub has attempted to deliver a message.
 - All message attributes
 ` + "```" + `
 
@@ -202,6 +203,10 @@ func (c *gcpPubSubReader) ReadBatch(ctx context.Context) (message.Batch, input.A
 		part.MetaSetMut(k, v)
 	}
 	part.MetaSetMut("gcp_pubsub_publish_time_unix", gmsg.PublishTime.Unix())
+
+	if gmsg.DeliveryAttempt != nil {
+		part.MetaSetMut("gcp_pubsub_delivery_attempt", *gmsg.DeliveryAttempt)
+	}
 
 	msg := message.Batch{part}
 	return msg, func(ctx context.Context, res error) error {

--- a/website/docs/components/inputs/gcp_pubsub.md
+++ b/website/docs/components/inputs/gcp_pubsub.md
@@ -67,7 +67,8 @@ For information on how to set up credentials check out
 This input adds the following metadata fields to each message:
 
 ``` text
-- gcp_pubsub_publish_time_unix
+- gcp_pubsub_publish_time_unix - The time at which the message was published to the topic.
+- gcp_pubsub_delivery_attempt - When dead lettering is enabled, this is set to the number of times PubSub has attempted to deliver a message.
 - All message attributes
 ```
 


### PR DESCRIPTION
This change introduces a new metadata field to messages from the gcp_pubsub input called `gcp_pubsub_delivery_attempt`. This field is set when a subscription has dead-lettering enabled and it tracks the number of attempts that PubSub tried to deliver a message for a given subscription.

Sample config:

```yaml
input:
  gcp_pubsub:
    project: ${GCP_PROJECT}
    subscription: ${SUBSCRIPTION_ID}

pipeline:
  processors:
    - log:
        level: INFO
        message: "${! content() }"
    - log:
        level: INFO
        message: "Publish attempts: ${! @gcp_pubsub_delivery_attempt }"

output:
  reject: "simulated error"
```

![pubsub_delivery_attempts_meta](https://user-images.githubusercontent.com/678548/231144071-ffaee611-190e-4b03-ae57-d1e3015245b1.png)

