### PR TITLE
Fix small mistakes in function doc comments

### DIFF
--- a/internal/component/metrics/local.go
+++ b/internal/component/metrics/local.go
@@ -101,13 +101,14 @@ func (l *Local) GetTimings() map[string]metrics.Timer {
 }
 
 // FlushTimings returns a map of the current state of the metrics paths to
-// counters and then resets the counters to 0.
+// timers and then resets the timers to 0.
 func (l *Local) FlushTimings() map[string]metrics.Timer {
 	return l.getTimings(true)
 }
 
-// FlushTimings returns a map of the current state of the metrics paths to
-// counters and then resets the counters to 0.
+// getTimings returns a map of the current state of the metrics paths to
+// timers before optionally reseting the timers as determined by the reset
+// value passed in.
 func (l *Local) getTimings(reset bool) map[string]metrics.Timer {
 	l.mut.Lock()
 	localFlatTimings := make(map[string]metrics.Timer, len(l.flatTimings))


### PR DESCRIPTION
This commit fixes a copy-paste mistake on `getTimings` and makes a small edit to `FlushTimings` to refer to timers instead of counters.

Background: I'm doing a research study on function comments that may be improvable. You can find more info and a short and optional anonymous survey [here](https://forms.office.com/e/yHv4PRXM2i).
 
Thanks for reviewing!
