### PR TITLE
Add bloblang zip method

### DIFF
--- a/internal/impl/pure/bloblang_objects.go
+++ b/internal/impl/pure/bloblang_objects.go
@@ -97,6 +97,50 @@ If a key within a nested path does not exist then it is ignored.`).
 		}); err != nil {
 		panic(err)
 	}
+
+	if err := bloblang.RegisterMethodV2("zip",
+		bloblang.NewPluginSpec().
+			Category(query.MethodCategoryObjectAndArray).
+			Variadic().
+			Description("zip an array value with one or more argument arrays.").
+			Example("", `root.foo = this.foo.zip(this.bar, this.baz)`,
+				[2]string{
+					`{"foo":["a","b","c"],"bar":[1,2,3],"baz":[4,5,6]}`,
+					`{"foo":[["a",1,4],["b",2,5],["c",3,6]]}`,
+				},
+			),
+		func(args *bloblang.ParsedParams) (bloblang.Method, error) {
+			sizeError := fmt.Errorf("can't zip different length array values")
+			argAnys := args.AsSlice()
+			argSlices := make([][]any, len(argAnys))
+			for i, a := range argAnys {
+				var ok bool
+				if argSlices[i], ok = a.([]any); !ok {
+					return nil, query.NewTypeError(a, query.ValueArray)
+				}
+				if len(argSlices[i]) != len(argSlices[0]) {
+					return nil, sizeError
+				}
+			}
+
+			return bloblang.ArrayMethod(func(i []any) (any, error) {
+				if len(i) != len(argSlices[0]) {
+					return nil, sizeError
+				}
+				resSlice := make([][]any, 0, len(i))
+				for offset, value := range i {
+					zipValue := make([]any, 0, len(argSlices)+1)
+					zipValue = append(zipValue, value)
+					for _, argSlice := range argSlices {
+						zipValue = append(zipValue, argSlice[offset])
+					}
+					resSlice = append(resSlice, zipValue)
+				}
+				return resSlice, nil
+			}), nil
+		}); err != nil {
+		panic(err)
+	}
 }
 
 func mapWith(m map[string]any, paths [][]string) map[string]any {

--- a/internal/impl/pure/bloblang_objects_test.go
+++ b/internal/impl/pure/bloblang_objects_test.go
@@ -75,3 +75,90 @@ func TestConcatMethod(t *testing.T) {
 		})
 	}
 }
+
+func TestZipMethod(t *testing.T) {
+	testCases := []struct {
+		name    string
+		mapping string
+		input   any
+		output  any
+		execErr string
+	}{
+		{
+			name:    "three arrays",
+			mapping: `root.foo = this.foo.zip(this.bar, this.baz)`,
+			input: map[string]any{
+				"foo": []any{"a", "b", "c"},
+				"bar": []any{1, 2, 3},
+				"baz": []any{
+					[]any{"x"},
+					[]any{"y"},
+					[]any{"z"},
+				},
+			},
+			output: map[string]any{
+				"foo": [][]any{
+					{"a", 1, []any{"x"}},
+					{"b", 2, []any{"y"}},
+					{"c", 3, []any{"z"}},
+				},
+			},
+		},
+		{
+			name:    "non array arg",
+			mapping: `root.foo = this.foo.zip(this.bar)`,
+			input: map[string]any{
+				"foo": []any{"first"},
+				"bar": "second",
+			},
+			execErr: "expected array value, got string",
+		},
+		{
+			name:    "non array target",
+			mapping: `root.foo = this.foo.zip(this.bar)`,
+			input: map[string]any{
+				"bar": []any{"first"},
+				"foo": "second",
+			},
+			execErr: "expected array value, got string",
+		},
+		{
+			name:    "jagged array value parameters",
+			mapping: `root.foo = this.foo.zip(this.bar, this.baz)`,
+			input: map[string]any{
+				"baz": []any{"first", "second"},
+				"bar": []any{"third"},
+				"foo": []any{"forth"},
+			},
+			execErr: "can't zip different length array values",
+		},
+		{
+			name:    "jagged array value and parameters",
+			mapping: `root.foo = this.foo.zip(this.bar, this.baz)`,
+			input: map[string]any{
+				"baz": []any{"first", "second"},
+				"bar": []any{"third", "forth"},
+				"foo": []any{"fifth"},
+			},
+			execErr: "can't zip different length array values",
+		},
+	}
+
+	for _, test := range testCases {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			exec, err := bloblang.Parse(test.mapping)
+			require.NoError(t, err)
+
+			res, err := exec.Query(test.input)
+
+			if test.execErr == "" {
+				require.NoError(t, err)
+				assert.Equal(t, test.output, res)
+			} else {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), test.execErr)
+			}
+		})
+	}
+}

--- a/website/docs/guides/bloblang/methods.md
+++ b/website/docs/guides/bloblang/methods.md
@@ -2600,6 +2600,20 @@ root = this.without("inner.a","inner.c","d")
 # Out: {"e":"fifth","inner":{"b":"second"}}
 ```
 
+### `zip`
+
+zip an array value with one or more argument arrays.
+
+#### Examples
+
+
+```coffee
+root.foo = this.foo.zip(this.bar, this.baz)
+
+# In:  {"foo":["a","b","c"],"bar":[1,2,3],"baz":[4,5,6]}
+# Out: {"foo":[["a",1,4],["b",2,5],["c",3,6]]}
+```
+
 ## Parsing
 
 ### `bloblang`


### PR DESCRIPTION
The `zip` method supports zipping multiple arrays of the same size.

Fixes #1991 