### PR TITLE
support adding context to errors in bloblang

### DIFF
--- a/internal/bloblang/query/errors.go
+++ b/internal/bloblang/query/errors.go
@@ -151,3 +151,12 @@ func NewTypeMismatch(operation string, lfn, rfn Function, left, right any) *Type
 		Operation: operation,
 	}
 }
+
+type ContextualError struct {
+	message string
+	Context map[string]any
+}
+
+func (ce *ContextualError) Error() string {
+	return ce.message
+}

--- a/internal/bloblang/query/functions.go
+++ b/internal/bloblang/query/functions.go
@@ -353,6 +353,30 @@ var _ = registerSimpleFunction(
 
 var _ = registerSimpleFunction(
 	NewFunctionSpec(
+		FunctionCategoryMessage, "error_with_context",
+		"If an error has occurred during the processing of a message this function returns the reported cause of the error as a string, otherwise `null`. For more information about error handling patterns read [here][error_handling].",
+		NewExampleSpec("",
+			`root.doc.error = error_with_context()`,
+		),
+	),
+	func(ctx FunctionContext) (any, error) {
+		v := ctx.MsgBatch.Get(ctx.Index).ErrorGet()
+		if v == nil {
+			return nil, nil
+		}
+
+		var ce *ContextualError
+		ok := errors.As(v, &ce)
+		if !ok {
+			return map[string]any{"message": v.Error()}, nil
+		}
+
+		return map[string]any{"message": v.Error(), "context": ce.Context}, nil
+	},
+)
+
+var _ = registerSimpleFunction(
+	NewFunctionSpec(
 		FunctionCategoryMessage, "errored",
 		"Returns a boolean value indicating whether an error has occurred during the processing of a message. For more information about error handling patterns read [here][error_handling].",
 		NewExampleSpec("",
@@ -789,14 +813,26 @@ root.doc.contents = (this.body.content | this.thing.body)`,
 			`{"nothing":"matches"}`,
 			`Error("failed assignment (line 1): unknown type")`,
 		),
-	).Param(ParamString("why", "A string explanation for why an error was thrown, this will be added to the resulting error message.")),
+	).
+		Param(ParamString("why", "A string explanation for why an error was thrown, this will be added to the resulting error message.")).
+		Param(ParamObject("context", "Additional data that can be associated with the error and later retrieved.").Optional()),
 	func(args *ParsedParams) (Function, error) {
 		msg, err := args.FieldString("why")
 		if err != nil {
 			return nil, err
 		}
+
+		context, err := args.FieldOptionalObject("context")
+		if err != nil {
+			return nil, err
+		}
+
 		return ClosureFunction("function throw", func(_ FunctionContext) (any, error) {
-			return nil, errors.New(msg)
+			if context == nil {
+				return nil, errors.New(msg)
+			}
+
+			return nil, &ContextualError{message: msg, Context: *context}
 		}, nil), nil
 	},
 )

--- a/internal/bloblang/query/params.go
+++ b/internal/bloblang/query/params.go
@@ -522,6 +522,35 @@ func (p *ParsedParams) FieldOptionalArray(n string) (*[]any, error) {
 	return &a, nil
 }
 
+// FieldObject returns an object value with a given name.
+func (p *ParsedParams) FieldObject(n string) (map[string]any, error) {
+	v, err := p.Field(n)
+	if err != nil {
+		return nil, err
+	}
+	a, ok := v.(map[string]any)
+	if !ok {
+		return nil, NewTypeError(v, ValueObject)
+	}
+	return a, nil
+}
+
+// FieldOptionalObject returns an optional object value with a given name.
+func (p *ParsedParams) FieldOptionalObject(n string) (*map[string]any, error) {
+	v, err := p.Field(n)
+	if err != nil {
+		return nil, err
+	}
+	if v == nil {
+		return nil, nil
+	}
+	a, ok := v.(map[string]any)
+	if !ok {
+		return nil, NewTypeError(v, ValueObject)
+	}
+	return &a, nil
+}
+
 // FieldString returns a string argument value with a given name.
 func (p *ParsedParams) FieldString(n string) (string, error) {
 	v, err := p.Field(n)

--- a/website/docs/guides/bloblang/functions.md
+++ b/website/docs/guides/bloblang/functions.md
@@ -196,6 +196,7 @@ Throws an error similar to a regular mapping error. This is useful for abandonin
 #### Parameters
 
 **`why`** &lt;string&gt; A string explanation for why an error was thrown, this will be added to the resulting error message.  
+**`context`** &lt;(optional) object&gt; Additional data that can be associated with the error and later retrieved.  
 
 #### Examples
 
@@ -273,6 +274,17 @@ If an error has occurred during the processing of a message this function return
 
 ```coffee
 root.doc.error = error()
+```
+
+### `error_with_context`
+
+If an error has occurred during the processing of a message this function returns the reported cause of the error as a string, otherwise `null`. For more information about error handling patterns read [here][error_handling].
+
+#### Examples
+
+
+```coffee
+root.doc.error = error_with_context()
 ```
 
 ### `errored`


### PR DESCRIPTION
This change updates the bloblang function `throw` to take a second, optional argument which is an object containing useful context about the error. This context can then be retrieved using the newly-added `error_with_context` function.

Sample usage:

```yaml
input:
  generate:
    count: 1
    mapping: root = "hello world"

pipeline:
  processors:
    - mutation: |
        root = throw(
          "what a bad day",
          {"error_code": "simulated_error", "error_kind": "permanent"}
        )
    - log:
        level: ERROR
        message: >-
          ${! "error occurred: %s (%s, %s)".format(
            error_with_context().message,
            error_with_context().context.error_code,
            error_with_context().context.error_kind
          )}

output:
  drop: {}
```