### PR TITLE
Enable plugin authors to support connection backoffs

### DIFF
--- a/internal/component/errors.go
+++ b/internal/component/errors.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"time"
 )
 
 // ErrNotUnwrapped is returned in cases where a component was meant to be
@@ -47,6 +48,17 @@ var (
 
 	ErrFailedSend = errors.New("message failed to reach a target destination")
 )
+
+// ErrBackOff is an error returned that allows for a back off duration to be specified
+type ErrBackOff struct {
+	Err  error
+	Wait time.Duration
+}
+
+// Error returns the Error string.
+func (e ErrBackOff) Error() string {
+	return e.Err.Error()
+}
 
 //------------------------------------------------------------------------------
 

--- a/internal/component/input/async_reader.go
+++ b/internal/component/input/async_reader.go
@@ -122,6 +122,11 @@ func (r *AsyncReader) loop() {
 				r.mgr.Logger().Errorf("Failed to connect to %v: %v\n", r.typeStr, err)
 				mFailedConn.Incr(1)
 
+				var e component.ErrBackOff
+				if errors.As(err, &e) {
+					time.Sleep(e.Wait)
+				}
+
 				nextBoff := r.connBackoff.NextBackOff()
 				if nextBoff == backoff.Stop {
 					r.mgr.Logger().Errorf("Maximum number of connection attempt retries has been met, gracefully terminating input %v", r.typeStr)

--- a/internal/component/input/async_reader.go
+++ b/internal/component/input/async_reader.go
@@ -124,7 +124,7 @@ func (r *AsyncReader) loop() {
 
 				var e component.ErrBackOff
 				if errors.As(err, &e) {
-					r.sleepWithCancellation(closeAtLeisureCtx, e.Wait)
+					_ = r.sleepWithCancellation(closeAtLeisureCtx, e.Wait)
 				}
 
 				nextBoff := r.connBackoff.NextBackOff()

--- a/public/service/input_test.go
+++ b/public/service/input_test.go
@@ -168,6 +168,52 @@ func TestBatchInputAirGapSad(t *testing.T) {
 	assert.Equal(t, component.ErrTypeClosed, err)
 }
 
+func TestBatchInputAirGapSadWithBackOff(t *testing.T) {
+	i := &fnBatchInput{
+		connect: func() error {
+			return NewErrBackOff(errors.New("bad connect"), time.Second*2)
+		},
+		read: func() (MessageBatch, AckFunc, error) {
+			return nil, nil, NewErrBackOff(errors.New("bad read"), time.Second*3)
+		},
+	}
+	agi := newAirGapBatchReader(i)
+
+	err := agi.Connect(context.Background())
+	assert.EqualError(t, err, "bad connect")
+
+	var e component.ErrBackOff
+	assert.True(t, errors.As(err, &e))
+	assert.Equal(t, e.Wait, time.Second*2)
+	assert.EqualError(t, e.Err, "bad connect")
+	assert.Equal(t, e.Error(), "bad connect")
+
+	_, _, err = agi.ReadBatch(context.Background())
+	assert.EqualError(t, err, "bad read")
+
+	assert.True(t, errors.As(err, &e))
+	assert.Equal(t, e.Wait, time.Second*3)
+	assert.EqualError(t, e.Err, "bad read")
+	assert.Equal(t, e.Error(), "bad read")
+
+	i.read = func() (MessageBatch, AckFunc, error) {
+		return nil, nil, NewErrBackOff(ErrNotConnected, time.Second*2)
+	}
+
+	_, _, err = agi.ReadBatch(context.Background())
+
+	assert.True(t, errors.As(err, &e))
+	assert.Equal(t, e.Wait, time.Second*2)
+	assert.True(t, errors.Is(e.Err, component.ErrNotConnected))
+
+	i.read = func() (MessageBatch, AckFunc, error) {
+		return nil, nil, ErrEndOfInput
+	}
+
+	_, _, err = agi.ReadBatch(context.Background())
+	assert.Equal(t, component.ErrTypeClosed, err)
+}
+
 func TestBatchInputAirGapHappy(t *testing.T) {
 	var ackErr error
 	ackFn := func(ctx context.Context, err error) error {

--- a/public/service/package.go
+++ b/public/service/package.go
@@ -13,6 +13,7 @@ package service
 import (
 	"context"
 	"errors"
+	"time"
 )
 
 var (
@@ -34,6 +35,21 @@ var (
 	// component to gracefully terminate the pipeline.
 	ErrEndOfBuffer = errors.New("end of buffer")
 )
+
+// ErrBackOff is an error returned that allows for a back off duration to be specified
+type ErrBackOff struct {
+	Err  error
+	Wait time.Duration
+}
+
+func NewErrBackOff(err error, wait time.Duration) ErrBackOff {
+	return ErrBackOff{err, wait}
+}
+
+// Error returns the Error string.
+func (e ErrBackOff) Error() string {
+	return e.Err.Error()
+}
 
 // Closer is implemented by components that support stopping and cleaning up
 // their underlying resources.


### PR DESCRIPTION
Closes: https://github.com/benthosdev/benthos/issues/885

This change adds the ability for plugin authors to return a `ErrBackOff` type that wraps the original error and allows authors to provide a `Wait` duration, causing the `Connect` function to pause for the duration in order slow down how quickly Benthos attempts to reconnect. It's based on your [your suggestion in this older PR](https://github.com/benthosdev/benthos/pull/886#issuecomment-933767400).
