### PR TITLE
amqp1 - Add SASL Mechanism 'anonymous'

### DIFF
--- a/internal/impl/amqp1/config.go
+++ b/internal/impl/amqp1/config.go
@@ -60,6 +60,8 @@ func saslOptFnsFromParsed(conf *service.ParsedConfig, opts *amqp.ConnOptions) er
 	switch mechanism {
 	case "plain":
 		opts.SASLType = amqp.SASLTypePlain(user, pass)
+	case "anonymous":
+		opts.SASLType = amqp.SASLTypeAnonymous()
 	case "none":
 	default:
 		return ErrSASLMechanismNotSupported(mechanism)
@@ -70,8 +72,9 @@ func saslOptFnsFromParsed(conf *service.ParsedConfig, opts *amqp.ConnOptions) er
 func saslFieldSpec() *service.ConfigField {
 	return service.NewObjectField(saslField,
 		service.NewStringAnnotatedEnumField(saslMechField, map[string]string{
-			"none":  "No SASL based authentication.",
-			"plain": "Plain text SASL authentication.",
+			"none":      "No SASL based authentication.",
+			"plain":     "Plain text SASL authentication.",
+			"anonymous": "Anonymous SASL authentication.",
 		}).Description("The SASL authentication mechanism to use.").
 			Default("none"),
 		service.NewStringField(saslUserField).


### PR DESCRIPTION
solves: #2072

Depending on AMQP1 broker and configuration of that broker it may be required that an anonymous user MUST explicitly use SASL mechanism "Anonymous" to be able create a connecection.

This commit addes a configuration option to connect to an amqp1 broker with SASL mechanism "anonymous".