### PR TITLE
Prevent redundant sudo calls in the install script

### DIFF
--- a/website/static/sh/install
+++ b/website/static/sh/install
@@ -145,6 +145,10 @@ install_benthos()
 	chmod +x "$PREFIX/tmp/$benthos_bin"
 
 	echo "Putting benthos in $benthos_install_path (may require password)"
+	if [ -n "$sudo_cmd" ] && [ -n "$(find "$benthos_install_path" -prune -user "$(id -u)")" ]; then
+		# Skip sudo if the current user is the owner of the Benthos install path
+		sudo_cmd=""
+	fi
 	$sudo_cmd mv "$PREFIX/tmp/$benthos_bin" "$benthos_install_path/$benthos_bin"
 	$sudo_cmd rm -- "$dl"
 


### PR DESCRIPTION
Fixes #2269.

While it's a bit cryptic, I think this approach should be portable across the OSes we care about. Details [here](https://unix.stackexchange.com/questions/269141/getting-the-owner-of-the-folder-with-the-if-command).