### PR TITLE
added basic protobuf support to `schema_registry_decode`

### DIFF
--- a/internal/impl/confluent/processor_schema_registry_decode.go
+++ b/internal/impl/confluent/processor_schema_registry_decode.go
@@ -39,7 +39,7 @@ func schemaRegistryDecoderConfig() *service.ConfigSpec {
 		Description(`
 Decodes messages automatically from a schema stored within a [Confluent Schema Registry service](https://docs.confluent.io/platform/current/schema-registry/index.html) by extracting a schema ID from the message and obtaining the associated schema from the registry. If a message fails to match against the schema then it will remain unchanged and the error can be caught using error handling methods outlined [here](/docs/configuration/error_handling).
 
-Currently only Avro schemas are supported.
+Currently only Avro and Protobuf schemas are supported.
 
 ### Avro JSON Format
 
@@ -54,7 +54,17 @@ For example, the union schema ` + "`[\"null\",\"string\",\"Foo\"]`, where `Foo`"
 - the string ` + "`\"a\"` as `{\"string\": \"a\"}`" + `; and
 - a ` + "`Foo` instance as `{\"Foo\": {...}}`, where `{...}` indicates the JSON encoding of a `Foo`" + ` instance.
 
-However, it is possible to instead create documents in [standard/raw JSON format](https://pkg.go.dev/github.com/linkedin/goavro/v2#NewCodecForStandardJSONFull) by setting the field ` + "[`avro_raw_json`](#avro_raw_json) to `true`" + `.`).
+However, it is possible to instead create documents in [standard/raw JSON format](https://pkg.go.dev/github.com/linkedin/goavro/v2#NewCodecForStandardJSONFull) by setting the field ` + "[`avro_raw_json`](#avro_raw_json) to `true`" + `.` +
+			`
+### Protobuf Format
+
+This processor decodes protobuf messages to JSON documents, you can read more about JSON mapping of protobuf messages here: https://developers.google.com/protocol-buffers/docs/proto3#json
+
+Current limitations:
+* It only supports protobuf definition with only ONE message type.
+* [Schema reference](https://docs.confluent.io/platform/current/schema-registry/fundamentals/serdes-develop/serdes-protobuf.html#schema-references-in-protobuf) is not supported yet.
+
+`).
 		Field(service.NewBoolField("avro_raw_json").
 			Description("Whether Avro messages should be decoded into normal JSON (\"json that meets the expectations of regular internet json\") rather than [Avro JSON](https://avro.apache.org/docs/current/specification/_print/#json-encoding). If `true` the schema returned from the subject should be decoded as [standard json](https://pkg.go.dev/github.com/linkedin/goavro/v2#NewCodecForStandardJSONFull) instead of as [avro json](https://pkg.go.dev/github.com/linkedin/goavro/v2#NewCodec). There is a [comment in goavro](https://github.com/linkedin/goavro/blob/5ec5a5ee7ec82e16e6e2b438d610e1cab2588393/union.go#L224-L249), the [underlining library used for avro serialization](https://github.com/linkedin/goavro), that explains in more detail the difference between the standard json and avro json.").
 			Advanced().Default(false)).

--- a/internal/impl/confluent/processor_schema_registry_decode.go
+++ b/internal/impl/confluent/processor_schema_registry_decode.go
@@ -355,7 +355,6 @@ func (s *schemaRegistryDecoder) getDecoder(id int) (schemaDecoder, error) {
 	if resPayload.Type == "PROTOBUF" {
 		decoder, err = s.getProtobufDecoder(resPayload)
 	} else {
-		// https://github.com/confluentinc/schema-registry/blob/master/avro-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaAvroSerializer.java#L93
 		decoder, err = s.getAvroDecoder(resPayload)
 	}
 
@@ -400,15 +399,13 @@ func (s *schemaRegistryDecoder) getProtobufDecoder(info schemaInfo) (schemaDecod
 			return err
 		}
 
-		// The next section is the list of message indexes. Here we only support protobuf definitation with only one message type.
-		// https://docs.confluent.io/platform/current/schema-registry/fundamentals/serdes-develop/index.html#wire-format
 		bytesRead, msgIndexes, err := readMessageIndexes(b)
 		if err != nil {
 			return err
 		}
 
-		if bytesRead > 1 || len(msgIndexes) > 1 {
-			return fmt.Errorf("not supported")
+		if len(msgIndexes) > 1 {
+			return fmt.Errorf("invalid number of message type in in protobuf definition, expected 1 got %d", len(msgIndexes))
 		}
 
 		msg := dynamic.NewMessage(msgTypes[msgIndexes[0]])

--- a/internal/impl/confluent/processor_schema_registry_decode_test.go
+++ b/internal/impl/confluent/processor_schema_registry_decode_test.go
@@ -167,6 +167,17 @@ const testSchemaLogicalTypes = `{
 	]
 }`
 
+const testProtoSchema = `
+syntax = "proto3";
+package ksql;
+
+message users {
+  int64 registertime = 1;
+  string userid = 2;
+  string regionid = 3;
+  string gender = 4;
+}`
+
 func TestSchemaRegistryDecodeAvro(t *testing.T) {
 	payload3, err := json.Marshal(struct {
 		Schema string `json:"schema"`
@@ -401,5 +412,66 @@ func TestSchemaRegistryDecodeClearExpired(t *testing.T) {
 		10: {lastUsedUnixSeconds: tNotStale},
 		15: {lastUsedUnixSeconds: tNearlyStale},
 	}, decoder.schemas)
+	decoder.cacheMut.Unlock()
+}
+func TestSchemaRegistryDecodeProtobuf(t *testing.T) {
+	payload1, err := json.Marshal(struct {
+		Type   string `json:"schemaType"`
+		Schema string `json:"schema"`
+	}{
+		Type:   "PROTOBUF",
+		Schema: testProtoSchema,
+	})
+	require.NoError(t, err)
+
+	returnedSchema1 := false
+	urlStr := runSchemaRegistryServer(t, func(path string) ([]byte, error) {
+		switch path {
+		case "/schemas/ids/1":
+			assert.False(t, returnedSchema1)
+			returnedSchema1 = true
+			return payload1, nil
+		}
+		return nil, nil
+	})
+
+	decoder, err := newSchemaRegistryDecoder(urlStr, noopReqSign, nil, false, service.MockResources())
+	require.NoError(t, err)
+
+	tests := []struct {
+		name        string
+		input       string
+		output      string
+		errContains string
+	}{
+		{
+			name:   "successful message",
+			input:  "\x00\x00\x00\x00\x01\x00\b\xa2\xb8\xe2\xec\xaf+\x12\x06User_2\x1a\bRegion_9\"\x05OTHER",
+			output: `{"registertime":"1490313321506","userid":"User_2","regionid":"Region_9","gender":"OTHER"}`,
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			outMsgs, err := decoder.Process(context.Background(), service.NewMessage([]byte(test.input)))
+			if test.errContains != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), test.errContains)
+			} else {
+				require.NoError(t, err)
+				require.Len(t, outMsgs, 1)
+
+				b, err := outMsgs[0].AsBytes()
+				require.NoError(t, err)
+
+				assert.Equal(t, test.output, string(b), "%s: %s", test.name)
+			}
+		})
+	}
+
+	require.NoError(t, decoder.Close(context.Background()))
+	decoder.cacheMut.Lock()
+	assert.Len(t, decoder.schemas, 0)
 	decoder.cacheMut.Unlock()
 }

--- a/internal/impl/confluent/processor_schema_registry_decode_test.go
+++ b/internal/impl/confluent/processor_schema_registry_decode_test.go
@@ -449,6 +449,11 @@ func TestSchemaRegistryDecodeProtobuf(t *testing.T) {
 			input:  "\x00\x00\x00\x00\x01\x00\b\xa2\xb8\xe2\xec\xaf+\x12\x06User_2\x1a\bRegion_9\"\x05OTHER",
 			output: `{"registertime":"1490313321506","userid":"User_2","regionid":"Region_9","gender":"OTHER"}`,
 		},
+		{
+			name:        "not supported message",
+			input:       "\x00\x00\x00\x00\x01\x04\x00\x02\b\xa2\xb8\xe2\xec\xaf+\x12\x06User_2\x1a\bRegion_9\"\x05OTHER",
+			errContains: `invalid number of message type in in protobuf definition, expected 1 got 2`,
+		},
 	}
 
 	for _, test := range tests {

--- a/website/docs/components/processors/schema_registry_decode.md
+++ b/website/docs/components/processors/schema_registry_decode.md
@@ -72,7 +72,7 @@ schema_registry_decode:
 
 Decodes messages automatically from a schema stored within a [Confluent Schema Registry service](https://docs.confluent.io/platform/current/schema-registry/index.html) by extracting a schema ID from the message and obtaining the associated schema from the registry. If a message fails to match against the schema then it will remain unchanged and the error can be caught using error handling methods outlined [here](/docs/configuration/error_handling).
 
-Currently only Avro schemas are supported.
+Currently only Avro and Protobuf schemas are supported.
 
 ### Avro JSON Format
 
@@ -88,6 +88,15 @@ For example, the union schema `["null","string","Foo"]`, where `Foo` is a record
 - a `Foo` instance as `{"Foo": {...}}`, where `{...}` indicates the JSON encoding of a `Foo` instance.
 
 However, it is possible to instead create documents in [standard/raw JSON format](https://pkg.go.dev/github.com/linkedin/goavro/v2#NewCodecForStandardJSONFull) by setting the field [`avro_raw_json`](#avro_raw_json) to `true`.
+### Protobuf Format
+
+This processor decodes protobuf messages to JSON documents, you can read more about JSON mapping of protobuf messages here: https://developers.google.com/protocol-buffers/docs/proto3#json
+
+Current limitations:
+* It only supports protobuf definition with only ONE message type.
+* [Schema reference](https://docs.confluent.io/platform/current/schema-registry/fundamentals/serdes-develop/serdes-protobuf.html#schema-references-in-protobuf) is not supported yet.
+
+
 
 ## Fields
 


### PR DESCRIPTION
Added basic protobuf support for `schema_registry_decode`. Tested with Confluent datagen connector.


Current limitations:
* It only supports protobuf definition with only ONE message type.
* [Schema reference](https://docs.confluent.io/platform/current/schema-registry/fundamentals/serdes-develop/serdes-protobuf.html#schema-references-in-protobuf) is not supported yet.

Related to #1906