### PR TITLE
fix(cue): allow labels on caches and rate limits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ All notable changes to this project will be documented in this file.
 - The `amqp_0_9` output now supports dynamic interpolation functions within the `exchange` field.
 - Field `custom_topic_creation` added to the `kafka` output.
 
+### Fixed
+
+- Allow labels on caches and rate limit resources when writing configs in CUE
+
 ## 4.22.0 - 2023-10-03
 
 ### Added

--- a/internal/cuegen/schema.go
+++ b/internal/cuegen/schema.go
@@ -71,6 +71,7 @@ func GenerateSchema(sch schema.Full) ([]byte, error) {
 		&componentOptions{
 			collectionIdent:  identCacheCollection,
 			disjunctionIdent: identCacheDisjunction,
+			canLabel:         true,
 		},
 	)
 	if err != nil {
@@ -83,6 +84,7 @@ func GenerateSchema(sch schema.Full) ([]byte, error) {
 		&componentOptions{
 			collectionIdent:  identRateLimitCollection,
 			disjunctionIdent: identRateLimitDisjunction,
+			canLabel:         true,
 		},
 	)
 	if err != nil {


### PR DESCRIPTION
This change fixes the CUE schema emitted by `benthos list --format cue` such that cache and rate-limit resources can take a `label` config. This is necessary so that these resources are addressable in configs.