### PR TITLE
Enhance protobuf resolution to register first level of nested messages

### DIFF
--- a/config/test/protobuf/schema/house.proto
+++ b/config/test/protobuf/schema/house.proto
@@ -4,6 +4,11 @@ package testing;
 import "person.proto";
 
 message House {
+  message Mailbox {
+    string color = 1;
+    string identifier = 2;
+  }
   repeated testing.Person people = 1;
   string address = 2;
+  Mailbox mailbox = 3;
 }

--- a/internal/impl/protobuf/common.go
+++ b/internal/impl/protobuf/common.go
@@ -35,6 +35,11 @@ func RegistriesFromMap(filesMap map[string]string) (*protoregistry.Files, *proto
 			if err := types.RegisterMessage(dynamicpb.NewMessageType(t.UnwrapMessage())); err != nil {
 				return nil, nil, fmt.Errorf("failed to register type '%v': %w", t.GetName(), err)
 			}
+			for _, nt := range t.GetNestedMessageTypes() {
+				if err := types.RegisterMessage(dynamicpb.NewMessageType(nt.UnwrapMessage())); err != nil {
+					return nil, nil, fmt.Errorf("failed to register type '%v': %w", nt.GetFullyQualifiedName(), err)
+				}
+			}
 		}
 	}
 	return files, types, nil

--- a/internal/impl/protobuf/processor_protobuf_test.go
+++ b/internal/impl/protobuf/processor_protobuf_test.go
@@ -57,6 +57,13 @@ func TestProtobufFromJSON(t *testing.T) {
 			input:          `{"id":747,"content":{"@type":"type.googleapis.com/testing.House","address":"123"}}`,
 			outputContains: []string{"type.googleapis.com/testing.House"},
 		},
+		{
+			name:           "any: json to protobuf with nested message",
+			message:        "testing.House.Mailbox",
+			importPath:     "../../../config/test/protobuf/schema",
+			input:          `{"color":"red","identifier":"123"}`,
+			outputContains: []string{"red"},
+		},
 	}
 
 	for i, test := range tests {


### PR DESCRIPTION
Hello, in this PR I'd like to propose a change that would allow users to utilize nested messages from `.proto` files.
This case is useful whenever you need to create partial serializations from legacy protobuf schemas.

With a protobuf like:
```protobuf
syntax = "proto3";
package testing;

import "person.proto";

message House {
  message Mailbox {
    string color = 1;
    string identifier = 2;
  }
  repeated testing.Person people = 1;
  string address = 2;
  Mailbox mailbox = 3;
}
```
This change would allow to use the protobuf processor with a `message` setting like:
```yaml
protobuf:
  operator: from_json
  import_paths: ["./']
  message: testing.House.Mailbox
```