### PR TITLE
Add skip BOM for CSV Reader

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -36,6 +36,7 @@ require (
 	github.com/couchbase/gocb/v2 v2.6.3
 	github.com/denisenkom/go-mssqldb v0.12.3
 	github.com/dgraph-io/ristretto v0.1.1
+	github.com/dimchansky/utfbom v1.1.1
 	github.com/dop251/goja v0.0.0-20220815083517-0c74f9139fd6
 	github.com/dop251/goja_nodejs v0.0.0-20220808115320-bac29516aae9
 	github.com/dustin/go-humanize v1.0.1

--- a/go.sum
+++ b/go.sum
@@ -313,6 +313,8 @@ github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2 h1:tdlZCpZ/P9DhczC
 github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2/go.mod h1:SqUrOPUnsFjfmXRMNPybcSiG0BgUW2AuFH8PAnS2iTw=
 github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f h1:lO4WD4F/rVNCu3HqELle0jiPLLBs70cWOduZpkS1E78=
 github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f/go.mod h1:cuUVRXasLTGF7a8hSLbxyZXjz+1KgoB3wDUb6vlszIc=
+github.com/dimchansky/utfbom v1.1.1 h1:vV6w1AhK4VMnhBno/TPVCoK9U/LP0PkLCS9tbxHdi/U=
+github.com/dimchansky/utfbom v1.1.1/go.mod h1:SxdoEBH5qIqFocHMyGOXVAybYJdr71b1Q/j0mACtrfE=
 github.com/dimfeld/httptreemux v5.0.1+incompatible h1:Qj3gVcDNoOthBAqftuD596rm4wg/adLLz5xh5CmpiCA=
 github.com/dimfeld/httptreemux v5.0.1+incompatible/go.mod h1:rbUlSV+CCpv/SuqUTP/8Bk2O3LyUV436/yaRGkhP6Z0=
 github.com/dlclark/regexp2 v1.4.1-0.20201116162257-a2a8dda75c91/go.mod h1:2pZnwuY/m+8K6iRw6wQdMtk+rH5tNGR1i55kozfMjCc=

--- a/internal/codec/reader.go
+++ b/internal/codec/reader.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/dimchansky/utfbom"
 	"github.com/klauspost/compress/gzip"
 	"github.com/klauspost/pgzip"
 
@@ -624,7 +625,10 @@ type csvReader struct {
 }
 
 func newCSVReader(r io.ReadCloser, ackFn ReaderAckFn, customComma *rune) (Reader, error) {
-	scanner := csv.NewReader(r)
+	// Skip BOM if present and return a new Reader
+	sr := utfbom.SkipOnly(r)
+
+	scanner := csv.NewReader(sr)
 	scanner.ReuseRecord = true
 	if customComma != nil {
 		scanner.Comma = *customComma

--- a/internal/impl/io/input_csv.go
+++ b/internal/impl/io/input_csv.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/benthosdev/benthos/v4/internal/filepath"
 	"github.com/benthosdev/benthos/v4/public/service"
+	"github.com/dimchansky/utfbom"
 )
 
 var (
@@ -368,7 +369,10 @@ func (r *csvReader) Connect(ctx context.Context) error {
 		return err
 	}
 
-	scanner := csv.NewReader(scannerInfo.handle)
+	// Skip BOM if present and return a new Reader
+	sr := utfbom.SkipOnly(scannerInfo.handle)
+
+	scanner := csv.NewReader(sr)
 	scanner.LazyQuotes = r.lazyQuotes
 	scanner.Comma = r.comma
 	scanner.ReuseRecord = true


### PR DESCRIPTION
Files exported from Excel, and probably other tools, add Byte Order Mark (BOM) at the beginning of the CSV file.

I've used library https://github.com/dimchansky/utfbom to detect such mark and remove, otherwise first header will include the mark, which is not printable, and will not be possible to access the value.