### PR TITLE
Allow to manually specify the number of partitions for new kafka topics

### DIFF
--- a/internal/component/output/config_kafka.go
+++ b/internal/component/output/config_kafka.go
@@ -10,29 +10,34 @@ import (
 
 // KafkaConfig contains configuration fields for the Kafka output type.
 type KafkaConfig struct {
-	Addresses              []string    `json:"addresses" yaml:"addresses"`
-	ClientID               string      `json:"client_id" yaml:"client_id"`
-	RackID                 string      `json:"rack_id" yaml:"rack_id"`
-	Key                    string      `json:"key" yaml:"key"`
-	Partitioner            string      `json:"partitioner" yaml:"partitioner"`
-	Partition              string      `json:"partition" yaml:"partition"`
-	Topic                  string      `json:"topic" yaml:"topic"`
-	PartitionsPerNewTopic  int         `json:"partitions_per_new_topic" yaml:"partitions_per_new_topic"`
-	TopicReplicationFactor int         `json:"topic_replication_factor" yaml:"topic_replication_factor"`
-	Compression            string      `json:"compression" yaml:"compression"`
-	MaxMsgBytes            int         `json:"max_msg_bytes" yaml:"max_msg_bytes"`
-	Timeout                string      `json:"timeout" yaml:"timeout"`
-	AckReplicas            bool        `json:"ack_replicas" yaml:"ack_replicas"`
-	TargetVersion          string      `json:"target_version" yaml:"target_version"`
-	TLS                    btls.Config `json:"tls" yaml:"tls"`
-	SASL                   sasl.Config `json:"sasl" yaml:"sasl"`
-	MaxInFlight            int         `json:"max_in_flight" yaml:"max_in_flight"`
-	retries.Config         `json:",inline" yaml:",inline"`
-	RetryAsBatch           bool                         `json:"retry_as_batch" yaml:"retry_as_batch"`
-	Batching               batchconfig.Config           `json:"batching" yaml:"batching"`
-	StaticHeaders          map[string]string            `json:"static_headers" yaml:"static_headers"`
-	Metadata               metadata.ExcludeFilterConfig `json:"metadata" yaml:"metadata"`
-	InjectTracingMap       string                       `json:"inject_tracing_map" yaml:"inject_tracing_map"`
+	Addresses           []string                  `json:"addresses" yaml:"addresses"`
+	ClientID            string                    `json:"client_id" yaml:"client_id"`
+	RackID              string                    `json:"rack_id" yaml:"rack_id"`
+	Key                 string                    `json:"key" yaml:"key"`
+	Partitioner         string                    `json:"partitioner" yaml:"partitioner"`
+	Partition           string                    `json:"partition" yaml:"partition"`
+	Topic               string                    `json:"topic" yaml:"topic"`
+	CustomTopicCreation customTopicCreationConfig `json:"custom_topic_creation" yaml:"custom_topic_creation"`
+	Compression         string                    `json:"compression" yaml:"compression"`
+	MaxMsgBytes         int                       `json:"max_msg_bytes" yaml:"max_msg_bytes"`
+	Timeout             string                    `json:"timeout" yaml:"timeout"`
+	AckReplicas         bool                      `json:"ack_replicas" yaml:"ack_replicas"`
+	TargetVersion       string                    `json:"target_version" yaml:"target_version"`
+	TLS                 btls.Config               `json:"tls" yaml:"tls"`
+	SASL                sasl.Config               `json:"sasl" yaml:"sasl"`
+	MaxInFlight         int                       `json:"max_in_flight" yaml:"max_in_flight"`
+	retries.Config      `json:",inline" yaml:",inline"`
+	RetryAsBatch        bool                         `json:"retry_as_batch" yaml:"retry_as_batch"`
+	Batching            batchconfig.Config           `json:"batching" yaml:"batching"`
+	StaticHeaders       map[string]string            `json:"static_headers" yaml:"static_headers"`
+	Metadata            metadata.ExcludeFilterConfig `json:"metadata" yaml:"metadata"`
+	InjectTracingMap    string                       `json:"inject_tracing_map" yaml:"inject_tracing_map"`
+}
+
+type customTopicCreationConfig struct {
+	Enabled           bool `json:"enabled" yaml:"enabled"`
+	Partitions        int  `json:"partitions" yaml:"partitions"`
+	ReplicationFactor int  `json:"replication_factor" yaml:"replication_factor"`
 }
 
 // NewKafkaConfig creates a new KafkaConfig with default values.
@@ -43,27 +48,30 @@ func NewKafkaConfig() KafkaConfig {
 	rConf.Backoff.MaxElapsedTime = "30s"
 
 	return KafkaConfig{
-		Addresses:              []string{},
-		ClientID:               "benthos",
-		RackID:                 "",
-		Key:                    "",
-		Partitioner:            "fnv1a_hash",
-		Partition:              "",
-		Topic:                  "",
-		PartitionsPerNewTopic:  0,
-		TopicReplicationFactor: 1,
-		Compression:            "none",
-		MaxMsgBytes:            1000000,
-		Timeout:                "5s",
-		AckReplicas:            false,
-		TargetVersion:          "2.0.0",
-		StaticHeaders:          map[string]string{},
-		Metadata:               metadata.NewExcludeFilterConfig(),
-		TLS:                    btls.NewConfig(),
-		SASL:                   sasl.NewConfig(),
-		MaxInFlight:            64,
-		Config:                 rConf,
-		RetryAsBatch:           false,
-		Batching:               batchconfig.NewConfig(),
+		Addresses:   []string{},
+		ClientID:    "benthos",
+		RackID:      "",
+		Key:         "",
+		Partitioner: "fnv1a_hash",
+		Partition:   "",
+		Topic:       "",
+		CustomTopicCreation: customTopicCreationConfig{
+			Enabled:           false,
+			Partitions:        -1,
+			ReplicationFactor: -1,
+		},
+		Compression:   "none",
+		MaxMsgBytes:   1000000,
+		Timeout:       "5s",
+		AckReplicas:   false,
+		TargetVersion: "2.0.0",
+		StaticHeaders: map[string]string{},
+		Metadata:      metadata.NewExcludeFilterConfig(),
+		TLS:           btls.NewConfig(),
+		SASL:          sasl.NewConfig(),
+		MaxInFlight:   64,
+		Config:        rConf,
+		RetryAsBatch:  false,
+		Batching:      batchconfig.NewConfig(),
 	}
 }

--- a/internal/component/output/config_kafka.go
+++ b/internal/component/output/config_kafka.go
@@ -10,27 +10,29 @@ import (
 
 // KafkaConfig contains configuration fields for the Kafka output type.
 type KafkaConfig struct {
-	Addresses        []string    `json:"addresses" yaml:"addresses"`
-	ClientID         string      `json:"client_id" yaml:"client_id"`
-	RackID           string      `json:"rack_id" yaml:"rack_id"`
-	Key              string      `json:"key" yaml:"key"`
-	Partitioner      string      `json:"partitioner" yaml:"partitioner"`
-	Partition        string      `json:"partition" yaml:"partition"`
-	Topic            string      `json:"topic" yaml:"topic"`
-	Compression      string      `json:"compression" yaml:"compression"`
-	MaxMsgBytes      int         `json:"max_msg_bytes" yaml:"max_msg_bytes"`
-	Timeout          string      `json:"timeout" yaml:"timeout"`
-	AckReplicas      bool        `json:"ack_replicas" yaml:"ack_replicas"`
-	TargetVersion    string      `json:"target_version" yaml:"target_version"`
-	TLS              btls.Config `json:"tls" yaml:"tls"`
-	SASL             sasl.Config `json:"sasl" yaml:"sasl"`
-	MaxInFlight      int         `json:"max_in_flight" yaml:"max_in_flight"`
-	retries.Config   `json:",inline" yaml:",inline"`
-	RetryAsBatch     bool                         `json:"retry_as_batch" yaml:"retry_as_batch"`
-	Batching         batchconfig.Config           `json:"batching" yaml:"batching"`
-	StaticHeaders    map[string]string            `json:"static_headers" yaml:"static_headers"`
-	Metadata         metadata.ExcludeFilterConfig `json:"metadata" yaml:"metadata"`
-	InjectTracingMap string                       `json:"inject_tracing_map" yaml:"inject_tracing_map"`
+	Addresses              []string    `json:"addresses" yaml:"addresses"`
+	ClientID               string      `json:"client_id" yaml:"client_id"`
+	RackID                 string      `json:"rack_id" yaml:"rack_id"`
+	Key                    string      `json:"key" yaml:"key"`
+	Partitioner            string      `json:"partitioner" yaml:"partitioner"`
+	Partition              string      `json:"partition" yaml:"partition"`
+	Topic                  string      `json:"topic" yaml:"topic"`
+	PartitionsPerNewTopic  int         `json:"partitions_per_new_topic" yaml:"partitions_per_new_topic"`
+	TopicReplicationFactor int         `json:"topic_replication_factor" yaml:"topic_replication_factor"`
+	Compression            string      `json:"compression" yaml:"compression"`
+	MaxMsgBytes            int         `json:"max_msg_bytes" yaml:"max_msg_bytes"`
+	Timeout                string      `json:"timeout" yaml:"timeout"`
+	AckReplicas            bool        `json:"ack_replicas" yaml:"ack_replicas"`
+	TargetVersion          string      `json:"target_version" yaml:"target_version"`
+	TLS                    btls.Config `json:"tls" yaml:"tls"`
+	SASL                   sasl.Config `json:"sasl" yaml:"sasl"`
+	MaxInFlight            int         `json:"max_in_flight" yaml:"max_in_flight"`
+	retries.Config         `json:",inline" yaml:",inline"`
+	RetryAsBatch           bool                         `json:"retry_as_batch" yaml:"retry_as_batch"`
+	Batching               batchconfig.Config           `json:"batching" yaml:"batching"`
+	StaticHeaders          map[string]string            `json:"static_headers" yaml:"static_headers"`
+	Metadata               metadata.ExcludeFilterConfig `json:"metadata" yaml:"metadata"`
+	InjectTracingMap       string                       `json:"inject_tracing_map" yaml:"inject_tracing_map"`
 }
 
 // NewKafkaConfig creates a new KafkaConfig with default values.
@@ -41,25 +43,27 @@ func NewKafkaConfig() KafkaConfig {
 	rConf.Backoff.MaxElapsedTime = "30s"
 
 	return KafkaConfig{
-		Addresses:     []string{},
-		ClientID:      "benthos",
-		RackID:        "",
-		Key:           "",
-		Partitioner:   "fnv1a_hash",
-		Partition:     "",
-		Topic:         "",
-		Compression:   "none",
-		MaxMsgBytes:   1000000,
-		Timeout:       "5s",
-		AckReplicas:   false,
-		TargetVersion: "2.0.0",
-		StaticHeaders: map[string]string{},
-		Metadata:      metadata.NewExcludeFilterConfig(),
-		TLS:           btls.NewConfig(),
-		SASL:          sasl.NewConfig(),
-		MaxInFlight:   64,
-		Config:        rConf,
-		RetryAsBatch:  false,
-		Batching:      batchconfig.NewConfig(),
+		Addresses:              []string{},
+		ClientID:               "benthos",
+		RackID:                 "",
+		Key:                    "",
+		Partitioner:            "fnv1a_hash",
+		Partition:              "",
+		Topic:                  "",
+		PartitionsPerNewTopic:  0,
+		TopicReplicationFactor: 1,
+		Compression:            "none",
+		MaxMsgBytes:            1000000,
+		Timeout:                "5s",
+		AckReplicas:            false,
+		TargetVersion:          "2.0.0",
+		StaticHeaders:          map[string]string{},
+		Metadata:               metadata.NewExcludeFilterConfig(),
+		TLS:                    btls.NewConfig(),
+		SASL:                   sasl.NewConfig(),
+		MaxInFlight:            64,
+		Config:                 rConf,
+		RetryAsBatch:           false,
+		Batching:               batchconfig.NewConfig(),
 	}
 }

--- a/website/docs/components/outputs/kafka.md
+++ b/website/docs/components/outputs/kafka.md
@@ -76,6 +76,8 @@ output:
     key: ""
     partitioner: fnv1a_hash
     partition: ""
+    partitions_per_new_topic: 0
+    topic_replication_factor: 1
     compression: none
     static_headers: {}
     metadata:
@@ -436,6 +438,22 @@ This field supports [interpolation functions](/docs/configuration/interpolation#
 
 Type: `string`  
 Default: `""`  
+
+### `partitions_per_new_topic`
+
+If a topic is created and this value is greater than zero then this number of partitions will be used for the topic.
+
+
+Type: `int`  
+Default: `0`  
+
+### `topic_replication_factor`
+
+The replication factor for the newly created topics. If `partitions_per_new_topic` is greater than zero this field is required, otherwise is ignored
+
+
+Type: `int`  
+Default: `1`  
 
 ### `compression`
 

--- a/website/docs/components/outputs/kafka.md
+++ b/website/docs/components/outputs/kafka.md
@@ -76,8 +76,10 @@ output:
     key: ""
     partitioner: fnv1a_hash
     partition: ""
-    partitions_per_new_topic: 0
-    topic_replication_factor: 1
+    custom_topic_creation:
+      enabled: false
+      partitions: -1
+      replication_factor: -1
     compression: none
     static_headers: {}
     metadata:
@@ -439,21 +441,36 @@ This field supports [interpolation functions](/docs/configuration/interpolation#
 Type: `string`  
 Default: `""`  
 
-### `partitions_per_new_topic`
+### `custom_topic_creation`
 
-If a topic is created and this value is greater than zero then this number of partitions will be used for the topic.
+If enabled, topics will be created with the specified number of partitions and replication factor if they do not already exist.
+
+
+Type: `object`  
+
+### `custom_topic_creation.enabled`
+
+Whether to enable custom topic creation.
+
+
+Type: `bool`  
+Default: `false`  
+
+### `custom_topic_creation.partitions`
+
+The number of partitions to create for new topics. Must be greater than 1
 
 
 Type: `int`  
-Default: `0`  
+Default: `-1`  
 
-### `topic_replication_factor`
+### `custom_topic_creation.replication_factor`
 
-The replication factor for the newly created topics. If `partitions_per_new_topic` is greater than zero this field is required, otherwise is ignored
+The replication factor to use for new topics. Must be an odd number, and less then or equal to the number of brokers
 
 
 Type: `int`  
-Default: `1`  
+Default: `-1`  
 
 ### `compression`
 


### PR DESCRIPTION
This PR adds two new fields for the kafka output.
- `partitions_per_new_topic`: the number of partition to generate if the topic is not existing. This value overrides the default configuration of the kafka broker. If the value is `0` (set by default), it is ignored, and the topic will be created normally.
- `topic_replication_factor`: the replication factor to assign to the topic. This value overrides the default configuration of the kafka broker. If `partitions_per_new_topic` is set to `0`, it is ignored. Must be an odd number (`1` by default)

I am not sure if and how I should update the integration tests. In case, let me know and I'll update the PR.

Closes #2088 