### PR TITLE
Fix snowflake_put output linting

### DIFF
--- a/internal/impl/snowflake/output_snowflake_put.go
+++ b/internal/impl/snowflake/output_snowflake_put.go
@@ -226,8 +226,8 @@ and it must be set to the `+"`<cloud>`"+` part of the Account Identifier
 		Field(service.NewBatchPolicyField("batching")).
 		Field(service.NewIntField("max_in_flight").Description("The maximum number of parallel message batches to have in flight at any given time.").Default(1)).
 		LintRule(`root = match {
-  this.exists("password") && this.exists("private_key_file") => [ "both `+"`password`"+` and `+"`private_key_file`"+` can't be set simultaneously" ],
-  this.exists("snowpipe") && (!this.exists("private_key_file") || this.private_key_file == "") => [ "`+"`private_key_file`"+` is required when setting `+"`snowpipe`"+`" ],
+  this.exists("password") && this.password != "" && this.exists("private_key_file") && this.private_key_file != "" => [ "both `+"`password`"+` and `+"`private_key_file`"+` can't be set simultaneously" ],
+  this.exists("snowpipe") && this.snowpipe != "" && (!this.exists("private_key_file") || this.private_key_file == "") => [ "`+"`private_key_file`"+` is required when setting `+"`snowpipe`"+`" ],
 }`).
 		Example("Kafka / realtime brokers", "Upload message batches from realtime brokers such as Kafka persisting the batch partition and offsets in the stage path and filename similarly to the [Kafka Connector scheme](https://docs.snowflake.com/en/user-guide/kafka-connector-ts.html#step-1-view-the-copy-history-for-the-table) and call Snowpipe to load them into a table. When batching is configured at the input level, it is done per-partition.", `
 input:


### PR DESCRIPTION
Users should now be able to run `benthos lint` on a config which has `private_key_file: "${PRIVATE_KEY_PATH:}"` and `snowpipe: "${SF_SNOWPIPE:}"` without having to set those env vars to some non-empty values.

Kinda' wish I could use [`.not_empty()`](https://www.benthos.dev/docs/guides/bloblang/methods#not_empty) instead of `this.exists("password") && this.password != ""`. What would you say about introducing `.is_not_empty()`?