### PR TITLE
Add JWT RSA signature bloblang methods

### DIFF
--- a/internal/impl/crypto/jwt_sign_test.go
+++ b/internal/impl/crypto/jwt_sign_test.go
@@ -28,8 +28,38 @@ func (c *testClaims) MarshalMap() map[string]any {
 	}
 }
 
-func TestBloblangSignJwtHS(t *testing.T) {
-	secret := "get-in-losers"
+func TestBloblangSignJwt(t *testing.T) {
+	dummySecretHMAC := "get-in-losers"
+
+	// Generated with `openssl genrsa 2048`
+	dummySecretRSA := `-----BEGIN RSA PRIVATE KEY-----
+MIIEowIBAAKCAQEAs/ibN8r68pLMR6gRzg4S8v8l6Q7yi8qURjkEbcNeM1rkokC7
+xh0I4JVTwxYSVv/JIW8qJdyspl5NIfuAVi32WfKvSAs+NIs+DMsNPYw3yuQals4A
+X8hith1YDvYpr8SD44jxhz/DR9lYKZFGhXGB+7NqQ7vpTWp3BceLYocazWJgusZt
+7CgecIq57ycM5hjM93BvlrUJ8nQ1a46wfL/8Cy4P0et70hzZrsjjN41KFhKY0iUw
+lyU41yEiDHvHDDsTMBxAZosWjSREGfJL6MfpXOInTHs/Gg6DZMkbxjQu6L06EdJ+
+Q/NwglJdAXM7Zo9rNELqRig6DdvG5JesdMsO+QIDAQABAoIBAEBo5ixWoe906FVw
+6kZjtRZwiIHbjqTHML/dIh+ifzFEA3WqU0m5FHdEGkFEwfWO/83OejgovUWhlFto
+JmsxceyJNYBEPdQSTXfIqAlyCHm9n2J/gZTGI8XnxJ8+LHcyjr09QqvT/zDUsX/W
+9XVGxW1urcZmFz5UrxpLazAtCEOeqzCRV2Lu05Jk8DWKBWDDjRS24qmWKH1vPSgC
++QuSIHX00OzhE5MuiGgPtE3C/qPzjKLYfvFW7xEN6azZAiIBmIp+Tp9oc8I1CZ/V
+buV4iKrkZbGqbZgH4d6FwUuk9NpvYokKn6mFyPYKQJUCwAh4jQhsvsminKeJjci/
+xEXIt40CgYEA21PvYT8vWw+gQbUnQsNFa5OBZY8N3YyakgGo3E4EkzjEmE5Ds+R4
+kom21PAvFpzY4kxuIJyNYGpvO9RAqh7hflNffTfDL3HRKfG1nAM4V9HOu4P2BFT1
+LYmCd8seTQRMZd3rR0zHjWZAos3rrJShESg5oG53lS+DWnptvV1KTWcCgYEA0hAN
+i9OpT5hP+p35QLEeeVhHBFlkz/TShssGT1BvKQldEbqTxQtGALfFdvGkYISxzIsj
+XpZHd2qfEx/lHiN0xkVz8IOKzS10susMtbcX0ByOBHRxz0+9qloxrP3o2sWVMkf+
+vR0/T0kLr1EPgjYb6hNDnQHLOobaNFq8Tu0ZpJ8CgYAMS6ZN01b6SeP4CwnKalwH
+7dsBMIXcd7dqnAE1aIJFJpeO2kRdX1+LB4FiapyZLe3SseoyldQvJYha2ElPwC9v
+/4iI4olkrYLGUTCXMG8GLVLjnEA8ee7MwLq5sH9gXe9SfqBj/N/rA2J4PgcKQ8LL
+zW99mPPHP0Sj290vEn3J3QKBgQCD4iQ/F6KDIIOGO0xUO1+Am9Xqex16GqFak3jg
+rwU7ZG+UQ+mmmo9WwAovxUKIfocKfoi0R/GSndRFs46rv2L/YHeMF2o7q0BLXJtc
+Mxm2RVc8oMcbe1r+6yWpELjzMX2cVesvXH91Dc1SQrhT7hjUe0fF+WxY0HWKzTTQ
+8LdazQKBgGvUgXyLA6Nx0fKr5HvsSHurX67trU7/4GuuOIm+aGx4MWu6E8NZdkxs
+tg+1jV0qRszLh20l2jcF5Xr1IUfQINcS2j7v1dGHdBzu9bmupRC7DTYXRiTv+L7L
+EppmxRJGlb1Mh0Egvc+eup2lzglmgdRe/FBX4LH6hhH6tohRt8Yx
+-----END RSA PRIVATE KEY-----`
+
 	inClaims := testClaims{
 		Sub:  "1234567890",
 		Mood: "Disdainful",
@@ -38,17 +68,21 @@ func TestBloblangSignJwtHS(t *testing.T) {
 
 	testCases := []struct {
 		method string
-		alg    *jwt.SigningMethodHMAC
+		secret string
+		alg    jwt.SigningMethod
 	}{
-		{method: "sign_jwt_hs256", alg: jwt.SigningMethodHS256},
-		{method: "sign_jwt_hs384", alg: jwt.SigningMethodHS384},
-		{method: "sign_jwt_hs512", alg: jwt.SigningMethodHS512},
+		{method: "sign_jwt_hs256", secret: dummySecretHMAC, alg: jwt.SigningMethodHS256},
+		{method: "sign_jwt_hs384", secret: dummySecretHMAC, alg: jwt.SigningMethodHS384},
+		{method: "sign_jwt_hs512", secret: dummySecretHMAC, alg: jwt.SigningMethodHS512},
+		{method: "sign_jwt_rs256", secret: dummySecretRSA, alg: jwt.SigningMethodRS256},
+		{method: "sign_jwt_rs384", secret: dummySecretRSA, alg: jwt.SigningMethodRS384},
+		{method: "sign_jwt_rs512", secret: dummySecretRSA, alg: jwt.SigningMethodRS512},
 	}
 
 	for _, tc := range testCases {
 		tc := tc
 		t.Run(tc.method, func(t *testing.T) {
-			mapping := fmt.Sprintf("root = this.%s(%q)", tc.method, secret)
+			mapping := fmt.Sprintf("root = this.%s(%q)", tc.method, tc.secret)
 
 			exe, err := bloblang.Parse(mapping)
 			require.NoError(t, err)
@@ -60,16 +94,24 @@ func TestBloblangSignJwtHS(t *testing.T) {
 			require.True(t, ok, "bloblang result is not a string")
 
 			var outClaims testClaims
-			_, err = jwt.ParseWithClaims(output, &outClaims, func(tok *jwt.Token) (interface{}, error) {
-				if _, ok := tok.Method.(*jwt.SigningMethodHMAC); !ok {
-					return nil, fmt.Errorf("not an hmac-sha signing method: %v", tok.Header["alg"])
+			_, err = jwt.ParseWithClaims(output, &outClaims, func(tok *jwt.Token) (any, error) {
+				var key any
+				switch tok.Method.(type) {
+				case *jwt.SigningMethodHMAC:
+					key = []byte(tc.secret)
+				case *jwt.SigningMethodRSA:
+					privateKey, err := jwt.ParseRSAPrivateKeyFromPEM([]byte(tc.secret))
+					require.NoError(t, err)
+					key = privateKey.Public()
+				default:
+					require.Fail(t, "unrecognised signing method")
 				}
 
-				if tok.Method != tc.alg {
+				if tok.Method.Alg() != tc.alg.Alg() {
 					return nil, fmt.Errorf("incorrect signing method: %v", tok.Header["alg"])
 				}
 
-				return []byte(secret), nil
+				return key, nil
 			})
 			require.NoError(t, err)
 			require.Equal(t, inClaims, outClaims)

--- a/website/docs/guides/bloblang/methods.md
+++ b/website/docs/guides/bloblang/methods.md
@@ -2341,15 +2341,18 @@ root = this.foo.merge(this.bar)
 
 Hash and sign an object representing JSON Web Token (JWT) claims using HS256.
 
+Introduced in version v4.12.0.
+
+
 #### Parameters
 
-**`signing_secret`** &lt;string&gt; The HMAC secret to use for signing the token.  
+**`signing_secret`** &lt;string&gt; The secret to use for signing the token.  
 
 #### Examples
 
 
 ```coffee
-root.signed = this.claims.sign_jwt_hs256("dont-tell-anyone")
+root.signed = this.claims.sign_jwt_hs256("""dont-tell-anyone""")
 
 # In:  {"claims":{"sub":"user123"}}
 # Out: {"signed":"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ1c2VyMTIzIn0.hUl-nngPMY_3h9vveWJUPsCcO5PeL6k9hWLnMYeFbFQ"}
@@ -2359,15 +2362,18 @@ root.signed = this.claims.sign_jwt_hs256("dont-tell-anyone")
 
 Hash and sign an object representing JSON Web Token (JWT) claims using HS384.
 
+Introduced in version v4.12.0.
+
+
 #### Parameters
 
-**`signing_secret`** &lt;string&gt; The HMAC secret to use for signing the token.  
+**`signing_secret`** &lt;string&gt; The secret to use for signing the token.  
 
 #### Examples
 
 
 ```coffee
-root.signed = this.claims.sign_jwt_hs384("dont-tell-anyone")
+root.signed = this.claims.sign_jwt_hs384("""dont-tell-anyone""")
 
 # In:  {"claims":{"sub":"user123"}}
 # Out: {"signed":"eyJhbGciOiJIUzM4NCIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ1c2VyMTIzIn0.zGYLr83aToon1efUNq-hw7XgT20lPvZb8sYei8x6S6mpHwb433SJdXJXx0Oio8AZ"}
@@ -2377,19 +2383,55 @@ root.signed = this.claims.sign_jwt_hs384("dont-tell-anyone")
 
 Hash and sign an object representing JSON Web Token (JWT) claims using HS512.
 
+Introduced in version v4.12.0.
+
+
 #### Parameters
 
-**`signing_secret`** &lt;string&gt; The HMAC secret to use for signing the token.  
+**`signing_secret`** &lt;string&gt; The secret to use for signing the token.  
 
 #### Examples
 
 
 ```coffee
-root.signed = this.claims.sign_jwt_hs512("dont-tell-anyone")
+root.signed = this.claims.sign_jwt_hs512("""dont-tell-anyone""")
 
 # In:  {"claims":{"sub":"user123"}}
 # Out: {"signed":"eyJhbGciOiJIUzUxMiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ1c2VyMTIzIn0.zBNR9o_6EDwXXKkpKLNJhG26j8Dc-mV-YahBwmEdCrmiWt5les8I9rgmNlWIowpq6Yxs4kLNAdFhqoRz3NXT3w"}
 ```
+
+### `sign_jwt_rs256`
+
+Hash and sign an object representing JSON Web Token (JWT) claims using RS256.
+
+Introduced in version v4.18.0.
+
+
+#### Parameters
+
+**`signing_secret`** &lt;string&gt; The secret to use for signing the token.  
+
+### `sign_jwt_rs384`
+
+Hash and sign an object representing JSON Web Token (JWT) claims using RS384.
+
+Introduced in version v4.18.0.
+
+
+#### Parameters
+
+**`signing_secret`** &lt;string&gt; The secret to use for signing the token.  
+
+### `sign_jwt_rs512`
+
+Hash and sign an object representing JSON Web Token (JWT) claims using RS512.
+
+Introduced in version v4.18.0.
+
+
+#### Parameters
+
+**`signing_secret`** &lt;string&gt; The secret to use for signing the token.  
 
 ### `slice`
 


### PR DESCRIPTION
This is needed for creating Installation Tokens to allow users to query the GraphQL API using GitHub App private keys.

Details here: https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/generating-an-installation-access-token-for-a-github-app

Tested using https://github.com/mihaitodor/benthos-playground/blob/main/benthos/github_app_graphql_query.yaml

This is an enhancement to #1735. I also added the versions at which these methods got introduced (assuming this PR makes it into the next release).

CC @disintegrator