### PR TITLE
fix incorrect CUE codegen for various components and fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
 
 - Errors encountered by the `gcp_pubsub` output should now present more specific logs.
 - The CUE schema for `switch` processor now correctly reflects that it takes a list of clauses.
+- Fixed the CUE schema for fields that take a 2d-array such as `workflow.order`.
 
 ## 4.18.0 - 2023-07-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 
 - Errors encountered by the `gcp_pubsub` output should now present more specific logs.
+- The CUE schema for `switch` processor now correctly reflects that it takes a list of clauses.
 
 ## 4.18.0 - 2023-07-02
 

--- a/cmd/tools/benthos_docs_gen/cue_test/expected.yml
+++ b/cmd/tools/benthos_docs_gen/cue_test/expected.yml
@@ -8,6 +8,12 @@ testCases:
       processors:
         - label: sample_transform
           mapping: root = this.uppercase()
+        - switch:
+            - check: count("total") == 1
+              processors:
+                - mapping: meta first = true
+            - processors:
+                - mapping: meta first = false
     output:
       switch:
         cases:

--- a/cmd/tools/benthos_docs_gen/cue_test/test.cue
+++ b/cmd/tools/benthos_docs_gen/cue_test/test.cue
@@ -1,33 +1,54 @@
 testCases:
-  simple: #Config & {
-    input: {
-      label: "sample_input"
-      generate: mapping: "root = 'hello'"
-    }
+	simple: #Config & {
+		input: {
+			label: "sample_input"
+			generate: mapping: "root = 'hello'"
+		}
 
-    pipeline: processors: [{
-      label: "sample_transform"
-      mapping: "root = this.uppercase()"
-    }]
+		pipeline: processors: [
+			{
+				label:   "sample_transform"
+				mapping: "root = this.uppercase()"
+			},
+			{
+				switch: [
+					{
+						check: "count(\"total\") == 1"
+						processors: [
+							{
+								mapping: "meta first = true"
+							},
+						]
+					},
+					{
+						processors: [
+							{
+								mapping: "meta first = false"
+							},
+						]
+					},
+				]
+			},
+		]
 
-    output: #Guarded & {
-      _output: {
-        label: "sample_output"
-        stdout: {}
-      }
-    }
-  }
+		output: #Guarded & {
+			_output: {
+				label: "sample_output"
+				stdout: {}
+			}
+		}
+	}
 
-  #Guarded: self = {
-    _output: #Output
+#Guarded: self = {
+	_output: #Output
 
-    switch: cases: [
-      {
-        check: "errored()"
-        output: reject: "failed to process message: ${! error() }"
-      },
-      {
-        output: self._output
-      }
-    ]
-  }
+	switch: cases: [
+		{
+			check: "errored()"
+			output: reject: "failed to process message: ${! error() }"
+		},
+		{
+			output: self._output
+		},
+	]
+}

--- a/internal/cuegen/cue.go
+++ b/internal/cuegen/cue.go
@@ -11,30 +11,14 @@ import (
 )
 
 func doComponentSpec(cs docs.ComponentSpec) (*ast.Field, error) {
-	cfg := cs.Config
-	if len(cfg.Children) == 0 {
-		simple, err := doFieldSpec(cfg)
-		if err != nil {
-			return nil, err
-		}
-		field := &ast.Field{
-			Label: ast.NewIdent(cs.Name),
-			Value: simple.Value,
-		}
-		if cs.Summary != "" {
-			ast.AddComment(field, doComment(cs.Summary))
-		}
-		return field, nil
-	}
-
-	fields, err := doFieldSpecs(cfg.Children)
+	f, err := doFieldSpec(cs.Config)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("%s: failed to generate CUE: %w", cs.Name, err)
 	}
 
 	field := &ast.Field{
 		Label: ast.NewIdent(cs.Name),
-		Value: ast.NewStruct(fields...),
+		Value: f.Value,
 	}
 
 	if cs.Summary != "" {

--- a/internal/cuegen/cue.go
+++ b/internal/cuegen/cue.go
@@ -84,7 +84,7 @@ func doFieldSpec(spec docs.FieldSpec) (*ast.Field, error) {
 		if err != nil {
 			return nil, err
 		}
-		f.Value = ast.NewList(ast.NewList(&ast.Ellipsis{Type: f.Value}))
+		f.Value = ast.NewList(&ast.Ellipsis{Type: ast.NewList(&ast.Ellipsis{Type: f.Value})})
 		return f, nil
 	case docs.KindMap:
 		f, err := doScalarField(spec)


### PR DESCRIPTION
This PR addresses a couple of bugs in the CUE schema generated by Benthos. Namely, the `switch` / `group_by` processors were not defined to take an array of clauses and the 2d-array of `workflow.order` (an any other similar fields) was defined as `[[...T]]` instead of `[...[...T]]`. The first problem was fixed by simplify the code generation logic for Benthos components. The latter required a specific fix.