### PR TITLE
Cleanup bloblang linting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+### Fixed
+
+- Allow comments in single root and directly imported bloblang mappings
+
 ## 4.20.0 - 2023-08-22
 
 ### Added

--- a/internal/bloblang/parser/combinators.go
+++ b/internal/bloblang/parser/combinators.go
@@ -653,14 +653,6 @@ func DiscardAll(parser Func) Func {
 	}
 }
 
-// Nothing is a parser that always returns an error. This can be useful for
-// disabling parsers.
-func Nothing() Func {
-	return func(input []rune) Result {
-		return Fail(NewError(input, "nothing"), input)
-	}
-}
-
 // MustBe applies a parser and if the result is a non-fatal error then it is
 // upgraded to a fatal one.
 func MustBe(parser Func) Func {

--- a/internal/bloblang/parser/mapping_parser.go
+++ b/internal/bloblang/parser/mapping_parser.go
@@ -97,8 +97,9 @@ func parseExecutor(pCtx Context) Func {
 }
 
 func singleRootImport(pCtx Context) Func {
+	newline := NewlineAllowComment()
 	whitespace := SpacesAndTabs()
-	allWhitespace := DiscardAll(OneOf(whitespace, Newline()))
+	allWhitespace := DiscardAll(OneOf(whitespace, newline))
 
 	parser := Sequence(
 		allWhitespace,
@@ -127,16 +128,20 @@ func singleRootImport(pCtx Context) Func {
 		if execRes.Err != nil {
 			return Fail(NewFatalError(input, NewImportError(fpath, importContent, execRes.Err)), input)
 		}
+		if len(res.Remaining) > 0 {
+			return Fail(NewFatalError(input, fmt.Errorf("unexpected content after single root import: %s", string(res.Remaining))), input)
+		}
 		return Success(execRes.Payload.(*mapping.Executor), res.Remaining)
 	}
 }
 
 func singleRootMapping(pCtx Context) Func {
+	newline := NewlineAllowComment()
 	whitespace := SpacesAndTabs()
-	allWhitespace := DiscardAll(OneOf(whitespace, Newline()))
+	allWhitespace := DiscardAll(OneOf(whitespace, newline))
 
 	return func(input []rune) Result {
-		res := queryParser(pCtx)(input)
+		res := queryParser(pCtx)(allWhitespace(input).Remaining)
 		if res.Err != nil {
 			return res
 		}

--- a/internal/config/watcher_test.go
+++ b/internal/config/watcher_test.go
@@ -36,10 +36,11 @@ output:
 	rdr := newDummyReader(confFilePath, nil)
 
 	changeChan := make(chan struct{})
+	once := sync.Once{}
 	var updatedConf stream.Config
 	require.NoError(t, rdr.SubscribeConfigChanges(func(conf *Type) error {
 		updatedConf = conf.Config
-		close(changeChan)
+		once.Do(func() { close(changeChan) })
 		return nil
 	}))
 

--- a/internal/docs/bloblang_test.go
+++ b/internal/docs/bloblang_test.go
@@ -1,0 +1,114 @@
+package docs
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestLintBloblangMapping(t *testing.T) {
+	type Test struct {
+		mapping   string
+		line      int
+		col       int
+		wantLints []Lint
+	}
+	tests := map[string]Test{
+		"mapping": {
+			mapping: `this.foo = "bar"`,
+			line:    0,
+			col:     0,
+		},
+		"empty mapping": {
+			mapping: ``,
+			line:    0,
+			col:     0,
+		},
+		"invalid mapping": {
+			mapping: `this.foo = #`,
+			line:    2,
+			col:     4,
+			wantLints: []Lint{
+				{
+					Line:   2,
+					Column: 16,
+					Level:  LintError,
+					Type:   LintBadBloblang,
+					What:   `expected query, got: #`,
+				},
+			},
+		},
+	}
+
+	ctx := NewLintContext(NewLintConfig())
+	for name, test := range tests {
+		test := test
+		t.Run(name, func(t *testing.T) {
+			gotLints := LintBloblangMapping(ctx, test.line, test.col, test.mapping)
+			require.EqualValues(t, test.wantLints, gotLints)
+		})
+	}
+}
+
+func TestLintBloblangField(t *testing.T) {
+	type Test struct {
+		mapping   string
+		line      int
+		col       int
+		wantLints []Lint
+	}
+	tests := map[string]Test{
+		"static string field": {
+			mapping: `foobar`,
+			line:    0,
+			col:     0,
+		},
+		"empty field": {
+			mapping: ``,
+			line:    0,
+			col:     0,
+		},
+		"interpolated field": {
+			mapping: `${! json() }`,
+			line:    0,
+			col:     0,
+		},
+		"invalid interpolated field": {
+			mapping: `${! whoopsie{} }`,
+			line:    2,
+			col:     4,
+			wantLints: []Lint{
+				{
+					Line:   2,
+					Column: 17,
+					Level:  LintError,
+					Type:   LintBadBloblang,
+					What:   `required: expected end of expression, got: {} }`,
+				},
+			},
+		},
+		"invalid empty interpolated field": {
+			mapping: `${! }`,
+			line:    2,
+			col:     4,
+			wantLints: []Lint{
+				{
+					Line:   2,
+					Column: 9,
+					Level:  LintError,
+					Type:   LintBadBloblang,
+					What:   `required: expected query, got: }`,
+				},
+			},
+		},
+	}
+
+	ctx := NewLintContext(NewLintConfig())
+	for name, test := range tests {
+		test := test
+		t.Run(name, func(t *testing.T) {
+			gotLints := LintBloblangField(ctx, test.line, test.col, test.mapping)
+			require.EqualValues(t, test.wantLints, gotLints)
+		})
+	}
+}


### PR DESCRIPTION
- Allow comments in single root and directly imported bloblang mappings

```yaml
input:
  generate:
    count: 1
    mapping: root.foo = "bar"
  processors:
    - mapping: |
        #!blobl

        from "test.blobl"
    - switch:
      - check: |
          #!blobl

          this.foo == "bar"
        processors:
          - noop: {}
```

- Explicitly reject content after a directly imported mapping (`from` statement)
- Add tests for directly imported mappings (`from` statement)
- Add bloblang mapping and interpolated field linter tests
- Deflake `watcher` test