### PR TITLE
Add v0_msg_exists_meta to Javascript

### DIFF
--- a/internal/impl/javascript/functions.go
+++ b/internal/impl/javascript/functions.go
@@ -200,6 +200,24 @@ var _ = registerVMRunnerFunction("v0_msg_as_structured", `Obtain the root of the
 		}
 	})
 
+var _ = registerVMRunnerFunction("v0_msg_exists_meta", `Checks that a metadata key exists in root level.`).
+	Param("name", "string", "The metadata key to search for.").
+	Example(`if (benthos.v0_msg_exists_meta("kafka_key")) {}`).
+	FnCtor(func(r *vmRunner) jsFunction {
+		return func(call goja.FunctionCall, rt *goja.Runtime, l *service.Logger) (interface{}, error) {
+			var name string
+			if err := parseArgs(call, &name); err != nil {
+				return nil, err
+			}
+
+			_, ok := r.targetMessage.MetaGet(name)
+			if !ok {
+				return false, nil
+			}
+			return true, nil
+		}
+	})
+
 var _ = registerVMRunnerFunction("v0_msg_get_meta", `Get the value of a metadata key from the processed message.`).
 	Param("name", "string", "The metadata key to search for.").
 	Example(`let key = benthos.v0_msg_get_meta("kafka_key");`).


### PR DESCRIPTION
Moin,

the function v0_msg_get_meta triggers a panic if the key is not found. Similar to Bloblang, I added a function v0_msg_exists_meta to allow meta keys to be optional.

**v0_msg_get_meta**:

Return error:
https://github.com/benthosdev/benthos/blob/main/internal/impl/javascript/functions.go#L215

Panic if error
https://github.com/benthosdev/benthos/blob/main/internal/impl/javascript/vm.go#L61

Greetings