### PR TITLE
Add MetadataFilter field for NATS outputs

### DIFF
--- a/internal/impl/nats/output_jetstream.go
+++ b/internal/impl/nats/output_jetstream.go
@@ -36,6 +36,9 @@ func natsJetStreamOutputConfig() *service.ConfigSpec {
 				"Content-Type": "application/json",
 				"Timestamp":    `${!meta("Timestamp")}`,
 			}).Version("4.1.0")).
+		Field(service.NewMetadataFilterField("metadata").
+			Description("Determine which (if any) metadata values should be added to messages as headers.").
+			Optional()).
 		Field(service.NewIntField("max_in_flight").
 			Description("The maximum number of messages to have in flight at a given time. Increase this to improve throughput.").
 			Default(1024)).
@@ -67,6 +70,7 @@ type jetStreamOutput struct {
 	subjectStrRaw string
 	subjectStr    *service.InterpolatedString
 	headers       map[string]*service.InterpolatedString
+	metaFilter    *service.MetadataFilter
 	authConf      auth.Config
 	tlsConf       *tls.Config
 
@@ -104,6 +108,12 @@ func newJetStreamWriterFromConfig(conf *service.ParsedConfig, mgr *service.Resou
 
 	if j.headers, err = conf.FieldInterpolatedStringMap("headers"); err != nil {
 		return nil, err
+	}
+
+	if conf.Contains("metadata") {
+		if j.metaFilter, err = conf.FieldMetadataFilter("metadata"); err != nil {
+			return nil, err
+		}
 	}
 
 	tlsConf, tlsEnabled, err := conf.FieldTLSToggled("tls")
@@ -192,6 +202,10 @@ func (j *jetStreamOutput) Write(ctx context.Context, msg *service.Message) error
 	for k, v := range j.headers {
 		jsmsg.Header.Add(k, v.String(msg))
 	}
+	_ = j.metaFilter.Walk(msg, func(key, value string) error {
+		jsmsg.Header.Add(key, value)
+		return nil
+	})
 
 	_, err = jCtx.PublishMsg(jsmsg)
 	return err

--- a/website/docs/components/outputs/nats.md
+++ b/website/docs/components/outputs/nats.md
@@ -32,6 +32,9 @@ output:
     urls: [] # No default (required)
     subject: foo.bar.baz # No default (required)
     headers: {}
+    metadata:
+      include_prefixes: []
+      include_patterns: []
     max_in_flight: 64
 ```
 
@@ -46,6 +49,9 @@ output:
     urls: [] # No default (required)
     subject: foo.bar.baz # No default (required)
     headers: {}
+    metadata:
+      include_prefixes: []
+      include_patterns: []
     max_in_flight: 64
     tls:
       enabled: false
@@ -152,6 +158,53 @@ Default: `{}`
 headers:
   Content-Type: application/json
   Timestamp: ${!meta("Timestamp")}
+```
+
+### `metadata`
+
+Determine which (if any) metadata values should be added to messages as headers.
+
+
+Type: `object`  
+
+### `metadata.include_prefixes`
+
+Provide a list of explicit metadata key prefixes to match against.
+
+
+Type: `array`  
+Default: `[]`  
+
+```yml
+# Examples
+
+include_prefixes:
+  - foo_
+  - bar_
+
+include_prefixes:
+  - kafka_
+
+include_prefixes:
+  - content-
+```
+
+### `metadata.include_patterns`
+
+Provide a list of explicit metadata key regular expression (re2) patterns to match against.
+
+
+Type: `array`  
+Default: `[]`  
+
+```yml
+# Examples
+
+include_patterns:
+  - .*
+
+include_patterns:
+  - _timestamp_unix$
 ```
 
 ### `max_in_flight`

--- a/website/docs/components/outputs/nats_jetstream.md
+++ b/website/docs/components/outputs/nats_jetstream.md
@@ -34,6 +34,9 @@ output:
     urls: [] # No default (required)
     subject: foo.bar.baz # No default (required)
     headers: {}
+    metadata:
+      include_prefixes: []
+      include_patterns: []
     max_in_flight: 1024
 ```
 
@@ -48,6 +51,9 @@ output:
     urls: [] # No default (required)
     subject: foo.bar.baz # No default (required)
     headers: {}
+    metadata:
+      include_prefixes: []
+      include_patterns: []
     max_in_flight: 1024
     tls:
       enabled: false
@@ -157,6 +163,53 @@ Requires version 4.1.0 or newer
 headers:
   Content-Type: application/json
   Timestamp: ${!meta("Timestamp")}
+```
+
+### `metadata`
+
+Determine which (if any) metadata values should be added to messages as headers.
+
+
+Type: `object`  
+
+### `metadata.include_prefixes`
+
+Provide a list of explicit metadata key prefixes to match against.
+
+
+Type: `array`  
+Default: `[]`  
+
+```yml
+# Examples
+
+include_prefixes:
+  - foo_
+  - bar_
+
+include_prefixes:
+  - kafka_
+
+include_prefixes:
+  - content-
+```
+
+### `metadata.include_patterns`
+
+Provide a list of explicit metadata key regular expression (re2) patterns to match against.
+
+
+Type: `array`  
+Default: `[]`  
+
+```yml
+# Examples
+
+include_patterns:
+  - .*
+
+include_patterns:
+  - _timestamp_unix$
 ```
 
 ### `max_in_flight`


### PR DESCRIPTION
## Motivation
NATS supports metadata in the form of Headers (in some configurations, [JetStream](https://docs.nats.io/nats-concepts/jetstream/headers) and [classic](https://docs.nats.io/release-notes/whats_new/whats_new_22#message-headers) since 2.2.0 ).
Benthos currently supports a `headers` object that can add explicit, interpolated headers. 

In this PR I'm adding functionality that allows passing through any `meta()` headers, using the MetadataFilter functionality that's built-in to Benthos (similar to Kafka outputs). 

Most of the heavylifting is already done by the platform so the changes are minimal. 

NOTE: This doesn't change the semantics of the existing configurations, since by default we still don't pass anything (thus it is backwards compatible). A user is required to explicitly add any headers they want, or use a catch-all regular expression:
```    
metadata:
  include_patterns: 
    - ".*"
```