### PR TITLE
fix definition for `label` and `processors` in CUE

### DIFF
--- a/internal/cuegen/component.go
+++ b/internal/cuegen/component.go
@@ -28,25 +28,6 @@ func doComponents(specs []docs.ComponentSpec, opts *componentOptions) ([]ast.Dec
 		fields = append(fields, field)
 	}
 
-	var addons []any
-	if opts.canLabel {
-		addons = append(
-			addons,
-			ast.NewIdent("label"),
-			token.OPTION,
-			ast.NewIdent("string"),
-		)
-	}
-
-	if opts.canPreProcess {
-		addons = append(
-			addons,
-			ast.NewIdent("processors"),
-			token.OPTION,
-			ast.NewList(&ast.Ellipsis{Type: ast.NewIdent("#Processor")}),
-		)
-	}
-
 	decls := []ast.Decl{
 		&ast.Field{
 			Label: opts.collectionIdent,
@@ -70,21 +51,24 @@ func doComponents(specs []docs.ComponentSpec, opts *componentOptions) ([]ast.Dec
 		},
 	}
 
-	if len(addons) > 0 {
+	if opts.canLabel {
 		decls = append(decls, &ast.Field{
 			Label: opts.disjunctionIdent,
-			Value: ast.NewBinExpr(
-				token.AND,
-				opts.disjunctionIdent,
-				ast.NewStruct(
-					ast.NewIdent("processors"),
-					token.OPTION,
-					ast.NewList(&ast.Ellipsis{Type: ast.NewIdent("#Processor")}),
+			Value: ast.NewStruct(
+				ast.NewIdent("label"),
+				token.OPTION,
+				ast.NewIdent("string"),
+			),
+		})
+	}
 
-					ast.NewIdent("label"),
-					token.OPTION,
-					ast.NewIdent("string"),
-				),
+	if opts.canPreProcess {
+		decls = append(decls, &ast.Field{
+			Label: opts.disjunctionIdent,
+			Value: ast.NewStruct(
+				ast.NewIdent("processors"),
+				token.OPTION,
+				ast.NewList(&ast.Ellipsis{Type: ast.NewIdent("#Processor")}),
 			),
 		})
 	}


### PR DESCRIPTION
The logic used to determine if Benthos components can have an associated `label` or `processors` was broken and specifically for the #Processors produced an infinite recursion. The output was:

```cue
#Processor: or([ for name, config in #AllProcessors {
	(name): config
}])
#Processor: #Processor & {
	processors?: [...#Processor]
	label?: string
}
```

The code has been updated to correctly generate this augmentation and we now have the following:

```cue
#Processor: or([ for name, config in #AllProcessors {
	(name): config
}])
#Processor: {
	label?: string
}
```