### PR TITLE
added client id and rack id support for kafka_franz input and output

### DIFF
--- a/internal/impl/kafka/input_kafka_franz.go
+++ b/internal/impl/kafka/input_kafka_franz.go
@@ -67,6 +67,14 @@ Finally, it's also possible to specify an explicit offset to consume from by add
 		Field(service.NewStringField("consumer_group").
 			Description("An optional consumer group to consume as. When specified the partitions of specified topics are automatically distributed across consumers sharing a consumer group, and partition offsets are automatically committed and resumed under this name. Consumer groups are not supported when specifying explicit partitions to consume from in the `topics` field.").
 			Optional()).
+		Field(service.NewStringField("client_id").
+			Description("An identifier for the client connection.").
+			Default("benthos").
+			Advanced()).
+		Field(service.NewStringField("rack_id").
+			Description("A rack identifier for this client.").
+			Default("").
+			Advanced()).
 		Field(service.NewIntField("checkpoint_limit").
 			Description("Determines how many messages of the same partition can be processed in parallel before applying back pressure. When a message of a given offset is delivered to the output the offset is only allowed to be committed when all messages of prior offsets have also been delivered, this ensures at-least-once delivery guarantees. However, this mechanism also increases the likelihood of duplicates in the event of crashes or server faults, reducing the checkpoint limit will mitigate this.").
 			Default(1024).
@@ -122,6 +130,8 @@ type franzKafkaReader struct {
 	seedBrokers     []string
 	topics          []string
 	topicPartitions map[string]map[int32]kgo.Offset
+	clientID        string
+	rackID          string
 	consumerGroup   string
 	tlsConf         *tls.Config
 	saslConfs       []sasl.Mechanism
@@ -192,6 +202,14 @@ func newFranzKafkaReaderFromConfig(conf *service.ParsedConfig, res *service.Reso
 	}
 
 	if f.regexPattern, err = conf.FieldBool("regexp_topics"); err != nil {
+		return nil, err
+	}
+
+	if f.clientID, err = conf.FieldString("client_id"); err != nil {
+		return nil, err
+	}
+
+	if f.rackID, err = conf.FieldString("rack_id"); err != nil {
 		return nil, err
 	}
 
@@ -594,6 +612,8 @@ func (f *franzKafkaReader) Connect(ctx context.Context) error {
 		kgo.ConsumeResetOffset(initialOffset),
 		kgo.SASL(f.saslConfs...),
 		kgo.ConsumerGroup(f.consumerGroup),
+		kgo.ClientID(f.clientID),
+		kgo.Rack(f.rackID),
 	}
 
 	if f.consumerGroup != "" {

--- a/internal/impl/kafka/output_kafka_franz.go
+++ b/internal/impl/kafka/output_kafka_franz.go
@@ -48,6 +48,14 @@ This output often out-performs the traditional ` + "`kafka`" + ` output as well 
 			Description("An optional explicit partition to set for each message. This field is only relevant when the `partitioner` is set to `manual`. The provided interpolation string must be a valid integer.").
 			Example(`${! meta("partition") }`).
 			Optional()).
+		Field(service.NewStringField("client_id").
+			Description("An identifier for the client connection.").
+			Default("benthos").
+			Advanced()).
+		Field(service.NewStringField("rack_id").
+			Description("A rack identifier for this client.").
+			Default("").
+			Advanced()).
 		Field(service.NewMetadataFilterField("metadata").
 			Description("Determine which (if any) metadata values should be added to messages as headers.").
 			Optional()).
@@ -111,6 +119,8 @@ type franzKafkaWriter struct {
 	topic            *service.InterpolatedString
 	key              *service.InterpolatedString
 	partition        *service.InterpolatedString
+	clientID         string
+	rackID           string
 	tlsConf          *tls.Config
 	saslConfs        []sasl.Mechanism
 	metaFilter       *service.MetadataFilter
@@ -217,6 +227,14 @@ func newFranzKafkaWriterFromConfig(conf *service.ParsedConfig, log *service.Logg
 		}
 	}
 
+	if f.clientID, err = conf.FieldString("client_id"); err != nil {
+		return nil, err
+	}
+
+	if f.rackID, err = conf.FieldString("rack_id"); err != nil {
+		return nil, err
+	}
+
 	if conf.Contains("metadata") {
 		if f.metaFilter, err = conf.FieldMetadataFilter("metadata"); err != nil {
 			return nil, err
@@ -250,6 +268,8 @@ func (f *franzKafkaWriter) Connect(ctx context.Context) error {
 		kgo.AllowAutoTopicCreation(), // TODO: Configure this
 		kgo.ProducerBatchMaxBytes(f.produceMaxBytes),
 		kgo.ProduceRequestTimeout(f.timeout),
+		kgo.ClientID(f.clientID),
+		kgo.Rack(f.rackID),
 		kgo.WithLogger(&kgoLogger{f.log}),
 	}
 	if f.tlsConf != nil {

--- a/website/docs/components/inputs/kafka_franz.md
+++ b/website/docs/components/inputs/kafka_franz.md
@@ -52,6 +52,8 @@ input:
     topics: [] # No default (required)
     regexp_topics: false
     consumer_group: "" # No default (optional)
+    client_id: benthos
+    rack_id: ""
     checkpoint_limit: 1024
     commit_period: 5s
     start_from_oldest: true
@@ -167,6 +169,22 @@ An optional consumer group to consume as. When specified the partitions of speci
 
 
 Type: `string`  
+
+### `client_id`
+
+An identifier for the client connection.
+
+
+Type: `string`  
+Default: `"benthos"`  
+
+### `rack_id`
+
+A rack identifier for this client.
+
+
+Type: `string`  
+Default: `""`  
 
 ### `checkpoint_limit`
 

--- a/website/docs/components/outputs/kafka_franz.md
+++ b/website/docs/components/outputs/kafka_franz.md
@@ -62,6 +62,8 @@ output:
     key: "" # No default (optional)
     partitioner: "" # No default (optional)
     partition: ${! meta("partition") } # No default (optional)
+    client_id: benthos
+    rack_id: ""
     metadata:
       include_prefixes: []
       include_patterns: []
@@ -160,6 +162,22 @@ Type: `string`
 
 partition: ${! meta("partition") }
 ```
+
+### `client_id`
+
+An identifier for the client connection.
+
+
+Type: `string`  
+Default: `"benthos"`  
+
+### `rack_id`
+
+A rack identifier for this client.
+
+
+Type: `string`  
+Default: `""`  
 
 ### `metadata`
 


### PR DESCRIPTION
Added `client_id` and `rack_id` support for `kafka_franz` input and output. The docs are simply copied and pasted from `kafka`

Closes #2090