### PR TITLE
Remove sync.Mutex/sync.WaitGroup from dispatchMessages

### DIFF
--- a/internal/batch/policy/policy.go
+++ b/internal/batch/policy/policy.go
@@ -149,7 +149,6 @@ func (p *Batcher) Flush(ctx context.Context) message.Batch {
 	if len(resultMsgs) == 1 {
 		return resultMsgs[0]
 	} else if len(resultMsgs) > 1 {
-
 		newMsg = make(message.Batch, 0, len(resultMsgs))
 		for _, m := range resultMsgs {
 			newMsg = append(newMsg, m...)

--- a/internal/batch/policy/policy.go
+++ b/internal/batch/policy/policy.go
@@ -59,14 +59,16 @@ func New(conf batchconfig.Config, mgr bundle.NewManagement) (*Batcher, error) {
 			return nil, fmt.Errorf("failed to parse duration string: %v", err)
 		}
 	}
-	var procs []iprocessor.V1
+
+	procs := make([]iprocessor.V1, len(conf.Processors))
+
 	for i, pconf := range conf.Processors {
 		pMgr := mgr.IntoPath("processors", strconv.Itoa(i))
 		proc, err := pMgr.NewProcessor(pconf)
 		if err != nil {
 			return nil, err
 		}
-		procs = append(procs, proc)
+		procs[i] = proc
 	}
 
 	batchOn := mgr.Metrics().GetCounterVec("batch_created", "mechanism")


### PR DESCRIPTION
Remove WaitGroup and Mutex from dispatchMessages.
    
This PR removes the use of the Mutex and the WaitGroup in dispatchMessages.  Both the Mutex and WaitGroup appear to be unnecessary in this routine.  Additionally, the newPending slice is now allocated up-front to avoid multiple allocations as items are appended.
