### PR TITLE
Add loop to update message visibility timeout to aws_sqs

### DIFF
--- a/internal/impl/aws/input_sqs.go
+++ b/internal/impl/aws/input_sqs.go
@@ -168,7 +168,9 @@ func (a *awsSQSReader) Connect(ctx context.Context) error {
 
 	a.sqs = sqs.New(a.session)
 
-	attributes, err := a.sqs.GetQueueAttributes(&sqs.GetQueueAttributesInput{})
+	attributes, err := a.sqs.GetQueueAttributes(&sqs.GetQueueAttributesInput{
+		QueueUrl: aws.String(a.conf.URL),
+	})
 	if err != nil {
 		return err
 	}

--- a/internal/impl/aws/input_sqs.go
+++ b/internal/impl/aws/input_sqs.go
@@ -11,12 +11,12 @@ import (
 	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/sqs"
-	"github.com/cenkalti/backoff/v4"
-
+	"github.com/aws/aws-sdk-go/service/sqs/sqsiface"
 	"github.com/benthosdev/benthos/v4/internal/component"
 	"github.com/benthosdev/benthos/v4/internal/impl/aws/config"
 	"github.com/benthosdev/benthos/v4/internal/shutdown"
 	"github.com/benthosdev/benthos/v4/public/service"
+	"github.com/cenkalti/backoff/v4"
 )
 
 const (
@@ -133,7 +133,7 @@ type awsSQSReader struct {
 	conf sqsiConfig
 
 	session *session.Session
-	sqs     *sqs.SQS
+	sqs     sqsiface.SQSAPI
 
 	messagesChan     chan *sqs.Message
 	ackMessagesChan  chan sqsMessageHandle
@@ -162,11 +162,9 @@ func newAWSSQSReader(conf sqsiConfig, sess *session.Session, log *service.Logger
 // Connect attempts to establish a connection to the target SQS
 // queue.
 func (a *awsSQSReader) Connect(ctx context.Context) error {
-	if a.sqs != nil {
-		return nil
+	if a.sqs == nil {
+		a.sqs = sqs.New(a.session)
 	}
-
-	a.sqs = sqs.New(a.session)
 
 	var wg sync.WaitGroup
 	wg.Add(3)

--- a/internal/impl/aws/input_sqs.go
+++ b/internal/impl/aws/input_sqs.go
@@ -12,11 +12,12 @@ import (
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/sqs"
 	"github.com/aws/aws-sdk-go/service/sqs/sqsiface"
+	"github.com/cenkalti/backoff/v4"
+
 	"github.com/benthosdev/benthos/v4/internal/component"
 	"github.com/benthosdev/benthos/v4/internal/impl/aws/config"
 	"github.com/benthosdev/benthos/v4/internal/shutdown"
 	"github.com/benthosdev/benthos/v4/public/service"
-	"github.com/cenkalti/backoff/v4"
 )
 
 const (

--- a/internal/impl/aws/input_sqs.go
+++ b/internal/impl/aws/input_sqs.go
@@ -348,6 +348,9 @@ func (a *awsSQSReader) updateVisibilityLoop(wg *sync.WaitGroup) {
 	var inflightMsgs []sqsMessageHandle
 
 	updateMsgs := func() {
+		if len(inflightMsgs) == 0 {
+			return
+		}
 		ctx, done := a.closeSignal.CloseNowCtx(context.Background())
 		defer done()
 		if err := a.updateVisibilityMessages(ctx, a.queueVisibilityTimeoutSeconds, inflightMsgs...); err != nil {
@@ -370,9 +373,7 @@ func (a *awsSQSReader) updateVisibilityLoop(wg *sync.WaitGroup) {
 				}
 			}
 		case <-updateTimer.C:
-			if len(inflightMsgs) > 0 {
-				updateMsgs()
-			}
+			updateMsgs()
 		case <-a.closeSignal.CloseAtLeisureChan():
 			return
 		}

--- a/internal/impl/aws/input_sqs.go
+++ b/internal/impl/aws/input_sqs.go
@@ -150,6 +150,8 @@ func newAWSSQSReader(conf sqsiConfig, sess *session.Session, log *service.Logger
 		messagesChan:     make(chan *sqs.Message),
 		ackMessagesChan:  make(chan sqsMessageHandle),
 		nackMessagesChan: make(chan sqsMessageHandle),
+		addInflightChan:  make(chan sqsMessageHandle),
+		delInflightChan:  make(chan sqsMessageHandle),
 		closeSignal:      shutdown.NewSignaller(),
 	}, nil
 }

--- a/internal/impl/aws/input_sqs.go
+++ b/internal/impl/aws/input_sqs.go
@@ -169,7 +169,8 @@ func (a *awsSQSReader) Connect(ctx context.Context) error {
 	a.sqs = sqs.New(a.session)
 
 	attributes, err := a.sqs.GetQueueAttributes(&sqs.GetQueueAttributesInput{
-		QueueUrl: aws.String(a.conf.URL),
+		QueueUrl:       aws.String(a.conf.URL),
+		AttributeNames: []*string{aws.String("All")},
 	})
 	if err != nil {
 		return err
@@ -369,7 +370,9 @@ func (a *awsSQSReader) updateVisibilityLoop(wg *sync.WaitGroup) {
 				}
 			}
 		case <-updateTimer.C:
-			updateMsgs()
+			if len(inflightMsgs) > 0 {
+				updateMsgs()
+			}
 		case <-a.closeSignal.CloseAtLeisureChan():
 			return
 		}

--- a/internal/impl/aws/input_sqs_test.go
+++ b/internal/impl/aws/input_sqs_test.go
@@ -1,0 +1,188 @@
+package aws
+
+import (
+	"context"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/request"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/sqs"
+	"github.com/aws/aws-sdk-go/service/sqs/sqsiface"
+	"github.com/stretchr/testify/require"
+)
+
+type mockSqsInput struct {
+	sqsiface.SQSAPI
+
+	mtx          chan struct{}
+	queueTimeout int
+	messages     []*sqs.Message
+	mesTimeouts  map[string]int
+}
+
+func (m *mockSqsInput) TimeoutLoop(ctx context.Context) {
+	t := time.NewTicker(time.Second)
+	defer t.Stop()
+
+	for {
+		select {
+		case <-t.C:
+			<-m.mtx
+
+			for mesId, timeout := range m.mesTimeouts {
+				timeout = timeout - 1
+				if timeout > 0 {
+					m.mesTimeouts[mesId] = timeout
+				} else {
+					m.mesTimeouts[mesId] = 0
+				}
+			}
+
+			m.mtx <- struct{}{}
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
+func (m *mockSqsInput) ReceiveMessageWithContext(ctx aws.Context, input *sqs.ReceiveMessageInput, opts ...request.Option) (*sqs.ReceiveMessageOutput, error) {
+	<-m.mtx
+	defer func() { m.mtx <- struct{}{} }()
+
+	messages := make([]*sqs.Message, 0, len(m.messages))
+
+	for _, message := range m.messages {
+		if timeout, found := m.mesTimeouts[*message.MessageId]; !found || timeout == 0 {
+			messages = append(messages, message)
+			m.mesTimeouts[*message.MessageId] = m.queueTimeout
+		}
+	}
+
+	return &sqs.ReceiveMessageOutput{Messages: messages}, nil
+}
+
+func (m *mockSqsInput) GetQueueAttributes(input *sqs.GetQueueAttributesInput) (*sqs.GetQueueAttributesOutput, error) {
+	return &sqs.GetQueueAttributesOutput{Attributes: map[string]*string{sqsiAttributeNameVisibilityTimeout: aws.String(strconv.Itoa(m.queueTimeout))}}, nil
+}
+
+func (m *mockSqsInput) ChangeMessageVisibilityBatchWithContext(ctx aws.Context, input *sqs.ChangeMessageVisibilityBatchInput, opts ...request.Option) (*sqs.ChangeMessageVisibilityBatchOutput, error) {
+	<-m.mtx
+	defer func() { m.mtx <- struct{}{} }()
+
+	for _, entry := range input.Entries {
+		if _, found := m.mesTimeouts[*entry.Id]; found {
+			m.mesTimeouts[*entry.Id] = int(*entry.VisibilityTimeout)
+		}
+	}
+
+	return &sqs.ChangeMessageVisibilityBatchOutput{}, nil
+}
+
+func (m *mockSqsInput) DeleteMessageBatchWithContext(ctx aws.Context, input *sqs.DeleteMessageBatchInput, opts ...request.Option) (*sqs.DeleteMessageBatchOutput, error) {
+	<-m.mtx
+	defer func() { m.mtx <- struct{}{} }()
+
+	for _, entry := range input.Entries {
+		delete(m.mesTimeouts, *entry.Id)
+		for i, message := range m.messages {
+			if *entry.Id == *message.MessageId {
+				m.messages = append(m.messages[:i], m.messages[i+1:]...)
+			}
+		}
+	}
+
+	return &sqs.DeleteMessageBatchOutput{}, nil
+}
+
+func TestSQSInput(t *testing.T) {
+	tCtx := context.Background()
+	defer tCtx.Done()
+
+	messages := []*sqs.Message{
+		{
+			Body:          aws.String("message-1"),
+			MessageId:     aws.String("message-1"),
+			ReceiptHandle: aws.String("message-1"),
+		},
+		{
+			Body:          aws.String("message-2"),
+			MessageId:     aws.String("message-2"),
+			ReceiptHandle: aws.String("message-2"),
+		},
+		{
+			Body:          aws.String("message-3"),
+			MessageId:     aws.String("message-3"),
+			ReceiptHandle: aws.String("message-3"),
+		},
+	}
+	expectedMessages := len(messages)
+
+	r, err := newAWSSQSReader(
+		sqsiConfig{
+			URL:                 "http://foo.example.com",
+			WaitTimeSeconds:     0,
+			DeleteMessage:       true,
+			ResetVisibility:     true,
+			MaxNumberOfMessages: 10,
+		},
+		session.Must(session.NewSession(&aws.Config{
+			Credentials: credentials.NewStaticCredentials("xxxxx", "xxxxx", "xxxxx"),
+		})),
+		nil,
+	)
+	require.NoError(t, err)
+
+	mockInput := &mockSqsInput{
+		mtx:          make(chan struct{}, 1),
+		queueTimeout: 10,
+		messages:     messages,
+		mesTimeouts:  make(map[string]int, expectedMessages),
+	}
+	mockInput.mtx <- struct{}{}
+	r.sqs = mockInput
+	go mockInput.TimeoutLoop(tCtx)
+
+	defer r.closeSignal.CloseNow()
+	err = r.Connect(tCtx)
+	require.NoError(t, err)
+
+	receivedMessages := make([]sqs.Message, 0, expectedMessages)
+
+	// Check that all messages are received from the reader
+	require.Eventually(t, func() bool {
+	out:
+		for {
+			select {
+			case mes := <-r.messagesChan:
+				receivedMessages = append(receivedMessages, *mes)
+			default:
+				break out
+			}
+		}
+		return len(receivedMessages) == expectedMessages
+	}, 30*time.Second, time.Second)
+
+	// Wait over the defined queue timeout and check that messages have not been received again
+	time.Sleep(time.Duration(mockInput.queueTimeout+5) * time.Second)
+	select {
+	case <-r.messagesChan:
+		require.Fail(t, "messages have been received again due to timeouts")
+	default:
+	}
+	// Check that even if they are not visible, messages haven't been deleted from the queue
+	require.Len(t, mockInput.messages, expectedMessages)
+	require.Len(t, mockInput.mesTimeouts, expectedMessages)
+
+	// Ack all messages and ensure that they are deleted from SQS
+	for _, message := range receivedMessages {
+		r.ackMessagesChan <- sqsMessageHandle{id: *message.MessageId, receiptHandle: *message.ReceiptHandle}
+	}
+
+	require.Eventually(t, func() bool {
+		return len(mockInput.messages) == 0
+	}, 5*time.Second, time.Second)
+}

--- a/internal/impl/aws/input_sqs_test.go
+++ b/internal/impl/aws/input_sqs_test.go
@@ -33,12 +33,12 @@ func (m *mockSqsInput) TimeoutLoop(ctx context.Context) {
 		case <-t.C:
 			<-m.mtx
 
-			for mesId, timeout := range m.mesTimeouts {
+			for mesID, timeout := range m.mesTimeouts {
 				timeout = timeout - 1
 				if timeout > 0 {
-					m.mesTimeouts[mesId] = timeout
+					m.mesTimeouts[mesID] = timeout
 				} else {
-					m.mesTimeouts[mesId] = 0
+					m.mesTimeouts[mesID] = 0
 				}
 			}
 


### PR DESCRIPTION
About https://github.com/benthosdev/benthos/issues/1948

The current `aws_sqs` input doesn't update the messages' visbility timeout while they are inflight, so messages may become visible again in the queue after a while and be read again, leading to more-than-once delivery.

This MR adds a control loop in the input that keeps track of inflight messages and updates their visibility timeout regularly.