### PR TITLE
Fix parse_log processor

### DIFF
--- a/internal/impl/pure/processor_parse_log.go
+++ b/internal/impl/pure/processor_parse_log.go
@@ -141,7 +141,15 @@ func parserRFC5424(bestEffort bool) parserFormat {
 			resMap["msgid"] = *res.MsgID
 		}
 		if res.StructuredData != nil {
-			resMap["structureddata"] = *res.StructuredData
+			structuredData := make(map[string]any, len(*res.StructuredData))
+			for key, dataItem := range *res.StructuredData {
+				elements := make(map[string]any, len(dataItem))
+				for itemKey, itemVal := range dataItem {
+					elements[itemKey] = itemVal
+				}
+				structuredData[key] = elements
+			}
+			resMap["structureddata"] = structuredData
 		}
 
 		return resMap, nil


### PR DESCRIPTION
Ensure that the `syslog_rfc5424` `structureddata` field is compatible with Bloblang.

This fixes #2192.