### PR TITLE
document `unarchive` processor metadata handling

### DIFF
--- a/internal/impl/pure/processor_unarchive.go
+++ b/internal/impl/pure/processor_unarchive.go
@@ -24,7 +24,9 @@ func unarchiveProcConfig() *service.ConfigSpec {
 		Description(`
 When a message is unarchived the new messages replace the original message in the batch. Messages that are selected but fail to unarchive (invalid format) will remain unchanged in the message batch but will be flagged as having failed, allowing you to [error handle them](/docs/configuration/error_handling).
 
-For the unarchive formats that contain file information (tar, zip), a metadata field is added to each message called ` + "`archive_filename`" + ` with the extracted filename.
+## Metadata
+
+The metadata found on the messages handled by this processor will be copied into the resulting messages. For the unarchive formats that contain file information (tar, zip), a metadata field is also added to each message called ` + "`archive_filename`" + ` with the extracted filename.
 `).
 		Field(service.NewStringAnnotatedEnumField("format", map[string]string{
 			`tar`:            `Extract messages from a unix standard tape archive.`,

--- a/website/docs/components/processors/unarchive.md
+++ b/website/docs/components/processors/unarchive.md
@@ -25,7 +25,9 @@ unarchive:
 
 When a message is unarchived the new messages replace the original message in the batch. Messages that are selected but fail to unarchive (invalid format) will remain unchanged in the message batch but will be flagged as having failed, allowing you to [error handle them](/docs/configuration/error_handling).
 
-For the unarchive formats that contain file information (tar, zip), a metadata field is added to each message called `archive_filename` with the extracted filename.
+## Metadata
+
+The metadata found on the messages handled by this processor will be copied into the resulting messages. For the unarchive formats that contain file information (tar, zip), a metadata field is also added to each message called `archive_filename` with the extracted filename.
 
 
 ## Fields


### PR DESCRIPTION
This change updates the documentation for the `unarchive` processor to explicitly mention that metadata is preserved from the source message to resulting messages.