### PR TITLE
Add log and try template examples

### DIFF
--- a/config/template_examples/output_log.yml
+++ b/config/template_examples/output_log.yml
@@ -1,0 +1,41 @@
+name: log
+type: output
+status: experimental
+summary: Behaves exactly like `log` processor but as an output.
+
+fields:
+  - name: level
+    type: string
+    default: INFO
+    description: |-
+       The log level to use.
+       Options: FATAL, ERROR, WARN, INFO, DEBUG, TRACE, ALL.
+
+  - name: fields_mapping
+    type: string
+    default: "root = this"
+    description: |-
+      An optional Bloblang mapping that can be used to specify extra fields to add to the log.
+      If log fields are also added with the fields field then those values will override matching keys from this mapping.
+
+  - name: message
+    type: string
+    default: ""
+    description: |-
+      The message to print. This field supports interpolation functions.
+
+mapping: |-
+  #!blobl
+  root.stdout = {}
+  root.processors = [
+    {
+      "log": {
+        "level": this.level,
+        "message": this.message,
+        "fields_mapping": this.fields_mapping
+      }
+    },
+    {
+      "mapping": "root = deleted()"
+    }
+  ]

--- a/config/template_examples/output_try.yml
+++ b/config/template_examples/output_try.yml
@@ -1,0 +1,27 @@
+name: try
+type: output
+status: experimental
+summary: Behaves exactly like `broker` output with the pattern `fan_out_sequential`
+
+fields:
+  - name: outputs
+    type: unknown
+    kind: list
+    description: |-
+      List of child outputs
+
+  - name: processors
+    type: unknown
+    kind: list
+    default: []
+    description: |-
+      List of processors to run before output
+
+mapping: |-
+  #!blobl
+  root.broker = {
+    "pattern": "fan_out_sequential",
+    "outputs": this.outputs,
+
+  }
+  root.processors = this.processors


### PR DESCRIPTION
This PR includes two handy outputs:

- log - Behaves exactly like `log` processor but as an output.
- try -  Behaves exactly like `broker` output with the pattern `fan_out_sequential`