### PR TITLE
Revert back to sarama 1.40.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/Azure/go-amqp v1.0.2
 	github.com/ClickHouse/clickhouse-go/v2 v2.14.3
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/trace v1.20.0
-	github.com/IBM/sarama v1.41.3
+	github.com/IBM/sarama v1.40.1
 	github.com/Jeffail/gabs/v2 v2.7.0
 	github.com/Jeffail/grok v1.1.0
 	github.com/Masterminds/squirrel v1.5.4

--- a/go.sum
+++ b/go.sum
@@ -93,8 +93,8 @@ github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/trace v1.20.
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/cloudmock v0.44.0 h1:ew7SfeajMJ3I4iXA1LERYY62fGCKO4TjVPw5QTPt47k=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.44.0 h1:GjWPDY9PUlNWwTI95L/lktUp35BLtzBoBElH314eafM=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.44.0/go.mod h1:qkFPtMouQjW5ugdHIOthiTbweVHUTqbS0Qsu55KqXks=
-github.com/IBM/sarama v1.41.3 h1:MWBEJ12vHC8coMjdEXFq/6ftO6DUZnQlFYcxtOJFa7c=
-github.com/IBM/sarama v1.41.3/go.mod h1:Xxho9HkHd4K/MDUo/T/sOqwtX/17D33++E9Wib6hUdQ=
+github.com/IBM/sarama v1.40.1 h1:lL01NNg/iBeigUbT+wpPysuTYW6roHo6kc1QrffRf0k=
+github.com/IBM/sarama v1.40.1/go.mod h1:+5OFwA5Du9I6QrznhaMHsuwWdWZNMjaBSIxEWEgKOYE=
 github.com/Jeffail/gabs/v2 v2.7.0 h1:Y2edYaTcE8ZpRsR2AtmPu5xQdFDIthFG0jYhu5PY8kg=
 github.com/Jeffail/gabs/v2 v2.7.0/go.mod h1:dp5ocw1FvBBQYssgHsG7I1WYsiLRtkUaB1FEtSwvNUw=
 github.com/Jeffail/grok v1.1.0 h1:kiHmZ+0J5w/XUihRgU3DY9WIxKrNQCDjnfAb6bMLFaE=
@@ -119,6 +119,7 @@ github.com/PaesslerAG/gval v1.2.2/go.mod h1:XRFLwvmkTEdYziLdaCeCa5ImcGVrfQbeNUbV
 github.com/PaesslerAG/jsonpath v0.1.0/go.mod h1:4BzmtoM/PI8fPO4aQGIusjGxGir2BzcV0grWtFzq1Y8=
 github.com/PaesslerAG/jsonpath v0.1.1 h1:c1/AToHQMVsduPAa4Vh6xp2U0evy4t8SWp8imEsylIk=
 github.com/PaesslerAG/jsonpath v0.1.1/go.mod h1:lVboNxFGal/VwW6d9JzIy56bUsYAP6tH/x80vjnCseY=
+github.com/Shopify/toxiproxy/v2 v2.5.0 h1:i4LPT+qrSlKNtQf5QliVjdP08GyAH8+BUIc9gT0eahc=
 github.com/ajstarks/svgo v0.0.0-20180226025133-644b8db467af/go.mod h1:K08gAheRH3/J6wwsYMMT4xOr94bZjxIelGM0+d/wbFw=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=

--- a/website/docs/components/inputs/kafka.md
+++ b/website/docs/components/inputs/kafka.md
@@ -31,7 +31,7 @@ input:
   kafka:
     addresses: [] # No default (required)
     topics: [] # No default (required)
-    target_version: 2.1.0 # No default (optional)
+    target_version: 1.0.0 # No default (optional)
     consumer_group: ""
     checkpoint_limit: 1024
 ```
@@ -46,7 +46,7 @@ input:
   kafka:
     addresses: [] # No default (required)
     topics: [] # No default (required)
-    target_version: 2.1.0 # No default (optional)
+    target_version: 1.0.0 # No default (optional)
     tls:
       enabled: false
       skip_cert_verify: false
@@ -186,7 +186,7 @@ Type: `string`
 ```yml
 # Examples
 
-target_version: 2.1.0
+target_version: 1.0.0
 
 target_version: 3.1.0
 ```

--- a/website/docs/components/outputs/kafka.md
+++ b/website/docs/components/outputs/kafka.md
@@ -31,7 +31,7 @@ output:
   kafka:
     addresses: [] # No default (required)
     topic: "" # No default (required)
-    target_version: 2.1.0 # No default (optional)
+    target_version: 1.0.0 # No default (optional)
     key: ""
     partitioner: fnv1a_hash
     compression: none
@@ -71,7 +71,7 @@ output:
       token_key: ""
     topic: "" # No default (required)
     client_id: benthos
-    target_version: 2.1.0 # No default (optional)
+    target_version: 1.0.0 # No default (optional)
     rack_id: ""
     key: ""
     partitioner: fnv1a_hash
@@ -406,7 +406,7 @@ Type: `string`
 ```yml
 # Examples
 
-target_version: 2.1.0
+target_version: 1.0.0
 
 target_version: 3.1.0
 ```


### PR DESCRIPTION
Considering the new version (1.41.0+) of sarama is breaking Kafka 1.0.0/EventHubs consumers, this PR reverts back to sarama 1.40.1.

https://github.com/benthosdev/benthos/issues/2176