### PR TITLE
Add `pow` method

### DIFF
--- a/internal/bloblang/query/methods_numbers.go
+++ b/internal/bloblang/query/methods_numbers.go
@@ -231,3 +231,39 @@ var _ = registerSimpleMethod(
 		}), nil
 	},
 )
+
+var _ = registerSimpleMethod(
+	NewMethodSpec(
+		"pow", "Returns the number raised to the specified exponent.",
+	).InCategory(
+		MethodCategoryNumbers,
+		"",
+		NewExampleSpec("",
+			`root.new_value = this.value.pow(2)`,
+			`{"value":2}`,
+			`{"new_value":4}`,
+			`{"value":5}`,
+			`{"new_value":25}`,
+		),
+		NewExampleSpec("",
+			`root.new_value = this.value * 10.pow(-2)`,
+			`{"value":2}`,
+			`{"new_value":0.02}`,
+		),
+	).Param(ParamFloat("exponent", "The exponent you want to raise to the power of.")),
+	func(args *ParsedParams) (simpleMethod, error) {
+		return numberMethod(func(f *float64, i *int64, ui *uint64) (any, error) {
+			v, err := args.FieldFloat("exponent")
+			if err != nil {
+				return nil, err
+			}
+			if f != nil {
+				return math.Pow(*f, v), nil
+			}
+			if i != nil {
+				return math.Pow(float64(*i), v), nil
+			}
+			return math.Pow(float64(*ui), v), nil
+		}), nil
+	},
+)

--- a/website/docs/guides/bloblang/methods.md
+++ b/website/docs/guides/bloblang/methods.md
@@ -1155,6 +1155,34 @@ root.new_value = [10,this.value].min()
 # Out: {"new_value":10}
 ```
 
+### `pow`
+
+Returns the number raised to the specified exponent.
+
+#### Parameters
+
+**`exponent`** &lt;float&gt; The exponent you want to raise to the power of.  
+
+#### Examples
+
+
+```coffee
+root.new_value = this.value.pow(2)
+
+# In:  {"value":2}
+# Out: {"new_value":4}
+
+# In:  {"value":5}
+# Out: {"new_value":25}
+```
+
+```coffee
+root.new_value = this.value * 10.pow(-2)
+
+# In:  {"value":2}
+# Out: {"new_value":0.02}
+```
+
 ### `round`
 
 Rounds numbers to the nearest integer, rounding half away from zero. If the resulting value fits within a 64-bit integer then that is returned, otherwise a new floating point number is returned.


### PR DESCRIPTION
Add the `pow` method that returns the number raised to a specified exponent.

Ex.:

``` coffee
root.new_value = this.value.pow(2)

# In:  {"value":2}
# Out: {"new_value":4}

# In:  {"value":5}
# Out: {"new_value":25}
``` 

```coffee
root.new_value = this.value * 10.pow(-2)

# In:  {"value":2}
# Out: {"new_value":0.02}
```