### PR TITLE
feat: Interpolation support for exchange name

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -86,6 +86,7 @@ require (
 	github.com/prometheus/client_golang v1.14.0
 	github.com/prometheus/common v0.39.0
 	github.com/pusher/pusher-http-go v4.0.1+incompatible
+	github.com/puzpuzpuz/xsync/v2 v2.4.1
 	github.com/quipo/dependencysolver v0.0.0-20170801134659-2b009cb4ddcc
 	github.com/rabbitmq/amqp091-go v1.4.0
 	github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475

--- a/go.sum
+++ b/go.sum
@@ -860,6 +860,8 @@ github.com/protocolbuffers/txtpbfmt v0.0.0-20201118171849-f6a6b3f636fc h1:gSVONB
 github.com/protocolbuffers/txtpbfmt v0.0.0-20201118171849-f6a6b3f636fc/go.mod h1:KbKfKPy2I6ecOIGA9apfheFv14+P3RSmmQvshofQyMY=
 github.com/pusher/pusher-http-go v4.0.1+incompatible h1:4u6tomPG1WhHaST7Wi9mw83Y+MS/j2EplR2YmDh8Xp4=
 github.com/pusher/pusher-http-go v4.0.1+incompatible/go.mod h1:XAv1fxRmVTI++2xsfofDhg7whapsLRG/gH/DXbF3a18=
+github.com/puzpuzpuz/xsync/v2 v2.4.1 h1:aGdE1C/HaR/QC6YAFdtZXi60Df8/qBIrs8PKrzkItcM=
+github.com/puzpuzpuz/xsync/v2 v2.4.1/go.mod h1:gD2H2krq/w52MfPLE+Uy64TzJDVY7lP2znR9qmR35kU=
 github.com/quipo/dependencysolver v0.0.0-20170801134659-2b009cb4ddcc h1:hK577yxEJ2f5s8w2iy2KimZmgrdAUZUNftE1ESmg2/Q=
 github.com/quipo/dependencysolver v0.0.0-20170801134659-2b009cb4ddcc/go.mod h1:OQt6Zo5B3Zs+C49xul8kcHo+fZ1mCLPvd0LFxiZ2DHc=
 github.com/rabbitmq/amqp091-go v1.4.0 h1:T2G+J9W9OY4p64Di23J6yH7tOkMocgnESvYeBjuG9cY=

--- a/website/docs/components/outputs/amqp_0_9.md
+++ b/website/docs/components/outputs/amqp_0_9.md
@@ -82,7 +82,7 @@ It's possible for this output type to create the target exchange by setting `exc
 
 TLS is automatic when connecting to an `amqps` URL, but custom settings can be enabled in the `tls` section.
 
-The fields 'key' and 'type' can be dynamically set using function interpolations described [here](/docs/configuration/interpolation#bloblang-queries).
+The fields 'exchange',  'key' and 'type' can be dynamically set using function interpolations described [here](/docs/configuration/interpolation#bloblang-queries).
 
 ## Fields
 
@@ -111,6 +111,7 @@ urls:
 ### `exchange`
 
 An AMQP exchange to publish to.
+This field supports [interpolation functions](/docs/configuration/interpolation#bloblang-queries).
 
 
 Type: `string`  


### PR DESCRIPTION
## What

In our use case, benthos will be reading messages from file and the exchange name will be present as a field under the headers key. This change allows the exchange name to be interpolated and hence becomes dynamic.

Here's my sample benthos config for testing:

```yaml
logger:
  level: DEBUG
  format: logfmt
  add_timestamp: false
  static_fields:
    '@service': benthos

input:
  file:
    paths: [ /tmp/data/messages ]
    codec: lines

pipeline:
  processors:
    - mutation: |
        root = {}
        root.message = json("headers.message")
        meta exchange = json("headers.exchange")
    - log:
        message: 'Got exchange: ${!meta("exchange")}'

output:
  amqp_0_9:
    urls: [amqp://root:root@localhost:5672/]
    exchange: '${!meta("exchange")}'
    persistent: true
```

When I fed the following messages:

```json
{"headers":{"exchange":"test2", "message":"for test2", "routing_key":"test-rk"}}
{"headers":{"exchange":"test1", "message":"for test1", "routing_key":"test-rk"}}
```

the messages were published successfully and the exchanges were logged correctly:

```
INFO Running main config from specified file       @service=benthos path=/tmp/benthos.conf
INFO Listening for HTTP requests at: http://0.0.0.0:4195  @service=benthos
INFO Consuming from file '/tmp/data/messages'      @service=benthos label="" path=root.input
ERRO HTTP Server error: listen tcp 0.0.0.0:4195: bind: address already in use  @service=benthos
INFO Launching a benthos instance, use CTRL+C to close  @service=benthos
INFO Got exchange: test2                           @service=benthos label="" path=root.pipeline.processors.1
INFO Got exchange: test1                           @service=benthos label="" path=root.pipeline.processors.1
INFO Sending AMQP messages to exchange: &{0xc0017b6d80}  @service=benthos label="" path=root.output
DEBU Waiting for pending acks to resolve before shutting down.  @service=benthos label="" path=root.input
DEBU Pending acks resolved.                        @service=benthos label="" path=root.input
INFO Pipeline has terminated. Shutting down the service  @service=benthos
```
