### PR TITLE
feat: Add SetPrintLoggerAtLevel method to StreamBuilder

### DIFF
--- a/public/service/stream_builder.go
+++ b/public/service/stream_builder.go
@@ -125,6 +125,13 @@ func (s *StreamBuilder) SetPrintLogger(l PrintLogger) {
 	s.customLogger = log.Wrap(l)
 }
 
+// SetPrintLoggerAtLevel sets a custom logger supporting a simple Print based interface
+// to be used by stream components, and specifies the logging level. This custom logger
+// will override any logging fields set via config.
+func (s *StreamBuilder) SetPrintLoggerAtLevel(l PrintLogger, level int) {
+	s.customLogger = log.WrapAtLevel(l, level)
+}
+
 // HTTPMultiplexer is an interface supported by most HTTP multiplexers.
 type HTTPMultiplexer interface {
 	HandleFunc(pattern string, handler func(http.ResponseWriter, *http.Request))


### PR DESCRIPTION
This commit adds a new method SetPrintLoggerAtLevel to StreamBuilder, which allows setting a custom logger supporting a simple Print-based interface for use by stream components, and specifying the logging level. This custom logger will override any logging fields set via configuration.