### PR TITLE
add `changestream` support for mongodb input

### DIFF
--- a/internal/impl/mongodb/input.go
+++ b/internal/impl/mongodb/input.go
@@ -39,7 +39,7 @@ func mongoConfigSpec() *service.ConfigSpec {
 			Description("The mongodb operation to perform.").
 			Default(FindInputOperation).Advanced().
 			Version("4.2.0")).
-		Field(service.NewStringField("resume_token_file").Description("State directory to restore/save resume token").Optional()).
+		Field(service.NewStringField("resume_token_file").Description("Resume token file to read or save resume token").Optional()).
 		Field(service.NewStringAnnotatedEnumField("json_marshal_mode", map[string]string{
 			string(client.JSONMarshalModeCanonical): "A string format that emphasizes type preservation at the expense of readability and interoperability. " +
 				"That is, conversion from canonical to BSON will generally preserve type information except in certain specific cases. ",

--- a/internal/impl/mongodb/input.go
+++ b/internal/impl/mongodb/input.go
@@ -126,7 +126,6 @@ func newMongoInput(conf *service.ParsedConfig) (service.Input, error) {
 		return &mongoInput{
 			query:           pipeline,
 			config:          config,
-			label:           conf.Label(),
 			operation:       operation,
 			resumeTokenPath: resumeTokenPath,
 			marshalCanon:    marshalMode == string(client.JSONMarshalModeCanonical),
@@ -141,7 +140,6 @@ type mongoInput struct {
 	cursor          *mongo.Cursor
 	changeStream    *mongo.ChangeStream
 	resumeTokenPath *string
-	label           string
 	operation       string
 	marshalCanon    bool
 }

--- a/public/service/config.go
+++ b/public/service/config.go
@@ -822,8 +822,3 @@ func (p *ParsedConfig) FieldObjectList(path ...string) ([]*ParsedConfig, error) 
 	}
 	return sList, nil
 }
-
-// Label return label name for current input.
-func (p *ParsedConfig) Label() string {
-	return p.mgr.Label()
-}

--- a/public/service/config.go
+++ b/public/service/config.go
@@ -822,3 +822,8 @@ func (p *ParsedConfig) FieldObjectList(path ...string) ([]*ParsedConfig, error) 
 	}
 	return sList, nil
 }
+
+// Label return label name for current input.
+func (p *ParsedConfig) Label() string {
+	return p.mgr.Label()
+}

--- a/website/docs/components/inputs/mongodb.md
+++ b/website/docs/components/inputs/mongodb.md
@@ -122,7 +122,9 @@ Options: `find`, `aggregate`, `changestream`.
 
 ### `resume_token_file`
 
-The optional directory to read or save mongodb change stream resume token, only works when `operation` is `changestream`.
+The optional file to read or save mongodb change stream resume token, only works when `operation` is
+`changestream`. A resume token will be written into `resume_token_file` as soon as the changed document has been `Decoded`
+successfully(not processed successfully).
 
 
 Type: `string`

--- a/website/docs/components/inputs/mongodb.md
+++ b/website/docs/components/inputs/mongodb.md
@@ -72,7 +72,7 @@ Once the rows from the query are exhausted this input shuts down, allowing the p
 The URL of the target MongoDB DB.
 
 
-Type: `string`  
+Type: `string`
 
 ```yml
 # Examples
@@ -85,49 +85,58 @@ url: mongodb://localhost:27017
 The name of the target MongoDB database.
 
 
-Type: `string`  
+Type: `string`
 
 ### `collection`
 
 The collection to select from.
 
 
-Type: `string`  
+Type: `string`
 
 ### `username`
 
 The username to connect to the database.
 
 
-Type: `string`  
-Default: `""`  
+Type: `string`
+Default: `""`
 
 ### `password`
 
 The password to connect to the database.
 
 
-Type: `string`  
-Default: `""`  
+Type: `string`
+Default: `""`
 
 ### `operation`
 
 The mongodb operation to perform.
 
 
-Type: `string`  
-Default: `"find"`  
-Requires version 4.2.0 or newer  
-Options: `find`, `aggregate`.
+Type: `string`
+Default: `"find"`
+Requires version 4.2.0 or newer
+Options: `find`, `aggregate`, `changestream`.
+
+### `resume_token_file`
+
+The optional directory to read or save mongodb change stream resume token, only works when `operation` is `changestream`.
+
+
+Type: `string`
+Requires version 4.14.0 or newer
+
 
 ### `json_marshal_mode`
 
 The json_marshal_mode setting is optional and controls the format of the output message.
 
 
-Type: `string`  
-Default: `"canonical"`  
-Requires version 4.7.0 or newer  
+Type: `string`
+Default: `"canonical"`
+Requires version 4.7.0 or newer
 
 | Option | Summary |
 |---|---|
@@ -140,7 +149,7 @@ Requires version 4.7.0 or newer
 Bloblang expression describing MongoDB query.
 
 
-Type: `string`  
+Type: `string`
 
 ```yml
 # Examples


### PR DESCRIPTION
An example for this feature is as following:

```yaml
# Common config fields, showing default values
input:
  label: ""
  mongodb:
    url: "mongodb://mongodb-0.mongodb-headless.develop.svc.cluster.local:27017,mongodb-1.mongodb-headless.develop.svc.cluster.local:27017/admin?readPreference=secondary&replicaSet=rs0&authSource=admin"
    database: "db"
    collection: "collection"
    username: "..."
    password: "..."
    operation: changestream
    resume_token_file: ~/.benthos/resume_token # make sure the directory exist
    query: ""
# Config fields, showing default values
output:
  label: ""
  file:
    path: "./output-file.txt"
    codec: lines
```

**NOTE**: Please make sure the `mongodb.*` parameters are correct.

Former configuration will follow mongodb change stream and write every changes into file `./output-file.txt` and a resume token bound to current changed document will be also written into `~/.benthos/resume_token` (**make sure the directory is already exist**) as soon as `benthos` has decoded this event.