### PR TITLE
Azure storage account linting with development connection string

### DIFF
--- a/internal/impl/azure/auth.go
+++ b/internal/impl/azure/auth.go
@@ -41,7 +41,7 @@ func azureComponentSpec(forBlobStorage bool) *service.ConfigSpec {
 		spec = spec.Field(service.NewStringField(bscFieldStorageSASToken).
 			Description("The storage account SAS token. This field is ignored if `" + bscFieldStorageConnectionString + "` or `" + bscFieldStorageAccessKey + "` are set.").
 			Default("")).
-			LintRule(`root = if this.storage_connection_string != "" && !this.storage_connection_string.contains("AccountName=") && this.storage_account == "" { [ "storage_account must be set if storage_connection_string does not contain the \"AccountName\" parameter" ] }`)
+			LintRule(`root = if this.storage_connection_string != "" && !this.storage_connection_string.contains("AccountName=")  && !this.storage_connection_string.contains("UseDevelopmentStorage=true;") && this.storage_account == "" { [ "storage_account must be set if storage_connection_string does not contain the \"AccountName\" parameter" ] }`)
 	}
 	spec = spec.Fields(
 		service.NewStringField(bscFieldStorageConnectionString).


### PR DESCRIPTION
Don't fail on lint when there's a development connection string without an AccountName (UseDevelopmentStorage=true;)