### PR TITLE
preserve *service.BatchError generated by plugins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
 - HTTP components no longer ignore `proxy_url` settings when OAuth2 is set.
 - The `PATCH` verb for the streams mode REST API no longer fails to patch over newer components implemented with the latest plugin APIs.
 - The `nats_jetstream` input no longer fails for configs that set `bind` to `true` and do not specify both a `stream` and `durable` together.
+- Fixed a bug where `(*service.BatchError).WalkMessages` did not iterate over the underlying errors.
 
 ### Changed
 

--- a/public/service/errors.go
+++ b/public/service/errors.go
@@ -74,19 +74,16 @@ func (err *BatchError) Unwrap() error {
 // If the provided error is not nil and can be cast to an internal batch error
 // we return a public batch error.
 func toPublicBatchError(err error) error {
+	// Modern Benthos components that use the public service API will return a
+	// *service.BatchError type. We will preserve this if we encounter it.
+	var target *BatchError
+	if ok := errors.As(err, &target); ok {
+		return err
+	}
+
 	var bErr *batch.Error
 	if err != nil && errors.As(err, &bErr) {
 		err = &BatchError{wrapped: bErr}
-	}
-	return err
-}
-
-// If the provided error is not nil and can be cast to a public batch error we
-// return the internal batch error.
-func fromPublicBatchError(err error) error {
-	var bErr *BatchError
-	if err != nil && errors.As(err, &bErr) {
-		err = bErr.wrapped
 	}
 	return err
 }

--- a/public/service/errors_test.go
+++ b/public/service/errors_test.go
@@ -68,3 +68,10 @@ func TestMockWalkableError_OmitSuccessfulMessages(t *testing.T) {
 
 	require.Equal(t, err.IndexedErrors(), 2, "indexed errors did not match size of batch")
 }
+
+func TestToPublicBatchError_PreservePublicError(t *testing.T) {
+	b := MessageBatch{NewMessage([]byte(`test`))}
+	err := NewBatchError(b, errors.New("test error headline"))
+
+	require.Same(t, err, toPublicBatchError(err))
+}

--- a/public/service/input.go
+++ b/public/service/input.go
@@ -216,7 +216,6 @@ func (r *ResourceInput) ReadBatch(ctx context.Context) (MessageBatch, AckFunc, e
 		return nil
 	})
 	return b, func(c context.Context, r error) error {
-		r = fromPublicBatchError(r)
 		return tran.Ack(c, r)
 	}, nil
 }
@@ -264,7 +263,6 @@ func (o *OwnedInput) ReadBatch(ctx context.Context) (MessageBatch, AckFunc, erro
 		return nil
 	})
 	return b, func(c context.Context, r error) error {
-		r = fromPublicBatchError(r)
 		return tran.Ack(c, r)
 	}, nil
 }

--- a/public/service/output.go
+++ b/public/service/output.go
@@ -117,11 +117,12 @@ func (a *airGapBatchWriter) WriteBatch(ctx context.Context, msg message.Batch) e
 		parts[i] = NewInternalMessage(part)
 		return nil
 	})
+
 	err := a.w.WriteBatch(ctx, parts)
 	if err != nil && errors.Is(err, ErrNotConnected) {
 		err = component.ErrNotConnected
 	}
-	err = fromPublicBatchError(err)
+
 	return err
 }
 


### PR DESCRIPTION
This change ensures that any `*service.BatchError`s that are returned from various plugins are preserved including their internal state. Previously, the air-gap layer of Benthos was intercepting errors generated by plugins and converting these between `*service.BatchError` and the internal `*batch.Error` types. These conversions were buggy because we would often lose the underlying `*message.SortGroup`. When plugin developers received `*service.BatchError`, in some cases, they were unable to iterate over the contained message errors with the `WalkMessages` method because the sort group was often `nil`.