### PR TITLE
Fix possible panic on Close when using pusher output

### DIFF
--- a/internal/impl/pusher/output_pusher.go
+++ b/internal/impl/pusher/output_pusher.go
@@ -145,7 +145,10 @@ func (p *pusherWriter) WriteBatch(ctx context.Context, b service.MessageBatch) (
 }
 
 func (p *pusherWriter) Close(ctx context.Context) error {
-	p.client.HTTPClient.CloseIdleConnections()
+	// p.client.HTTPClient might be nil if this output was never used. See: https://github.com/pusher/pusher-http-go/blob/v4.0.1/client.go#L115
+	if p.client.HTTPClient != nil {
+		p.client.HTTPClient.CloseIdleConnections()
+	}
 	p.log.Infof("Pusher connection closed")
 	return nil
 }


### PR DESCRIPTION
We are seeing a panic when shutting down Benthos:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x7046d4]

goroutine 20 [running]:
net/http.(*Client).CloseIdleConnections(0x0?)
	/usr/local/go/src/net/http/client.go:938 +0x14
github.com/benthosdev/benthos/v4/internal/impl/pusher.(*pusherWriter).Close(0xc000fc4000, {0x0?, 0x0?})
	/src/vendor/github.com/benthosdev/benthos/v4/internal/impl/pusher/output_pusher.go:148 +0x28
github.com/benthosdev/benthos/v4/public/service.(*airGapBatchWriter).Close(0xc003a26140?, {0xc001449301?, 0x5089200?})
	/src/vendor/github.com/benthosdev/benthos/v4/public/service/output.go:129 +0x2f
github.com/benthosdev/benthos/v4/internal/component/output.(*AsyncWriter).loop.func1()
	/src/vendor/github.com/benthosdev/benthos/v4/internal/component/output/async_writer.go:133 +0x39
github.com/benthosdev/benthos/v4/internal/component/output.(*AsyncWriter).loop(0xc001633b80)
	/src/vendor/github.com/benthosdev/benthos/v4/internal/component/output/async_writer.go:269 +0x717
created by github.com/benthosdev/benthos/v4/internal/component/output.(*AsyncWriter).Consume
	/src/vendor/github.com/benthosdev/benthos/v4/internal/component/output/async_writer.go:277 +0x79
```

Turns out the `HTTPClient` field in the pusher client will only be created on the first request. If the output never received a message, it will panic. 