### PR TITLE
fix message ordering support on gcp_pubsub output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ All notable changes to this project will be documented in this file.
 - Field `wait_time_seconds` added to the `aws_sqs` input.
 - Field `timeout` added to the `gcp_cloud_storage` output.
 
+### Fixed
+
+- Restore message ordering support to `gcp_pubsub` output. This issue was introduced in 4.16.0 as a result of [#1836](https://github.com/benthosdev/benthos/pull/1836).
+
 ### Changed
 
 - The `nats` input default value of `prefetch_count` has been increased from `32` to a more appropriate `524288`.

--- a/internal/impl/gcp/output_pubsub.go
+++ b/internal/impl/gcp/output_pubsub.go
@@ -332,6 +332,10 @@ func (out *pubsubOutput) getTopic(ctx context.Context, name string) (pubsubTopic
 		return nil, fmt.Errorf("topic '%v' does not exist", name)
 	}
 
+	if out.orderingKeyQ != nil {
+		t.EnableOrdering()
+	}
+
 	out.topics[name] = t
 	return t, nil
 }

--- a/internal/impl/gcp/output_pubsub_test.go
+++ b/internal/impl/gcp/output_pubsub_test.go
@@ -92,6 +92,7 @@ func TestPubSubOutput_MessageAttr(t *testing.T) {
 
 	fooTopic := &mockTopic{}
 	fooTopic.On("Exists").Return(true, nil).Once()
+	fooTopic.On("EnableOrdering").Return().Once()
 	fooTopic.On("Stop").Return().Once()
 
 	fooMsgA := &mockPublishResult{}
@@ -125,10 +126,10 @@ func TestPubSubOutput_MessageAttr(t *testing.T) {
 	err = out.WriteBatch(ctx, service.MessageBatch{msg})
 	require.NoError(t, err, "publish failed")
 
-	require.Len(t, fooTopic.Calls, 2)
-	require.Equal(t, fooTopic.Calls[1].Method, "Publish")
-	require.Len(t, fooTopic.Calls[1].Arguments, 2)
-	psmsg := fooTopic.Calls[1].Arguments[1].(*pubsub.Message)
+	require.Len(t, fooTopic.Calls, 3)
+	require.Equal(t, fooTopic.Calls[2].Method, "Publish")
+	require.Len(t, fooTopic.Calls[2].Arguments, 2)
+	psmsg := fooTopic.Calls[2].Arguments[1].(*pubsub.Message)
 	require.Equal(t, map[string]string{"keep_a": "good stuff"}, psmsg.Attributes)
 	require.Equal(t, "foo_1", psmsg.OrderingKey)
 }

--- a/internal/impl/gcp/pubsub.go
+++ b/internal/impl/gcp/pubsub.go
@@ -13,6 +13,7 @@ type pubsubClient interface {
 type pubsubTopic interface {
 	Exists(ctx context.Context) (bool, error)
 	Publish(ctx context.Context, msg *pubsub.Message) publishResult
+	EnableOrdering()
 	Stop()
 }
 
@@ -38,9 +39,15 @@ type airGappedTopic struct {
 func (at *airGappedTopic) Exists(ctx context.Context) (bool, error) {
 	return at.t.Exists(ctx)
 }
+
 func (at *airGappedTopic) Publish(ctx context.Context, msg *pubsub.Message) publishResult {
 	return at.t.Publish(ctx, msg)
 }
+
+func (at *airGappedTopic) EnableOrdering() {
+	at.t.EnableMessageOrdering = true
+}
+
 func (at *airGappedTopic) Stop() {
 	at.t.Stop()
 }

--- a/internal/impl/gcp/pubsub_mock_test.go
+++ b/internal/impl/gcp/pubsub_mock_test.go
@@ -11,7 +11,9 @@ type mockPubSubClient struct {
 	mock.Mock
 }
 
-func (c *mockPubSubClient) Topic(id string, _ *pubsub.PublishSettings) pubsubTopic {
+var _ pubsubClient = &mockPubSubClient{}
+
+func (c *mockPubSubClient) Topic(id string, settings *pubsub.PublishSettings) pubsubTopic {
 	args := c.Called(id)
 
 	return args.Get(0).(pubsubTopic)
@@ -20,6 +22,8 @@ func (c *mockPubSubClient) Topic(id string, _ *pubsub.PublishSettings) pubsubTop
 type mockTopic struct {
 	mock.Mock
 }
+
+var _ pubsubTopic = &mockTopic{}
 
 func (mt *mockTopic) Exists(context.Context) (bool, error) {
 	args := mt.Called()
@@ -32,6 +36,10 @@ func (mt *mockTopic) Publish(ctx context.Context, msg *pubsub.Message) publishRe
 	return args.Get(0).(publishResult)
 }
 
+func (mt *mockTopic) EnableOrdering() {
+	mt.Called()
+}
+
 func (mt *mockTopic) Stop() {
 	mt.Called()
 }
@@ -39,6 +47,8 @@ func (mt *mockTopic) Stop() {
 type mockPublishResult struct {
 	mock.Mock
 }
+
+var _ publishResult = &mockPublishResult{}
 
 func (m *mockPublishResult) Get(ctx context.Context) (string, error) {
 	args := m.Called()


### PR DESCRIPTION
This change restores message ordering support on gcp_pubsub that broke as part of rewriting this output. The `*pubsub.Topic` type has a flag that needs to be set after acquiring the topic.