### PR TITLE
Allow redundant urls for amqp 1

### DIFF
--- a/internal/impl/amqp1/config.go
+++ b/internal/impl/amqp1/config.go
@@ -11,6 +11,7 @@ import (
 const (
 	// Shared
 	urlField      = "url"
+	urlsField     = "urls"
 	tlsField      = "tls"
 	saslField     = "sasl"
 	saslMechField = "mechanism"

--- a/internal/impl/amqp1/input.go
+++ b/internal/impl/amqp1/input.go
@@ -38,7 +38,15 @@ You can access these metadata fields using [function interpolation](/docs/config
 			service.NewURLField(urlField).
 				Description("A URL to connect to.").
 				Example("amqp://localhost:5672/").
-				Example("amqps://guest:guest@localhost:5672/"),
+				Example("amqps://guest:guest@localhost:5672/").
+				Optional(),
+			service.NewURLListField(urlsField).
+				Description("A list of URLs to connect to. The first URL to successfully establish a connection will be used until the connection is closed. If an item of the list contains commas it will be expanded into multiple URLs.").
+				Example([]string{"amqp://guest:guest@127.0.0.1:5672/"}).
+				Example([]string{"amqp://127.0.0.1:5672/,amqp://127.0.0.2:5672/"}).
+				Example([]string{"amqp://127.0.0.1:5672/", "amqp://127.0.0.2:5672/"}).
+				Optional().
+				Version("T.B.D"),
 			service.NewStringField(sourceAddrField).
 				Description("The source address to consume from.").
 				Example("/foo").
@@ -67,7 +75,7 @@ func init() {
 //------------------------------------------------------------------------------
 
 type amqp1Reader struct {
-	url        string
+	urls       []string
 	sourceAddr string
 	renewLock  bool
 	connOpts   *amqp.ConnOptions
@@ -83,9 +91,25 @@ func amqp1ReaderFromParsed(conf *service.ParsedConfig, mgr *service.Resources) (
 		connOpts: &amqp.ConnOptions{},
 	}
 
-	var err error
-	if a.url, err = conf.FieldString(urlField); err != nil {
+	urlStrs, err := conf.FieldStringList(urlsField)
+	if err != nil {
 		return nil, err
+	}
+
+	for _, u := range urlStrs {
+		for _, splitURL := range strings.Split(u, ",") {
+			if trimmed := strings.TrimSpace(splitURL); len(trimmed) > 0 {
+				a.urls = append(a.urls, trimmed)
+			}
+		}
+	}
+
+	if singleURL, _ := conf.FieldString(urlField); singleURL != "" {
+		a.urls = append(a.urls, singleURL)
+	}
+
+	if len(a.urls) == 0 {
+		return nil, errors.New("must specify at least one URL")
 	}
 
 	if a.sourceAddr, err = conf.FieldString(sourceAddrField); err != nil {
@@ -125,8 +149,8 @@ func (a *amqp1Reader) Connect(ctx context.Context) (err error) {
 	}
 
 	// Create client
-	if conn.client, err = amqp.Dial(ctx, a.url, a.connOpts); err != nil {
-		return
+	if conn.client, err = a.reDial(ctx, a.urls); err != nil {
+		return err
 	}
 
 	// Open a session
@@ -247,6 +271,26 @@ func (a *amqp1Reader) ReadBatch(ctx context.Context) (service.MessageBatch, serv
 
 func (a *amqp1Reader) Close(ctx context.Context) error {
 	return a.disconnect(ctx)
+}
+
+// reDial connection to amqp with one or more fallback URLs.
+func (a *amqp1Reader) reDial(ctx context.Context, urls []string) (conn *amqp.Conn, err error) {
+	for i, url := range urls {
+		conn, err = amqp.Dial(ctx, url, a.connOpts)
+		if err != nil {
+			a.log.With("error", err).Warnf("unable to connect to url %q #%d, trying next", url, i)
+
+			continue
+		}
+
+		a.log.Tracef("successful connection to use %q #%d", url, i)
+
+		return conn, nil
+	}
+
+	a.log.With("error", err).Tracef("unable to connect to any of %d urls, return error", len(a.urls))
+
+	return nil, err
 }
 
 //------------------------------------------------------------------------------

--- a/internal/impl/amqp1/input.go
+++ b/internal/impl/amqp1/input.go
@@ -104,12 +104,14 @@ func amqp1ReaderFromParsed(conf *service.ParsedConfig, mgr *service.Resources) (
 		}
 	}
 
-	if singleURL, _ := conf.FieldString(urlField); singleURL != "" {
-		a.urls = append(a.urls, singleURL)
-	}
-
 	if len(a.urls) == 0 {
-		return nil, errors.New("must specify at least one URL")
+		singleURL, err := conf.FieldString(urlField)
+		if err != nil {
+			return nil, err
+		}
+
+		a.urls = append(a.urls, singleURL)
+
 	}
 
 	if a.sourceAddr, err = conf.FieldString(sourceAddrField); err != nil {

--- a/internal/impl/amqp1/output.go
+++ b/internal/impl/amqp1/output.go
@@ -2,7 +2,6 @@ package amqp1
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"strings"
 	"sync"
@@ -111,12 +110,13 @@ func amqp1WriterFromParsed(conf *service.ParsedConfig, mgr *service.Resources) (
 		}
 	}
 
-	if singleURL, _ := conf.FieldString(urlField); singleURL != "" {
-		a.urls = append(a.urls, singleURL)
-	}
-
 	if len(a.urls) == 0 {
-		return nil, errors.New("must specify at least one URL")
+		singleURL, err := conf.FieldString(urlField)
+		if err != nil {
+			return nil, err
+		}
+
+		a.urls = []string{singleURL}
 	}
 
 	if a.targetAddr, err = conf.FieldString(targetAddrField); err != nil {

--- a/internal/impl/amqp1/output.go
+++ b/internal/impl/amqp1/output.go
@@ -2,7 +2,9 @@ package amqp1
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"strings"
 	"sync"
 
 	"github.com/Azure/go-amqp"
@@ -29,7 +31,15 @@ This output benefits from sending multiple messages in flight in parallel for im
 			service.NewURLField(urlField).
 				Description("A URL to connect to.").
 				Example("amqp://localhost:5672/").
-				Example("amqps://guest:guest@localhost:5672/"),
+				Example("amqps://guest:guest@localhost:5672/").
+				Optional(),
+			service.NewURLListField(urlsField).
+				Description("A list of URLs to connect to. The first URL to successfully establish a connection will be used until the connection is closed. If an item of the list contains commas it will be expanded into multiple URLs.").
+				Example([]string{"amqp://guest:guest@127.0.0.1:5672/"}).
+				Example([]string{"amqp://127.0.0.1:5672/,amqp://127.0.0.2:5672/"}).
+				Example([]string{"amqp://127.0.0.1:5672/", "amqp://127.0.0.2:5672/"}).
+				Optional().
+				Version("T.B.D"),
 			service.NewStringField(targetAddrField).
 				Description("The target address to write to.").
 				Example("/foo").
@@ -72,7 +82,7 @@ type amqp1Writer struct {
 	session *amqp.Session
 	sender  *amqp.Sender
 
-	url                      string
+	urls                     []string
 	targetAddr               string
 	metaFilter               *service.MetadataExcludeFilter
 	applicationPropertiesMap *bloblang.Executor
@@ -88,9 +98,25 @@ func amqp1WriterFromParsed(conf *service.ParsedConfig, mgr *service.Resources) (
 		connOpts: &amqp.ConnOptions{},
 	}
 
-	var err error
-	if a.url, err = conf.FieldString(urlField); err != nil {
+	urlStrs, err := conf.FieldStringList(urlsField)
+	if err != nil {
 		return nil, err
+	}
+
+	for _, u := range urlStrs {
+		for _, splitURL := range strings.Split(u, ",") {
+			if trimmed := strings.TrimSpace(splitURL); len(trimmed) > 0 {
+				a.urls = append(a.urls, trimmed)
+			}
+		}
+	}
+
+	if singleURL, _ := conf.FieldString(urlField); singleURL != "" {
+		a.urls = append(a.urls, singleURL)
+	}
+
+	if len(a.urls) == 0 {
+		return nil, errors.New("must specify at least one URL")
 	}
 
 	if a.targetAddr, err = conf.FieldString(targetAddrField); err != nil {
@@ -136,8 +162,8 @@ func (a *amqp1Writer) Connect(ctx context.Context) (err error) {
 	)
 
 	// Create client
-	if client, err = amqp.Dial(ctx, a.url, a.connOpts); err != nil {
-		return
+	if client, err = a.reDial(ctx, a.urls); err != nil {
+		return err
 	}
 
 	// Open a session
@@ -250,4 +276,24 @@ func (a *amqp1Writer) Write(ctx context.Context, msg *service.Message) error {
 
 func (a *amqp1Writer) Close(ctx context.Context) error {
 	return a.disconnect(ctx)
+}
+
+// reDial connection to amqp with one or more fallback URLs.
+func (a *amqp1Writer) reDial(ctx context.Context, urls []string) (conn *amqp.Conn, err error) {
+	for i, url := range urls {
+		conn, err = amqp.Dial(ctx, url, a.connOpts)
+		if err != nil {
+			a.log.With("error", err).Warnf("unable to connect to url %q #%d, trying next", url, i)
+
+			continue
+		}
+
+		a.log.Tracef("successful connection to use %q #%d", url, i)
+
+		return conn, nil
+	}
+
+	a.log.With("error", err).Tracef("unable to connect to any of %d urls, return error", len(a.urls))
+
+	return nil, err
 }

--- a/website/docs/components/inputs/amqp_1.md
+++ b/website/docs/components/inputs/amqp_1.md
@@ -29,7 +29,8 @@ Reads messages from an AMQP (1.0) server.
 input:
   label: ""
   amqp_1:
-    url: amqp://localhost:5672/ # No default (required)
+    url: amqp://localhost:5672/ # No default (optional)
+    urls: [] # No default (optional)
     source_address: /foo # No default (required)
 ```
 
@@ -41,7 +42,8 @@ input:
 input:
   label: ""
   amqp_1:
-    url: amqp://localhost:5672/ # No default (required)
+    url: amqp://localhost:5672/ # No default (optional)
+    urls: [] # No default (optional)
     source_address: /foo # No default (required)
     azure_renew_lock: false
     tls:
@@ -88,6 +90,28 @@ Type: `string`
 url: amqp://localhost:5672/
 
 url: amqps://guest:guest@localhost:5672/
+```
+
+### `urls`
+
+A list of URLs to connect to. The first URL to successfully establish a connection will be used until the connection is closed. If an item of the list contains commas it will be expanded into multiple URLs.
+
+
+Type: `array`  
+Requires version T.B.D or newer  
+
+```yml
+# Examples
+
+urls:
+  - amqp://guest:guest@127.0.0.1:5672/
+
+urls:
+  - amqp://127.0.0.1:5672/,amqp://127.0.0.2:5672/
+
+urls:
+  - amqp://127.0.0.1:5672/
+  - amqp://127.0.0.2:5672/
 ```
 
 ### `source_address`

--- a/website/docs/components/outputs/amqp_1.md
+++ b/website/docs/components/outputs/amqp_1.md
@@ -29,7 +29,8 @@ Sends messages to an AMQP (1.0) server.
 output:
   label: ""
   amqp_1:
-    url: amqp://localhost:5672/ # No default (required)
+    url: amqp://localhost:5672/ # No default (optional)
+    urls: [] # No default (optional)
     target_address: /foo # No default (required)
     max_in_flight: 64
     metadata:
@@ -44,7 +45,8 @@ output:
 output:
   label: ""
   amqp_1:
-    url: amqp://localhost:5672/ # No default (required)
+    url: amqp://localhost:5672/ # No default (optional)
+    urls: [] # No default (optional)
     target_address: /foo # No default (required)
     max_in_flight: 64
     tls:
@@ -89,6 +91,28 @@ Type: `string`
 url: amqp://localhost:5672/
 
 url: amqps://guest:guest@localhost:5672/
+```
+
+### `urls`
+
+A list of URLs to connect to. The first URL to successfully establish a connection will be used until the connection is closed. If an item of the list contains commas it will be expanded into multiple URLs.
+
+
+Type: `array`  
+Requires version T.B.D or newer  
+
+```yml
+# Examples
+
+urls:
+  - amqp://guest:guest@127.0.0.1:5672/
+
+urls:
+  - amqp://127.0.0.1:5672/,amqp://127.0.0.2:5672/
+
+urls:
+  - amqp://127.0.0.1:5672/
+  - amqp://127.0.0.2:5672/
 ```
 
 ### `target_address`


### PR DESCRIPTION
This should fix #2106 

to be backward compatible, both fields `url` and `urls` will co-exist for some time,

by default we will parse `urls` and if it is empty we will try to use field `url` as fallback.

IMPORTANT: we need to fill the field Version with the right value instead the placeholder T.B.D (to be defined) and regenerate docs before release a new version.

enjoy