### PR TITLE
feat: add level_name parameter to logging

### DIFF
--- a/internal/log/docs.go
+++ b/internal/log/docs.go
@@ -17,6 +17,7 @@ func Spec() docs.FieldSpecs {
 		).HasDefault("INFO").LinterFunc(nil),
 		docs.FieldString("format", "Set the format of emitted logs.").HasOptions("json", "logfmt").HasDefault("logfmt"),
 		docs.FieldBool("add_timestamp", "Whether to include timestamps in logs.").HasDefault(false),
+		docs.FieldString("level_name", "The name of the level field added to logs when the `format` is `json`.").HasDefault("level"),
 		docs.FieldString("timestamp_name", "The name of the timestamp field added to logs when `add_timestamp` is set to `true` and the `format` is `json`.").HasDefault("time"),
 		docs.FieldString("message_name", "The name of the message field added to logs when the the `format` is `json`.").HasDefault("msg"),
 		docs.FieldString("static_fields", "A map of key/value pairs to add to each structured log.").Map().HasDefault(map[string]string{

--- a/internal/log/logrus.go
+++ b/internal/log/logrus.go
@@ -19,6 +19,7 @@ type Config struct {
 	LogLevel      string            `json:"level" yaml:"level"`
 	Format        string            `json:"format" yaml:"format"`
 	AddTimeStamp  bool              `json:"add_timestamp" yaml:"add_timestamp"`
+	LevelName     string            `json:"level_name" yaml:"level_name"`
 	MessageName   string            `json:"message_name" yaml:"message_name"`
 	TimestampName string            `json:"timestamp_name" yaml:"timestamp_name"`
 	StaticFields  map[string]string `json:"static_fields" yaml:"static_fields"`
@@ -38,6 +39,7 @@ func NewConfig() Config {
 		LogLevel:      "INFO",
 		Format:        "logfmt",
 		AddTimeStamp:  false,
+		LevelName:     "level",
 		TimestampName: "time",
 		MessageName:   "msg",
 		StaticFields: map[string]string{
@@ -130,8 +132,9 @@ func New(stream io.Writer, fs ifs.FS, config Config) (Modular, error) {
 		logger.SetFormatter(&logrus.JSONFormatter{
 			DisableTimestamp: !config.AddTimeStamp,
 			FieldMap: logrus.FieldMap{
-				logrus.FieldKeyTime: config.TimestampName,
-				logrus.FieldKeyMsg:  config.MessageName,
+				logrus.FieldKeyTime:  config.TimestampName,
+				logrus.FieldKeyMsg:   config.MessageName,
+				logrus.FieldKeyLevel: config.LevelName,
 			},
 		})
 	case "logfmt":
@@ -140,8 +143,9 @@ func New(stream io.Writer, fs ifs.FS, config Config) (Modular, error) {
 			QuoteEmptyFields: true,
 			FullTimestamp:    config.AddTimeStamp,
 			FieldMap: logrus.FieldMap{
-				logrus.FieldKeyTime: config.TimestampName,
-				logrus.FieldKeyMsg:  config.MessageName,
+				logrus.FieldKeyTime:  config.TimestampName,
+				logrus.FieldKeyMsg:   config.MessageName,
+				logrus.FieldKeyLevel: config.LevelName,
 			},
 		})
 	default:

--- a/internal/log/logrus_test.go
+++ b/internal/log/logrus_test.go
@@ -128,7 +128,7 @@ func TestLoggerWithOtherNames(t *testing.T) {
 	expected := `{"@service":"benthos_service","@system":"foo","foo":"bar","message":"Warning message foo fields","severity":"warning"}
 `
 
-	assert.Equal(t, expected, buf.String())
+	require.JSONEq(t, expected, buf.String())
 }
 
 type logCounter struct {

--- a/internal/log/logrus_test.go
+++ b/internal/log/logrus_test.go
@@ -101,6 +101,36 @@ func TestLoggerWithNonStringKeys(t *testing.T) {
 	assert.Equal(t, expected, buf.String())
 }
 
+func TestLoggerWithOtherNames(t *testing.T) {
+	loggerConfig := NewConfig()
+	loggerConfig.AddTimeStamp = false
+	loggerConfig.Format = "logfmt"
+	loggerConfig.LogLevel = "WARN"
+	loggerConfig.StaticFields = map[string]string{
+		"@service": "benthos_service",
+		"@system":  "foo",
+	}
+	loggerConfig.LevelName = "severity"
+	loggerConfig.MessageName = "message"
+
+	var buf bytes.Buffer
+
+	logger, err := New(&buf, ifs.OS(), loggerConfig)
+	require.NoError(t, err)
+
+	logger = logger.WithFields(map[string]string{
+		"foo": "bar",
+	})
+	require.NoError(t, err)
+
+	logger.Warnln("Warning message foo fields")
+
+	expected := `severity=warning message="Warning message foo fields" @service=benthos_service @system=foo foo=bar
+`
+
+	assert.Equal(t, expected, buf.String())
+}
+
 type logCounter struct {
 	count int
 }

--- a/internal/log/logrus_test.go
+++ b/internal/log/logrus_test.go
@@ -104,7 +104,7 @@ func TestLoggerWithNonStringKeys(t *testing.T) {
 func TestLoggerWithOtherNames(t *testing.T) {
 	loggerConfig := NewConfig()
 	loggerConfig.AddTimeStamp = false
-	loggerConfig.Format = "logfmt"
+	loggerConfig.Format = "json"
 	loggerConfig.LogLevel = "WARN"
 	loggerConfig.StaticFields = map[string]string{
 		"@service": "benthos_service",
@@ -125,7 +125,7 @@ func TestLoggerWithOtherNames(t *testing.T) {
 
 	logger.Warnln("Warning message foo fields")
 
-	expected := `severity=warning message="Warning message foo fields" @service=benthos_service @system=foo foo=bar
+	expected := `{"@service":"benthos_service","@system":"foo","foo":"bar","message":"Warning message foo fields","severity":"warning"}
 `
 
 	assert.Equal(t, expected, buf.String())

--- a/website/docs/components/logger/about.md
+++ b/website/docs/components/logger/about.md
@@ -75,6 +75,14 @@ Whether to include timestamps in logs.
 Type: `bool`  
 Default: `false`  
 
+### `level_name`
+
+The name of the level field added to logs when the `format` is `json`.
+
+
+Type: `string`  
+Default: `"level"`  
+
 ### `timestamp_name`
 
 The name of the timestamp field added to logs when `add_timestamp` is set to `true` and the `format` is `json`.


### PR DESCRIPTION
Adds parameter `level_name` to `logging`. Closes #1944
