### PR TITLE
Add secure option to open_telemetry_collector tracer

### DIFF
--- a/internal/impl/otlp/tracer_otlp.go
+++ b/internal/impl/otlp/tracer_otlp.go
@@ -25,11 +25,17 @@ func init() {
 			service.NewURLField("url").
 				Description("The URL of a collector to send tracing events to.").
 				Default("localhost:4318"),
+			service.NewBoolField("secure").
+				Description("Connect to the collector over HTTPS").
+				Default(false),
 		).Description("A list of http collectors.")).
 		Field(service.NewObjectListField("grpc",
 			service.NewURLField("url").
 				Description("The URL of a collector to send tracing events to.").
 				Default("localhost:4317"),
+			service.NewBoolField("secure").
+				Description("Connect to the collector with client transport security").
+				Default(false),
 		).Description("A list of grpc collectors.")).
 		Field(service.NewStringMapField("tags").
 			Description("A map of tags to add to all tracing spans.").
@@ -52,7 +58,8 @@ func init() {
 }
 
 type collector struct {
-	url string
+	url    string
+	secure bool
 }
 
 type otlp struct {
@@ -95,7 +102,16 @@ func collectors(conf *service.ParsedConfig, name string) ([]collector, error) {
 		if err != nil {
 			return nil, err
 		}
-		collectors = append(collectors, collector{u})
+
+		secure, err := pc.FieldBool("secure")
+		if err != nil {
+			return nil, err
+		}
+
+		collectors = append(collectors, collector{
+			url:    u,
+			secure: secure,
+		})
 	}
 	return collectors, nil
 }
@@ -142,10 +158,15 @@ func addGrpcCollectors(ctx context.Context, collectors []collector, opts []trace
 	defer cancel()
 
 	for _, c := range collectors {
-		exp, err := otlptrace.New(ctx, otlptracegrpc.NewClient(
-			otlptracegrpc.WithInsecure(),
+		clientOpts := []otlptracegrpc.Option{
 			otlptracegrpc.WithEndpoint(c.url),
-		))
+		}
+
+		if !c.secure {
+			clientOpts = append(clientOpts, otlptracegrpc.WithInsecure())
+		}
+
+		exp, err := otlptrace.New(ctx, otlptracegrpc.NewClient(clientOpts...))
 		if err != nil {
 			return nil, err
 		}
@@ -159,10 +180,14 @@ func addHTTPCollectors(ctx context.Context, collectors []collector, opts []trace
 	defer cancel()
 
 	for _, c := range collectors {
-		exp, err := otlptrace.New(ctx, otlptracehttp.NewClient(
-			otlptracehttp.WithInsecure(),
+		clientOpts := []otlptracehttp.Option{
 			otlptracehttp.WithEndpoint(c.url),
-		))
+		}
+
+		if !c.secure {
+			clientOpts = append(clientOpts, otlptracehttp.WithInsecure())
+		}
+		exp, err := otlptrace.New(ctx, otlptracehttp.NewClient(clientOpts...))
 		if err != nil {
 			return nil, err
 		}

--- a/website/docs/components/tracers/open_telemetry_collector.md
+++ b/website/docs/components/tracers/open_telemetry_collector.md
@@ -66,6 +66,14 @@ The URL of a collector to send tracing events to.
 Type: `string`  
 Default: `"localhost:4318"`  
 
+### `http[].secure`
+
+Connect to the collector over HTTPS
+
+
+Type: `bool`  
+Default: `false`  
+
 ### `grpc`
 
 A list of grpc collectors.
@@ -80,6 +88,14 @@ The URL of a collector to send tracing events to.
 
 Type: `string`  
 Default: `"localhost:4317"`  
+
+### `grpc[].secure`
+
+Connect to the collector with client transport security
+
+
+Type: `bool`  
+Default: `false`  
 
 ### `tags`
 


### PR DESCRIPTION
## Overview

Currently `benthos` always connects to open telemetry trace collectors insecurely (i.e. over http or insecure gRPC), which causes tracing to fail if the trace collector is expecting a secure connection.

## Description

This PR adds the `secure` option to the `open_telemetry_collector` tracer, which configures the otel trace collector to use HTTPS or gRPC over TLS if set to true.

## Other thoughts

- An alternative to a new option would be to specify secure / insecure as part of the tracer URL (e.g. `url: https://otlp.collector.com`). I decided against this since specifying them separately better matches `otlptrace.New`'s API and avoids having to do a bunch of dumb URL parsing, string matching and invalid schema handling.
- Thanks for maintaining such a great library @Jeffail, @mihaitodor and all the others! :heart: 