### PR TITLE
MongoDB input - add batching

### DIFF
--- a/internal/impl/mongodb/input.go
+++ b/internal/impl/mongodb/input.go
@@ -6,6 +6,7 @@ import (
 
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
 
 	"github.com/benthosdev/benthos/v4/public/service"
 )
@@ -14,6 +15,7 @@ import (
 const (
 	FindInputOperation      = "find"
 	AggregateInputOperation = "aggregate"
+	DefaultBatchSize        = 1000
 )
 
 func mongoConfigSpec() *service.ConfigSpec {
@@ -21,8 +23,8 @@ func mongoConfigSpec() *service.ConfigSpec {
 		// Stable(). TODO
 		Version("3.64.0").
 		Categories("Services").
-		Summary("Executes a find query and creates a message for each row received.").
-		Description(`Once the rows from the query are exhausted this input shuts down, allowing the pipeline to gracefully terminate (or the next input in a [sequence](/docs/components/inputs/sequence) to execute).`).
+		Summary("Executes a query and creates a message for each document received.").
+		Description(`Once the documents from the query are exhausted, this input shuts down, allowing the pipeline to gracefully terminate (or the next input in a [sequence](/docs/components/inputs/sequence) to execute).`).
 		Fields(clientFields()...).
 		Field(service.NewStringField("collection").Description("The collection to select from.")).
 		Field(service.NewStringEnumField("operation", FindInputOperation, AggregateInputOperation).
@@ -44,26 +46,47 @@ func mongoConfigSpec() *service.ConfigSpec {
 			Example(`
   root.from = {"$lte": timestamp_unix()}
   root.to = {"$gte": timestamp_unix()}
-`))
+`)).
+		Field(service.NewIntField("batchSize").
+			Description("A number of documents at which the batch should be flushed. Greater than `0`. Operations: `find`, `aggregate`").
+			Optional().
+			Default(1000).
+			Version("4.22.0")).
+		Field(service.NewIntMapField("sort").
+			Description("An object specifying fields to sort by, and the respective sort order (`1` ascending, `-1` descending). Operations: `find`").
+			Optional().
+			Example(`
+name: 1
+age: -1
+`).
+			Version("4.22.0")).
+		Field(service.NewIntField("limit").
+			Description("A number of documents to return. Operations: `find`").
+			Optional().
+			Version("4.22.0"))
 }
 
 func init() {
-	err := service.RegisterInput(
+	err := service.RegisterBatchInput(
 		"mongodb", mongoConfigSpec(),
-		func(conf *service.ParsedConfig, mgr *service.Resources) (service.Input, error) {
-			return newMongoInput(conf)
+		func(conf *service.ParsedConfig, mgr *service.Resources) (service.BatchInput, error) {
+			return newMongoInput(conf, mgr.Logger())
 		})
 	if err != nil {
 		panic(err)
 	}
 }
 
-func newMongoInput(conf *service.ParsedConfig) (service.Input, error) {
+func newMongoInput(conf *service.ParsedConfig, logger *service.Logger) (service.BatchInput, error) {
+	var (
+		batchSize, limit int
+		sort             map[string]int
+	)
+
 	mClient, database, err := getClient(conf)
 	if err != nil {
 		return nil, err
 	}
-
 	collection, err := conf.FieldString("collection")
 	if err != nil {
 		return nil, err
@@ -84,14 +107,36 @@ func newMongoInput(conf *service.ParsedConfig) (service.Input, error) {
 	if err != nil {
 		return nil, err
 	}
-
-	return service.AutoRetryNacks(&mongoInput{
+	if conf.Contains("batchSize") {
+		batchSize, err = conf.FieldInt("batchSize")
+		if err != nil {
+			return nil, err
+		}
+	}
+	if conf.Contains("sort") {
+		sort, err = conf.FieldIntMap("sort")
+		if err != nil {
+			return nil, err
+		}
+	}
+	if conf.Contains("limit") {
+		limit, err = conf.FieldInt("limit")
+		if err != nil {
+			return nil, err
+		}
+	}
+	return service.AutoRetryNacksBatched(&mongoInput{
 		query:        query,
 		collection:   collection,
 		client:       mClient,
 		database:     database,
 		operation:    operation,
 		marshalCanon: marshalMode == string(JSONMarshalModeCanonical),
+		batchSize:    int32(batchSize),
+		sort:         sort,
+		limit:        int64(limit),
+		count:        0,
+		logger:       logger,
 	}), nil
 }
 
@@ -103,6 +148,11 @@ type mongoInput struct {
 	cursor       *mongo.Cursor
 	operation    string
 	marshalCanon bool
+	batchSize    int32
+	sort         map[string]int
+	limit        int64
+	count        int
+	logger       *service.Logger
 }
 
 func (m *mongoInput) Connect(ctx context.Context) error {
@@ -118,11 +168,21 @@ func (m *mongoInput) Connect(ctx context.Context) error {
 	collection := m.database.Collection(m.collection)
 	switch m.operation {
 	case "find":
-		m.cursor, err = collection.Find(ctx, m.query)
+		var findOptions *options.FindOptions
+		findOptions, err = m.getFindOptions()
+		if err != nil {
+			return fmt.Errorf("error parsing 'find' options: %v", err)
+		}
+		m.cursor, err = collection.Find(ctx, m.query, findOptions)
 	case "aggregate":
-		m.cursor, err = collection.Aggregate(ctx, m.query)
+		var aggregateOptions *options.AggregateOptions
+		aggregateOptions, err = m.getAggregateOptions()
+		if err != nil {
+			return fmt.Errorf("error parsing 'aggregate' options: %v", err)
+		}
+		m.cursor, err = collection.Aggregate(ctx, m.query, aggregateOptions)
 	default:
-		return fmt.Errorf("opertaion %s not supported. the supported values are \"find\" and \"aggregate\"", m.operation)
+		return fmt.Errorf("operation '%s' not supported. the supported values are 'find' and 'aggregate'", m.operation)
 	}
 	if err != nil {
 		_ = m.client.Disconnect(ctx)
@@ -131,33 +191,68 @@ func (m *mongoInput) Connect(ctx context.Context) error {
 	return nil
 }
 
-func (m *mongoInput) Read(ctx context.Context) (*service.Message, service.AckFunc, error) {
+func (m *mongoInput) ReadBatch(ctx context.Context) (service.MessageBatch, service.AckFunc, error) {
+	i := 0
+	batch := make(service.MessageBatch, m.batchSize)
+
 	if m.cursor == nil {
 		return nil, nil, service.ErrNotConnected
 	}
-	if !m.cursor.Next(ctx) {
-		return nil, nil, service.ErrEndOfInput
-	}
-	var decoded any
-	if err := m.cursor.Decode(&decoded); err != nil {
-		return nil, nil, err
-	}
 
-	data, err := bson.MarshalExtJSON(decoded, m.marshalCanon, false)
-	if err != nil {
-		return nil, nil, err
-	}
+	for m.cursor.Next(ctx) {
+		msg := service.NewMessage(nil)
+		msg.MetaSet("mongo_database", m.database.Name())
+		msg.MetaSet("mongo_collection", m.collection)
 
-	msg := service.NewMessage(nil)
-	msg.SetBytes(data)
-	return msg, func(ctx context.Context, err error) error {
-		return nil
-	}, nil
+		var decoded any
+		if err := m.cursor.Decode(&decoded); err != nil {
+			msg.SetError(err)
+		} else {
+			data, err := bson.MarshalExtJSON(decoded, m.marshalCanon, false)
+			if err != nil {
+				msg.SetError(err)
+			}
+			msg.SetBytes(data)
+		}
+		batch[i] = msg
+		i++
+		m.count++
+
+		if m.cursor.RemainingBatchLength() == 0 {
+			return batch[:i], func(ctx context.Context, err error) error {
+				return nil
+			}, nil
+		}
+	}
+	return nil, nil, service.ErrEndOfInput
 }
 
 func (m *mongoInput) Close(ctx context.Context) error {
 	if m.cursor != nil && m.client != nil {
+		m.logger.Debugf("Got %d documents from '%s' collection", m.count, m.collection)
 		return m.client.Disconnect(ctx)
 	}
 	return nil
+}
+
+func (m *mongoInput) getFindOptions() (*options.FindOptions, error) {
+	findOptions := options.Find()
+	if m.batchSize > 0 {
+		findOptions.SetBatchSize(m.batchSize)
+	}
+	if m.sort != nil {
+		findOptions.SetSort(m.sort)
+	}
+	if m.limit > 0 {
+		findOptions.SetLimit(m.limit)
+	}
+	return findOptions, nil
+}
+
+func (m *mongoInput) getAggregateOptions() (*options.AggregateOptions, error) {
+	aggregateOptions := options.Aggregate()
+	if m.batchSize > 0 {
+		aggregateOptions.SetBatchSize(m.batchSize)
+	}
+	return aggregateOptions, nil
 }

--- a/website/docs/components/inputs/mongodb.md
+++ b/website/docs/components/inputs/mongodb.md
@@ -17,7 +17,7 @@ import TabItem from '@theme/TabItem';
 :::caution EXPERIMENTAL
 This component is experimental and therefore subject to change or removal outside of major version releases.
 :::
-Executes a find query and creates a message for each row received.
+Executes a query and creates a message for each document received.
 
 Introduced in version 3.64.0.
 
@@ -42,6 +42,9 @@ input:
     query: |2 # No default (required)
         root.from = {"$lte": timestamp_unix()}
         root.to = {"$gte": timestamp_unix()}
+    batchSize: 1000
+    sort: {} # No default (optional)
+    limit: 0 # No default (optional)
 ```
 
 </TabItem>
@@ -62,12 +65,15 @@ input:
     query: |2 # No default (required)
         root.from = {"$lte": timestamp_unix()}
         root.to = {"$gte": timestamp_unix()}
+    batchSize: 1000
+    sort: {} # No default (optional)
+    limit: 0 # No default (optional)
 ```
 
 </TabItem>
 </Tabs>
 
-Once the rows from the query are exhausted this input shuts down, allowing the pipeline to gracefully terminate (or the next input in a [sequence](/docs/components/inputs/sequence) to execute).
+Once the documents from the query are exhausted, this input shuts down, allowing the pipeline to gracefully terminate (or the next input in a [sequence](/docs/components/inputs/sequence) to execute).
 
 ## Fields
 
@@ -156,5 +162,38 @@ query: |2
     root.from = {"$lte": timestamp_unix()}
     root.to = {"$gte": timestamp_unix()}
 ```
+
+### `batchSize`
+
+A number of documents at which the batch should be flushed. Greater than `0`. Operations: `find`, `aggregate`
+
+
+Type: `int`  
+Default: `1000`  
+Requires version 4.22.0 or newer  
+
+### `sort`
+
+An object specifying fields to sort by, and the respective sort order (`1` ascending, `-1` descending). Operations: `find`
+
+
+Type: `object`  
+Requires version 4.22.0 or newer  
+
+```yml
+# Examples
+
+sort: |2
+  name: 1
+  age: -1
+```
+
+### `limit`
+
+A number of documents to return. Operations: `find`
+
+
+Type: `int`  
+Requires version 4.22.0 or newer  
 
 


### PR DESCRIPTION
This PR converts the MongoDB Input component into a `BatchInput`.  Its performance is greatly improved on collections with large document counts.

This implementation does not use the usual BatchPolicy mechanism, but rather conforms the configuration closer to `find` and `aggregate` options in the MongoDB driver.  For the `find` operation, `limit` and `sort` options are also implemented.