### PR TITLE
Fix init-time panic in Go 1.21

### DIFF
--- a/internal/impl/twitter/init.go
+++ b/internal/impl/twitter/init.go
@@ -2,6 +2,9 @@ package twitter
 
 import (
 	_ "embed"
+	// bloblang functions are registered in init functions under this package
+	// so ensure they are loaded first
+	_ "github.com/benthosdev/benthos/v4/internal/impl/pure"
 
 	"github.com/benthosdev/benthos/v4/internal/bundle"
 	"github.com/benthosdev/benthos/v4/internal/template"


### PR DESCRIPTION
See issue #2033 for details, the quick version is there was an implicit reliance on package initialization ordering, but this ordering was changed in Go 1.21. The fix is to add an explicit import to make this force the desired order.