### PR TITLE
Fix HTTP server path prefix matching

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -264,8 +264,8 @@ func (t *Type) RegisterEndpoint(path, desc string, handlerFunc http.HandlerFunc)
 			h(w, r)
 		})
 
-		t.mux.PathPrefix(path).Handler(wrapHandler)
-		t.mux.PathPrefix(t.conf.RootPath + path).Handler(wrapHandler)
+		t.mux.Path(path).Handler(wrapHandler)
+		t.mux.Path(t.conf.RootPath + path).Handler(wrapHandler)
 	}
 	t.handlers[path] = handlerFunc
 }


### PR DESCRIPTION
Fixes #2018 and should still support the use-case ( #1797 ) that introduced this behaviour in https://github.com/benthosdev/benthos/commit/61aa1d860051ced3a6540a30cc3f08b88621fb99 