### PR TITLE
Add option to select pulsar topics with regex

### DIFF
--- a/internal/impl/pulsar/input.go
+++ b/internal/impl/pulsar/input.go
@@ -21,16 +21,26 @@ const (
 func init() {
 	err := service.RegisterInput(
 		"pulsar",
-		service.NewConfigSpec().
-			Version("3.43.0").
-			Categories("Services").
-			Summary("Reads messages from an Apache Pulsar server.").
-			Description(`
+		inputConfigSpec(),
+		func(conf *service.ParsedConfig, mgr *service.Resources) (service.Input, error) {
+			return newPulsarReaderFromParsed(conf, mgr.Logger())
+		})
+	if err != nil {
+		panic(err)
+	}
+}
+
+func inputConfigSpec() *service.ConfigSpec {
+	return service.NewConfigSpec().
+		Version("3.43.0").
+		Categories("Services").
+		Summary("Reads messages from an Apache Pulsar server.").
+		Description(`
 ### Metadata
 
 This input adds the following metadata fields to each message:
 
-`+"```text"+`
+` + "```text" + `
 - pulsar_message_id
 - pulsar_key
 - pulsar_ordering_key
@@ -40,36 +50,34 @@ This input adds the following metadata fields to each message:
 - pulsar_producer_name
 - pulsar_redelivery_count
 - All properties of the message
-`+"```"+`
+` + "```" + `
 
 You can access these metadata fields using
 [function interpolation](/docs/configuration/interpolation#bloblang-queries).
 `).
-			Field(service.NewURLField("url").
-				Description("A URL to connect to.").
-				Example("pulsar://localhost:6650").
-				Example("pulsar://pulsar.us-west.example.com:6650").
-				Example("pulsar+ssl://pulsar.us-west.example.com:6651")).
-			Field(service.NewStringListField("topics").
-				Description("A list of topics to subscribe to.")).
-			Field(service.NewStringField("subscription_name").
-				Description("Specify the subscription name for this consumer.")).
-			Field(service.NewStringEnumField("subscription_type", "shared", "key_shared", "failover", "exclusive").
-				Description("Specify the subscription type for this consumer.\n\n> NOTE: Using a `key_shared` subscription type will __allow out-of-order delivery__ since nack-ing messages sets non-zero nack delivery delay - this can potentially cause consumers to stall. See [Pulsar documentation](https://pulsar.apache.org/docs/en/2.8.1/concepts-messaging/#negative-acknowledgement) and [this Github issue](https://github.com/apache/pulsar/issues/12208) for more details.").
-				Default(defaultSubscriptionType)).
-			Field(service.NewObjectField("tls",
-				service.NewStringField("root_cas_file").
-					Description("An optional path of a root certificate authority file to use. This is a file, often with a .pem extension, containing a certificate chain from the parent trusted root certificate, to possible intermediate signing certificates, to the host certificate.").
-					Default("").
-					Example("./root_cas.pem")).
-				Description("Specify the path to a custom CA certificate to trust broker TLS service.")).
-			Field(authField()),
-		func(conf *service.ParsedConfig, mgr *service.Resources) (service.Input, error) {
-			return newPulsarReaderFromParsed(conf, mgr.Logger())
-		})
-	if err != nil {
-		panic(err)
-	}
+		Field(service.NewURLField("url").
+			Description("A URL to connect to.").
+			Example("pulsar://localhost:6650").
+			Example("pulsar://pulsar.us-west.example.com:6650").
+			Example("pulsar+ssl://pulsar.us-west.example.com:6651")).
+		Field(service.NewStringListField("topics").
+			Description("A list of topics to subscribe to. This or topics_pattern must be set.").
+			Default([]string{})).
+		Field(service.NewStringField("topics_pattern").
+			Description("A regular expression matching the topics to subscribe to. This or topics must be set.").
+			Default("")).
+		Field(service.NewStringField("subscription_name").
+			Description("Specify the subscription name for this consumer.")).
+		Field(service.NewStringEnumField("subscription_type", "shared", "key_shared", "failover", "exclusive").
+			Description("Specify the subscription type for this consumer.\n\n> NOTE: Using a `key_shared` subscription type will __allow out-of-order delivery__ since nack-ing messages sets non-zero nack delivery delay - this can potentially cause consumers to stall. See [Pulsar documentation](https://pulsar.apache.org/docs/en/2.8.1/concepts-messaging/#negative-acknowledgement) and [this Github issue](https://github.com/apache/pulsar/issues/12208) for more details.").
+			Default(defaultSubscriptionType)).
+		Field(service.NewObjectField("tls",
+			service.NewStringField("root_cas_file").
+				Description("An optional path of a root certificate authority file to use. This is a file, often with a .pem extension, containing a certificate chain from the parent trusted root certificate, to possible intermediate signing certificates, to the host certificate.").
+				Default("").
+				Example("./root_cas.pem")).
+			Description("Specify the path to a custom CA certificate to trust broker TLS service.")).
+		Field(authField())
 }
 
 //------------------------------------------------------------------------------
@@ -81,12 +89,13 @@ type pulsarReader struct {
 
 	log *service.Logger
 
-	authConf    authConfig
-	url         string
-	topics      []string
-	subName     string
-	subType     string
-	rootCasFile string
+	authConf      authConfig
+	url           string
+	topics        []string
+	topicsPattern string
+	subName       string
+	subType       string
+	rootCasFile   string
 }
 
 func newPulsarReaderFromParsed(conf *service.ParsedConfig, log *service.Logger) (p *pulsarReader, err error) {
@@ -104,6 +113,9 @@ func newPulsarReaderFromParsed(conf *service.ParsedConfig, log *service.Logger) 
 	if p.topics, err = conf.FieldStringList("topics"); err != nil {
 		return
 	}
+	if p.topicsPattern, err = conf.FieldString("topics_pattern"); err != nil {
+		return
+	}
 	if p.subName, err = conf.FieldString("subscription_name"); err != nil {
 		return
 	}
@@ -118,8 +130,9 @@ func newPulsarReaderFromParsed(conf *service.ParsedConfig, log *service.Logger) 
 		err = errors.New("field url must not be empty")
 		return
 	}
-	if len(p.topics) == 0 {
-		err = errors.New("field topics must not be empty")
+	if len(p.topics) == 0 && len(p.topicsPattern) == 0 ||
+		len(p.topics) != 0 && len(p.topicsPattern) != 0 {
+		err = errors.New("exactly one of fields topics and topics_pattern must be set")
 		return
 	}
 	if p.subName == "" {
@@ -192,14 +205,16 @@ func (p *pulsarReader) Connect(ctx context.Context) error {
 		return err
 	}
 
-	if consumer, err = client.Subscribe(pulsar.ConsumerOptions{
+	options := pulsar.ConsumerOptions{
 		Topics:           p.topics,
+		TopicsPattern:    p.topicsPattern,
 		SubscriptionName: p.subName,
 		Type:             subType,
 		KeySharedPolicy: &pulsar.KeySharedPolicy{
 			AllowOutOfOrderDelivery: true,
 		},
-	}); err != nil {
+	}
+	if consumer, err = client.Subscribe(options); err != nil {
 		client.Close()
 		return err
 	}

--- a/internal/impl/pulsar/input_test.go
+++ b/internal/impl/pulsar/input_test.go
@@ -1,0 +1,61 @@
+package pulsar
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/benthosdev/benthos/v4/public/service"
+)
+
+func TestParseInputTopicXorPattern(t *testing.T) {
+	tests := []struct {
+		name, config string
+		errStr       string
+	}{
+		{
+			name:   "topics",
+			config: `topics: ["my_cool_topic"]`,
+		},
+		{
+			name:   "topics_pattern",
+			config: `topics_pattern: ".*cool_topic"`,
+		},
+		{
+			name:   "topics and topics_pattern fails",
+			errStr: "exactly one of fields topics and topics_pattern must be set",
+			config: `
+topics: ["my_cool_topic"]
+topics_pattern: ".*_cool_topic"
+`,
+		},
+		{
+			name:   "providing neither fails",
+			errStr: "exactly one of fields topics and topics_pattern must be set",
+			config: ``,
+		},
+	}
+
+	baseConfig := `
+url: pulsar://localhost:6650/
+subscription_name: "sub"
+`
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			env := service.NewEnvironment()
+
+			conf := baseConfig + test.config
+			parsed, err := inputConfigSpec().ParseYAML(conf, env)
+			require.NoError(t, err, "parse config")
+
+			reader, err := newPulsarReaderFromParsed(parsed, service.MockResources().Logger())
+			if test.errStr != "" {
+				require.EqualError(t, err, test.errStr)
+			} else {
+				require.NoError(t, err, "new reader from parsed")
+				require.NoError(t, reader.Close(context.Background()))
+			}
+		})
+	}
+}

--- a/internal/impl/pulsar/output.go
+++ b/internal/impl/pulsar/output.go
@@ -14,33 +14,7 @@ import (
 func init() {
 	err := service.RegisterOutput(
 		"pulsar",
-		service.NewConfigSpec().
-			Version("3.43.0").
-			Categories("Services").
-			Summary("Write messages to an Apache Pulsar server.").
-			Field(service.NewURLField("url").
-				Description("A URL to connect to.").
-				Example("pulsar://localhost:6650").
-				Example("pulsar://pulsar.us-west.example.com:6650").
-				Example("pulsar+ssl://pulsar.us-west.example.com:6651")).
-			Field(service.NewStringField("topic").
-				Description("The topic to publish to.")).
-			Field(service.NewObjectField("tls",
-				service.NewStringField("root_cas_file").
-					Description("An optional path of a root certificate authority file to use. This is a file, often with a .pem extension, containing a certificate chain from the parent trusted root certificate, to possible intermediate signing certificates, to the host certificate.").
-					Default("").
-					Example("./root_cas.pem")).
-				Description("Specify the path to a custom CA certificate to trust broker TLS service.")).
-			Field(service.NewInterpolatedStringField("key").
-				Description("The key to publish messages with.").
-				Default("")).
-			Field(service.NewInterpolatedStringField("ordering_key").
-				Description("The ordering key to publish messages with.").
-				Default("")).
-			Field(service.NewIntField("max_in_flight").
-				Description("The maximum number of messages to have in flight at a given time. Increase this to improve throughput.").
-				Default(64)).
-			Field(authField()),
+		outputConfigSpec(),
 		func(conf *service.ParsedConfig, mgr *service.Resources) (service.Output, int, error) {
 			w, err := newPulsarWriterFromParsed(conf, mgr.Logger())
 			if err != nil {
@@ -55,6 +29,36 @@ func init() {
 	if err != nil {
 		panic(err)
 	}
+}
+
+func outputConfigSpec() *service.ConfigSpec {
+	return service.NewConfigSpec().
+		Version("3.43.0").
+		Categories("Services").
+		Summary("Write messages to an Apache Pulsar server.").
+		Field(service.NewURLField("url").
+			Description("A URL to connect to.").
+			Example("pulsar://localhost:6650").
+			Example("pulsar://pulsar.us-west.example.com:6650").
+			Example("pulsar+ssl://pulsar.us-west.example.com:6651")).
+		Field(service.NewStringField("topic").
+			Description("The topic to publish to.")).
+		Field(service.NewObjectField("tls",
+			service.NewStringField("root_cas_file").
+				Description("An optional path of a root certificate authority file to use. This is a file, often with a .pem extension, containing a certificate chain from the parent trusted root certificate, to possible intermediate signing certificates, to the host certificate.").
+				Default("").
+				Example("./root_cas.pem")).
+			Description("Specify the path to a custom CA certificate to trust broker TLS service.")).
+		Field(service.NewInterpolatedStringField("key").
+			Description("The key to publish messages with.").
+			Default("")).
+		Field(service.NewInterpolatedStringField("ordering_key").
+			Description("The ordering key to publish messages with.").
+			Default("")).
+		Field(service.NewIntField("max_in_flight").
+			Description("The maximum number of messages to have in flight at a given time. Increase this to improve throughput.").
+			Default(64)).
+		Field(authField())
 }
 
 //------------------------------------------------------------------------------

--- a/website/docs/components/inputs/pulsar.md
+++ b/website/docs/components/inputs/pulsar.md
@@ -35,7 +35,8 @@ input:
   label: ""
   pulsar:
     url: pulsar://localhost:6650 # No default (required)
-    topics: [] # No default (required)
+    topics: []
+    topics_pattern: ""
     subscription_name: "" # No default (required)
     subscription_type: shared
     tls:
@@ -51,7 +52,8 @@ input:
   label: ""
   pulsar:
     url: pulsar://localhost:6650 # No default (required)
-    topics: [] # No default (required)
+    topics: []
+    topics_pattern: ""
     subscription_name: "" # No default (required)
     subscription_type: shared
     tls:
@@ -111,10 +113,19 @@ url: pulsar+ssl://pulsar.us-west.example.com:6651
 
 ### `topics`
 
-A list of topics to subscribe to.
+A list of topics to subscribe to. This or topics_pattern must be set.
 
 
 Type: `array`  
+Default: `[]`  
+
+### `topics_pattern`
+
+A regular expression matching the topics to subscribe to. This or topics must be set.
+
+
+Type: `string`  
+Default: `""`  
 
 ### `subscription_name`
 


### PR DESCRIPTION
Pulsar clients support consuming multiple topics dynamically by providing a regex (see [the TopicsPattern field](https://pkg.go.dev/github.com/apache/pulsar-client-go/pulsar#ConsumerOptions)). This change adds that ability as a config option for the Pulsar input.

Closes https://github.com/benthosdev/benthos/issues/1988