### PR TITLE
Build with Go 1.21 and remove 1.19

### DIFF
--- a/.github/workflows/cross_build.yml
+++ b/.github/workflows/cross_build.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: [1.19.x, 1.20.x]
+        go-version: [1.20.x, 1.21.x]
         os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     env:

--- a/.github/workflows/docker_edge.yml
+++ b/.github/workflows/docker_edge.yml
@@ -14,7 +14,7 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.20.x
+        go-version: 1.21.x
         check-latest: true
 
     - name: Check Out Repo

--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.20.x
+        go-version: 1.21.x
         check-latest: true
 
     - name: Checkout code

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.20.x
+        go-version: 1.21.x
         check-latest: true
 
     - name: Check Out Repo
@@ -48,7 +48,7 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.20.x
+        go-version: 1.21.x
         check-latest: true
 
     - name: Check Out Repo

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.20.x
+        go-version: 1.21.x
         check-latest: true
 
     - name: Checkout code
@@ -53,7 +53,7 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.20.x
+        go-version: 1.21.x
         check-latest: true
 
     - name: Checkout code

--- a/resources/docker/Dockerfile
+++ b/resources/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.20 AS build
+FROM golang:1.21 AS build
 
 ENV CGO_ENABLED=0
 ENV GOOS=linux

--- a/resources/docker/Dockerfile.cgo
+++ b/resources/docker/Dockerfile.cgo
@@ -1,4 +1,4 @@
-FROM golang:1.20 AS build
+FROM golang:1.21 AS build
 
 ENV CGO_ENABLED=1
 ENV GOOS=linux


### PR DESCRIPTION
Build with the newer version of go (1.21) and remove deprecated go version (1.19)
Addresses: https://github.com/benthosdev/benthos/pull/2034#pullrequestreview-1572685794