### PR TITLE
Add options to protobuf processor: discard_unknown and use_proto_names

### DIFF
--- a/internal/impl/protobuf/processor_protobuf_test.go
+++ b/internal/impl/protobuf/processor_protobuf_test.go
@@ -19,6 +19,7 @@ func TestProtobufFromJSON(t *testing.T) {
 		importPath     string
 		input          string
 		outputContains []string
+		discardUnknown bool
 	}
 
 	tests := []testCase{
@@ -44,6 +45,14 @@ func TestProtobufFromJSON(t *testing.T) {
 			outputContains: []string{"caleb"},
 		},
 		{
+			name:           "json to protobuf with discard_unknown",
+			message:        "testing.Person",
+			importPath:     "../../../config/test/protobuf/schema",
+			input:          `{"firstName":"caleb","lastName":"quaye","missingfield":"anyvalue"}`,
+			outputContains: []string{"caleb"},
+			discardUnknown: true,
+		},
+		{
 			name:           "any: json to protobuf 1",
 			message:        "testing.Envelope",
 			importPath:     "../../../config/test/protobuf/schema",
@@ -65,7 +74,8 @@ func TestProtobufFromJSON(t *testing.T) {
 operator: from_json
 message: %v
 import_paths: [ %v ]
-`, test.message, test.importPath), nil)
+discard_unknown: %t
+`, test.message, test.importPath, test.discardUnknown), nil)
 			require.NoError(t, err)
 
 			proc, err := newProtobuf(conf, service.MockResources())

--- a/internal/impl/protobuf/processor_protobuf_test.go
+++ b/internal/impl/protobuf/processor_protobuf_test.go
@@ -99,11 +99,12 @@ discard_unknown: %t
 
 func TestProtobufToJSON(t *testing.T) {
 	type testCase struct {
-		name       string
-		message    string
-		importPath string
-		input      []byte
-		output     string
+		name          string
+		message       string
+		importPath    string
+		input         []byte
+		output        string
+		useProtoNames bool
 	}
 
 	tests := []testCase{
@@ -131,6 +132,18 @@ func TestProtobufToJSON(t *testing.T) {
 				0x6d,
 			},
 			output: `{"firstName":"caleb","lastName":"quaye","email":"caleb@myspace.com"}`,
+		},
+		{
+			name:          "protobuf to json with use_proto_names",
+			message:       "testing.Person",
+			importPath:    "../../../config/test/protobuf/schema",
+			useProtoNames: true,
+			input: []byte{
+				0x0a, 0x05, 0x63, 0x61, 0x6c, 0x65, 0x62, 0x12, 0x05, 0x71, 0x75, 0x61, 0x79, 0x65, 0x32, 0x11,
+				0x63, 0x61, 0x6c, 0x65, 0x62, 0x40, 0x6d, 0x79, 0x73, 0x70, 0x61, 0x63, 0x65, 0x2e, 0x63, 0x6f,
+				0x6d,
+			},
+			output: `{"first_name":"caleb","last_name":"quaye","email":"caleb@myspace.com"}`,
 		},
 		{
 			name:       "any: protobuf to json 1",
@@ -162,7 +175,8 @@ func TestProtobufToJSON(t *testing.T) {
 operator: to_json
 message: %v
 import_paths: [ %v ]
-`, test.message, test.importPath), nil)
+use_proto_names: %t
+`, test.message, test.importPath, test.useProtoNames), nil)
 			require.NoError(t, err)
 
 			proc, err := newProtobuf(conf, service.MockResources())

--- a/website/docs/components/processors/protobuf.md
+++ b/website/docs/components/processors/protobuf.md
@@ -24,6 +24,8 @@ label: ""
 protobuf:
   operator: "" # No default (required)
   message: "" # No default (required)
+  discard_unknown: false
+  use_proto_names: false
   import_paths: []
 ```
 
@@ -41,31 +43,6 @@ Converts protobuf messages into a generic JSON structure. This makes it easier t
 
 Attempts to create a target protobuf message from a generic JSON structure.
 
-
-## Fields
-
-### `operator`
-
-The [operator](#operators) to execute
-
-
-Type: `string`  
-Options: `to_json`, `from_json`.
-
-### `message`
-
-The fully qualified name of the protobuf message to convert to/from.
-
-
-Type: `string`  
-
-### `import_paths`
-
-A list of directories containing .proto files, including all definitions required for parsing the target message. If left empty the current directory is used. Each directory listed will be walked with all found .proto files imported.
-
-
-Type: `array`  
-Default: `[]`  
 
 ## Examples
 
@@ -165,5 +142,46 @@ pipeline:
 
 </TabItem>
 </Tabs>
+
+## Fields
+
+### `operator`
+
+The [operator](#operators) to execute
+
+
+Type: `string`  
+Options: `to_json`, `from_json`.
+
+### `message`
+
+The fully qualified name of the protobuf message to convert to/from.
+
+
+Type: `string`  
+
+### `discard_unknown`
+
+If true, from_json discards unknown fields to schema.
+
+
+Type: `bool`  
+Default: `false`  
+
+### `use_proto_names`
+
+If true, to_json unserializes fields exactly as named in schema file.
+
+
+Type: `bool`  
+Default: `false`  
+
+### `import_paths`
+
+A list of directories containing .proto files, including all definitions required for parsing the target message. If left empty the current directory is used. Each directory listed will be walked with all found .proto files imported.
+
+
+Type: `array`  
+Default: `[]`  
 
 


### PR DESCRIPTION
Hello blobs.
In this PR I'd like to propose two new config settings for the `protobuf` processor that would come in really handy.

## For operator `from_json`, option `discard_unknown`
As per the [official `proto` docs](https://pkg.go.dev/google.golang.org/protobuf/proto#UnmarshalOptions), while Unmarshaling from JSON object to protobuf message we can set the option `DiscardUnknown` to true to force the serialization to discard any unknown field to the schema.

**The current behavior cancels the serialization if the schema is not respected 100%.**

Used like:
```
protobuf:
  operator: from_json
  import_paths: [./protos]
  message: com.Entity
  discard_unknown: true  # false by default
```

## For operator `to_json`, option `use_proto_names`
As per the [official `protojson` docs](https://pkg.go.dev/google.golang.org/protobuf/encoding/protojson#MarshalOptions), while Marshaling from protobuf message to JSON, we can set the option `UseProtoNames` to true will create a JSON with field names exactly as defined in the protobuf schema file.

**The current behavior always deserializes the fields in lowerCamelCase format**

Used like:
```
protobuf:
  operator: to_json
  import_paths: [./protos]
  message: com.Entity
  use_proto_names: true  # false by default
```

## Notes
- I'm very noobie at Golang, apologies for the overall quality.
- `make lint` and `make fmt` are throwing errors for me.
- `make test` are all passing
- Thanks for this great tool.