### PR TITLE
Fix string formatting when setting custom slog logger

### DIFF
--- a/internal/log/slog.go
+++ b/internal/log/slog.go
@@ -1,6 +1,7 @@
 package log
 
 import (
+	"fmt"
 	"os"
 
 	"log/slog"
@@ -32,28 +33,28 @@ func (l *logHandler) With(keyValues ...any) Modular {
 }
 
 func (l *logHandler) Fatalf(format string, v ...any) {
-	l.slog.Error(format, v...)
+	l.slog.Error(fmt.Sprintf(format, v...))
 	os.Exit(1)
 }
 
 func (l *logHandler) Errorf(format string, v ...any) {
-	l.slog.Error(format, v...)
+	l.slog.Error(fmt.Sprintf(format, v...))
 }
 
 func (l *logHandler) Warnf(format string, v ...any) {
-	l.slog.Warn(format, v...)
+	l.slog.Warn(fmt.Sprintf(format, v...))
 }
 
 func (l *logHandler) Infof(format string, v ...any) {
-	l.slog.Info(format, v...)
+	l.slog.Info(fmt.Sprintf(format, v...))
 }
 
 func (l *logHandler) Debugf(format string, v ...any) {
-	l.slog.Debug(format, v...)
+	l.slog.Debug(fmt.Sprintf(format, v...))
 }
 
 func (l *logHandler) Tracef(format string, v ...any) {
-	l.slog.Debug(format, v...)
+	l.slog.Debug(fmt.Sprintf(format, v...))
 }
 
 func (l *logHandler) Fatalln(message string) {

--- a/internal/log/slog_test.go
+++ b/internal/log/slog_test.go
@@ -64,3 +64,20 @@ func TestSlogToBenthosLoggerAdapterMapKV(t *testing.T) {
 		assert.Contains(t, bufStr, exp)
 	}
 }
+
+func TestSlogMessageFormatting(t *testing.T) {
+	var buf bytes.Buffer
+	h := slog.NewTextHandler(&buf, &slog.HandlerOptions{ReplaceAttr: clearTimeAttr, Level: slog.LevelDebug})
+	s := slog.New(h)
+
+	var logger Modular = NewBenthosLogAdapter(s)
+	require.NotNil(t, logger)
+
+	logger.Debugf("Hello %s %d", "World", 1)
+	logger.Infof("Hello %s %d", "World", 2)
+	logger.Warnf("Hello %s %d", "World", 3)
+	logger.Errorf("Hello %s %d", "World", 4)
+
+	expected := "time=\"\" level=DEBUG msg=\"Hello World 1\"\ntime=\"\" level=INFO msg=\"Hello World 2\"\ntime=\"\" level=WARN msg=\"Hello World 3\"\ntime=\"\" level=ERROR msg=\"Hello World 4\"\n"
+	assert.Equal(t, expected, buf.String())
+}


### PR DESCRIPTION
Currently when using the `Modular` logging interface to format strings you get the following output:

```golang
func TestSlogMessageFormattingTest(t *testing.T) {
	var buf bytes.Buffer
	h := slog.NewTextHandler(&buf, &slog.HandlerOptions{ReplaceAttr: clearTimeAttr, Level: slog.LevelDebug})
	s := slog.New(h)

	var logger Modular = NewBenthosLogAdapter(s)
	logger.Warnf("Hello %s", "World")

	expected := "time=\"\" level=WARN msg=\"Hello %s\" !BADKEY=World\n"
	assert.Equal(t, expected, buf.String())
}
```

This change fixes that and instead returns the expected log line:

```
"time=\"\" level=WARN msg=\"Hello World\"\n"
```