### PR TITLE
Add log line with Benthos version

### DIFF
--- a/internal/cli/common/service.go
+++ b/internal/cli/common/service.go
@@ -38,6 +38,8 @@ func RunService(c *cli.Context, version, dateBuilt string, streamsMode bool) int
 		return 1
 	}
 
+	logger.Infof("Benthos version: %s", version)
+
 	if mainPath == "" {
 		logger.Infof("Running without a main config file")
 	} else if inferredMainPath {

--- a/internal/cli/common/service.go
+++ b/internal/cli/common/service.go
@@ -44,7 +44,7 @@ func RunService(c *cli.Context, version, dateBuilt string, streamsMode bool) int
 	} else if inferredMainPath {
 		verLogger.With("path", mainPath).Infof("Running main config from file found in a default path")
 	} else {
-		verLogger.With("path", mainPath).With("path", mainPath).Infof("Running main config from specified file")
+		verLogger.With("path", mainPath).Infof("Running main config from specified file")
 	}
 
 	strict := !c.Bool("chilled")

--- a/internal/cli/common/service.go
+++ b/internal/cli/common/service.go
@@ -38,14 +38,13 @@ func RunService(c *cli.Context, version, dateBuilt string, streamsMode bool) int
 		return 1
 	}
 
-	logger.Infof("Benthos version: %s", version)
-
+	verLogger := logger.With("version", version)
 	if mainPath == "" {
-		logger.Infof("Running without a main config file")
+		verLogger.Infof("Running without a main config file")
 	} else if inferredMainPath {
-		logger.With("path", mainPath).Infof("Running main config from file found in a default path")
+		verLogger.With("path", mainPath).Infof("Running main config from file found in a default path")
 	} else {
-		logger.With("path", mainPath).Infof("Running main config from specified file")
+		verLogger.With("path", mainPath).With("path", mainPath).Infof("Running main config from specified file")
 	}
 
 	strict := !c.Bool("chilled")


### PR DESCRIPTION
Adds a standard log output on startup identifying Benthos version.

On untagged builds, this displays the commit hash; otherwise, the tag is shown.