### PR TITLE
Config Passthrough for disable of idempotent write with Franz Kafka producer

### DIFF
--- a/website/docs/components/outputs/kafka_franz.md
+++ b/website/docs/components/outputs/kafka_franz.md
@@ -64,6 +64,7 @@ output:
     partition: ${! meta("partition") } # No default (optional)
     client_id: benthos
     rack_id: ""
+    disable_idempotent_write: false
     metadata:
       include_prefixes: []
       include_patterns: []
@@ -178,6 +179,14 @@ A rack identifier for this client.
 
 Type: `string`  
 Default: `""`  
+
+### `disable_idempotent_write`
+
+Disabled the idempotent write producer option, meaning the IDEMPOTENT_WRITE permission on CLUSTER is no longer required. Not recommended unless absolutely necessary
+
+
+Type: `bool`  
+Default: `false`  
 
 ### `metadata`
 


### PR DESCRIPTION
In certain cases you may wish to disable idempotent write for the Franz-Go Kafka client, for example it requires additional cluster privileges (`IDEMPOTENT_WRITE` on `CLUSTER`), and can have repercussions with regards to retrying failed messages. This currently defaults to enabled on the Franz-Go client so I have created a config passthrough as below.

The default behaviour of the other bundled Sarama Kafka client does not enable Idempotent write by default, so it requires less permissions than the Franz-Go client to produce to a cluster. Allowing this config passthrough allows for easier migration from one Kafka client to the other.

You can read more about the `DisableIdempotentWrite` option [here](https://pkg.go.dev/github.com/twmb/franz-go/pkg/kgo#DisableIdempotentWrite).