### PR TITLE
shallow-copy in gcp_bigquery_select processor

### DIFF
--- a/internal/impl/gcp/processor_bigquery_select.go
+++ b/internal/impl/gcp/processor_bigquery_select.go
@@ -169,6 +169,7 @@ func (proc *bigQuerySelectProcessor) ProcessBatch(ctx context.Context, batch ser
 	outBatch := make(service.MessageBatch, 0, len(batch))
 
 	for i, msg := range batch {
+		msg = msg.Copy()
 		outBatch = append(outBatch, msg)
 
 		var args []any


### PR DESCRIPTION
This change updates the `gcp_bigquery_select` processor to shallow copy incoming messages and mutate the copies rather than unintentionally mutate the original messages.