### PR TITLE
Create the sarama ClusterAdmin with the actual sarama configuration.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/Azure/go-amqp v1.0.2
 	github.com/ClickHouse/clickhouse-go/v2 v2.14.3
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/trace v1.20.0
-	github.com/IBM/sarama v1.42.0
+	github.com/IBM/sarama v1.42.1
 	github.com/Jeffail/gabs/v2 v2.7.0
 	github.com/Jeffail/grok v1.1.0
 	github.com/Masterminds/squirrel v1.5.4

--- a/go.sum
+++ b/go.sum
@@ -93,8 +93,8 @@ github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/trace v1.20.
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/cloudmock v0.44.0 h1:ew7SfeajMJ3I4iXA1LERYY62fGCKO4TjVPw5QTPt47k=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.44.0 h1:GjWPDY9PUlNWwTI95L/lktUp35BLtzBoBElH314eafM=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.44.0/go.mod h1:qkFPtMouQjW5ugdHIOthiTbweVHUTqbS0Qsu55KqXks=
-github.com/IBM/sarama v1.42.0 h1:E5Kp9D5iIxI4b0Y0DYdiXil72v3kHIZMG8qTfWXVh2s=
-github.com/IBM/sarama v1.42.0/go.mod h1:Xxho9HkHd4K/MDUo/T/sOqwtX/17D33++E9Wib6hUdQ=
+github.com/IBM/sarama v1.42.1 h1:wugyWa15TDEHh2kvq2gAy1IHLjEjuYOYgXz/ruC/OSQ=
+github.com/IBM/sarama v1.42.1/go.mod h1:Xxho9HkHd4K/MDUo/T/sOqwtX/17D33++E9Wib6hUdQ=
 github.com/Jeffail/gabs/v2 v2.7.0 h1:Y2edYaTcE8ZpRsR2AtmPu5xQdFDIthFG0jYhu5PY8kg=
 github.com/Jeffail/gabs/v2 v2.7.0/go.mod h1:dp5ocw1FvBBQYssgHsG7I1WYsiLRtkUaB1FEtSwvNUw=
 github.com/Jeffail/grok v1.1.0 h1:kiHmZ+0J5w/XUihRgU3DY9WIxKrNQCDjnfAb6bMLFaE=

--- a/internal/impl/kafka/output_sarama_kafka.go
+++ b/internal/impl/kafka/output_sarama_kafka.go
@@ -257,10 +257,6 @@ func NewKafkaWriterFromParsed(conf *service.ParsedConfig, mgr *service.Resources
 		return backoff.WithMaxRetries(&boff, uint64(maxRetries))
 	}
 
-	if k.admin, err = sarama.NewClusterAdmin(k.addresses, sarama.NewConfig()); err != nil {
-		return nil, err
-	}
-
 	if k.retryAsBatch, err = conf.FieldBool(oskFieldRetryAsBatch); err != nil {
 		return nil, err
 	}
@@ -290,6 +286,11 @@ func NewKafkaWriterFromParsed(conf *service.ParsedConfig, mgr *service.Resources
 	if k.saramConf, err = k.saramaConfigFromParsed(conf); err != nil {
 		return nil, err
 	}
+
+	if k.admin, err = sarama.NewClusterAdmin(k.addresses, k.saramConf); err != nil {
+		return nil, err
+	}
+
 	return &k, nil
 }
 


### PR DESCRIPTION
Using sarama 1.42.0, we're not able to connect a sarama output to a kafka 1.0.0/ Event hubs. 
Probably it happens with all but the default version.
Using the actual sarama config to create the ClusterAdmin we can now connect to any kafka successfuly.

Fixes https://github.com/benthosdev/benthos/issues/2199