### PR TITLE
fix: test metadata input object

### DIFF
--- a/internal/cli/test/docs/docs.go
+++ b/internal/cli/test/docs/docs.go
@@ -79,7 +79,7 @@ It is also possible to target processors in a separate file by prefixing the tar
 				"Sets the raw content of the message by reading a file. The path of the file should be relative to the path of the test file.",
 				"./foo/bar.txt",
 			).Optional(),
-			docs.FieldString("metadata", "A map of metadata key/values to add to the input message.").Map().Optional(),
+			docs.FieldAnything("metadata", "A map of metadata key/values to add to the input message.").Map().Optional(),
 		),
 		docs.FieldObject(
 			"input_batches", "Define a series of batches of messages to feed into your test, specify either an `input_batch` or a series of `input_batches`.",

--- a/website/docs/configuration/unit_testing.md
+++ b/website/docs/configuration/unit_testing.md
@@ -423,7 +423,7 @@ file_content: ./foo/bar.txt
 A map of metadata key/values to add to the input message.
 
 
-Type: map of `string`  
+Type: map of `unknown`  
 
 ### `tests[].input_batches`
 


### PR DESCRIPTION
Fixes linting errors due to metadata being passed as an object in test inputs. Updates cli docs.go to accept `FieldAnything` for "metadata" test input.

**Steps to reproduce issue**

```yaml
processor_resources:
  - label: some_resource_processor
    branch:
      processors:
        - switch:
            - check: "@foo.is_bar"
              processors:
                - mapping: |
                    root = { "foo": "bar" }
            - processors:
                - mapping: |
                    root = { "foo": "???" }
      result_map: root = this

tests:
  - name: foobar
    target_processors: /processor_resources/0
    input_batch:
      - content: |
          { "key": "value" }
        metadata:
          foo: { "is_bar": true, "things": ["a", "b"] }
    output_batches:
      - - json_equals: |
            { "foo": "bar" }
```

```shell
❯ benthos test resource.yaml
Test 'resource.yaml' failed

Failures:

--- resource.yaml ---

Lint: (22,1) expected string value
```