### PR TITLE
Fix logging in amqp_0_9 components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ All notable changes to this project will be documented in this file.
 
 - The `parse_parquet` Bloblang function, `parquet_decode`, `parquet_encode` processors and the `parquet` input have all been upgraded to the latest version of the underlying Parquet library. Since this underlying library is experimental it is likely that behaviour changes will result. One significant change is that encoding numerical values that are larger than the column type (`float64` into `FLOAT`, `int64` into `INT32`, etc) will no longer be automatically converted.
 
+### Fixed
+
+- The `amqp_0_9` output no longer prints bogus exchange name when connecting to the server.
+
 ## 4.24.0 - 2023-11-24
 
 ### Added

--- a/internal/impl/amqp09/input.go
+++ b/internal/impl/amqp09/input.go
@@ -263,7 +263,7 @@ func (a *amqp09Reader) Connect(ctx context.Context) (err error) {
 
 	amqpChan, err = conn.Channel()
 	if err != nil {
-		return fmt.Errorf("AMQP 0.9 Channel: %s", err)
+		return fmt.Errorf("AMQP 0.9 Channel: %w", err)
 	}
 
 	if a.queueDeclare {
@@ -277,7 +277,7 @@ func (a *amqp09Reader) Connect(ctx context.Context) (err error) {
 		); err != nil {
 			_ = amqpChan.Close()
 			_ = conn.Close()
-			return fmt.Errorf("queue Declare: %s", err)
+			return fmt.Errorf("queue Declare: %w", err)
 		}
 	}
 
@@ -291,7 +291,7 @@ func (a *amqp09Reader) Connect(ctx context.Context) (err error) {
 		); err != nil {
 			_ = amqpChan.Close()
 			_ = conn.Close()
-			return fmt.Errorf("queue Bind: %s", err)
+			return fmt.Errorf("queue Bind: %w", err)
 		}
 	}
 
@@ -300,7 +300,7 @@ func (a *amqp09Reader) Connect(ctx context.Context) (err error) {
 	); err != nil {
 		_ = amqpChan.Close()
 		_ = conn.Close()
-		return fmt.Errorf("qos: %s", err)
+		return fmt.Errorf("qos: %w", err)
 	}
 
 	if consumerChan, err = amqpChan.Consume(
@@ -314,14 +314,14 @@ func (a *amqp09Reader) Connect(ctx context.Context) (err error) {
 	); err != nil {
 		_ = amqpChan.Close()
 		_ = conn.Close()
-		return fmt.Errorf("queue Consume: %s", err)
+		return fmt.Errorf("queue Consume: %w", err)
 	}
 
 	a.conn = conn
 	a.amqpChan = amqpChan
 	a.consumerChan = consumerChan
 
-	a.log.Infof("Receiving AMQP 0.9 messages from queue: %v\n", a.queue)
+	a.log.Infof("Receiving AMQP 0.9 messages from queue: %s", a.queue)
 	return
 }
 
@@ -332,13 +332,13 @@ func (a *amqp09Reader) disconnect() error {
 
 	if a.amqpChan != nil {
 		if err := a.amqpChan.Cancel(a.consumerTag, true); err != nil {
-			a.log.Errorf("Failed to cancel consumer: %v\n", err)
+			a.log.Errorf("Failed to cancel consumer: %w", err)
 		}
 		a.amqpChan = nil
 	}
 	if a.conn != nil {
 		if err := a.conn.Close(); err != nil {
-			a.log.Errorf("Failed to close connection cleanly: %v\n", err)
+			a.log.Errorf("Failed to close connection cleanly: %w", err)
 		}
 		a.conn = nil
 	}
@@ -386,7 +386,7 @@ func amqpSetMetadata(p *service.Message, k string, v any) {
 		return
 	case []interface{}:
 		for key, value := range v {
-			amqpSetMetadata(p, fmt.Sprintf("%s_%v", metaKey, key), value)
+			amqpSetMetadata(p, fmt.Sprintf("%s_%d", metaKey, key), value)
 		}
 		return
 	default:
@@ -503,18 +503,18 @@ func (a *amqp09Reader) dial(amqpURL string) (conn *amqp.Connection, err error) {
 		if u.User != nil {
 			conn, err = amqp.DialTLS(amqpURL, a.tlsConf)
 			if err != nil {
-				return nil, fmt.Errorf("%w: %s", errAMQP09Connect, err)
+				return nil, fmt.Errorf("%w: %w", errAMQP09Connect, err)
 			}
 		} else {
 			conn, err = amqp.DialTLS_ExternalAuth(amqpURL, a.tlsConf)
 			if err != nil {
-				return nil, fmt.Errorf("%w: %s", errAMQP09Connect, err)
+				return nil, fmt.Errorf("%w: %w", errAMQP09Connect, err)
 			}
 		}
 	} else {
 		conn, err = amqp.Dial(amqpURL)
 		if err != nil {
-			return nil, fmt.Errorf("%w: %s", errAMQP09Connect, err)
+			return nil, fmt.Errorf("%w: %w", errAMQP09Connect, err)
 		}
 	}
 


### PR DESCRIPTION
Currently, users will see a log message similar to this when the `amqp_0_9` output attempts to connect to a server: "Sending AMQP messages to exchange: \u0026{0xc0027123c0}".

This regression was introduced in #1976.

Note: I took the liberty to standardise some of the other log messages in the `amqp_0_9` components.