### PR TITLE
re-export msgpack plugins via public interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ All notable changes to this project will be documented in this file.
 
 - Flag `--skip-env-var-check` added to the `lint` subcommand, this disables the new linting behaviour where environment variable interpolations without defaults throw linting errors when the variable is not defined.
 
+### Fixed
+
+- Provide msgpack plugins through github.com/benthosdev/benthos/v4/public/components/msgpack
+
 ## 4.14.0 - 2023-04-25
 
 ### Added

--- a/public/components/all/package.go
+++ b/public/components/all/package.go
@@ -29,6 +29,7 @@ import (
 	_ "github.com/benthosdev/benthos/v4/public/components/memcached"
 	_ "github.com/benthosdev/benthos/v4/public/components/mongodb"
 	_ "github.com/benthosdev/benthos/v4/public/components/mqtt"
+	_ "github.com/benthosdev/benthos/v4/public/components/msgpack"
 	_ "github.com/benthosdev/benthos/v4/public/components/nanomsg"
 	_ "github.com/benthosdev/benthos/v4/public/components/nats"
 	_ "github.com/benthosdev/benthos/v4/public/components/nsq"

--- a/public/components/msgpack/package.go
+++ b/public/components/msgpack/package.go
@@ -1,0 +1,6 @@
+package msgpack
+
+import (
+	// Bring in the internal plugin definitions.
+	_ "github.com/benthosdev/benthos/v4/internal/impl/msgpack"
+)


### PR DESCRIPTION
The msgpack bloblang and processor plugins were not exposed through public/components package. This change re-exports these plugins so they can be cherry-picked in custom Benthos builds.