### PR TITLE
Fix MySQL driver select float32

### DIFF
--- a/internal/bloblang/query/type_helpers.go
+++ b/internal/bloblang/query/type_helpers.go
@@ -56,7 +56,7 @@ func ITypeOf(i any) ValueType {
 		return ValueString
 	case []byte:
 		return ValueBytes
-	case int, int8, int16, int32, int64, uint8, uint16, uint32, uint64, float64, json.Number:
+	case int, int8, int16, int32, int64, uint8, uint16, uint32, uint64, float32, float64, json.Number:
 		return ValueNumber
 	case bool:
 		return ValueBool


### PR DESCRIPTION
Currently, the underlying type is `float32` which isn't handled correctly by bloblang.

Note: I don't think this is the right fix, or if it is, then it's probably incomplete. Both `sqlRowsToArray` and `sqlRowToMap` from https://github.com/benthosdev/benthos/blob/9820711f2832637581996469fe64367c1bd5e583/internal/impl/sql/util.go may return data as `float32`. However, [`ITypeOf()`](https://github.com/benthosdev/benthos/blob/9820711f2832637581996469fe64367c1bd5e583/internal/bloblang/query/type_helpers.go#L53C6-L53C13) doesn't currently support `float32`. While my small change does fix the issue in this case, I'm not sure if this is the correct fix. I also saw there's [`ISanitize()`](https://github.com/benthosdev/benthos/blob/9820711f2832637581996469fe64367c1bd5e583/internal/bloblang/query/type_helpers.go#L330C6-L330C15) which can convert multiple types to something that `ITypeOf` does support, but it's not called on every code path and I'm not sure if maybe it should get called in `sqlRowsToArray` and `sqlRowToMap` and in other places. I do, however, see that `IGetNumber()`, `IGetBool()` and some of the other helpers (but not all!) do have a case for `float32`, so maybe the right thing to do is to add `float32` to all of them and call it a day?

Here's how to reproduce the issue I'm seeing:

```yaml
input:
  sql_raw:
    args_mapping: "[1]"
    driver: mysql
    dsn: testuser:testpass@tcp(localhost:3306)/testdb
    query: SELECT c FROM tbl where 1 = ?
    init_statement: |
      CREATE TABLE tbl(c float(255,3));
      # INSERT INTO tbl(c) VALUES(2.789);

  processors:
    - mapping: |
        #!blobl
        root = this.c.type()
```

You'll need to uncomment the insert statement on a second run because it looks like the `init_statement` doesn't support multiple statements for the `mysql` driver.