### PR TITLE
Explain use of whitespace in field_template

### DIFF
--- a/internal/docs/field_template.go
+++ b/internal/docs/field_template.go
@@ -30,6 +30,7 @@ func FieldsTemplate(lintableExamples bool) string {
 	if lintableExamples {
 		exampleHint = "yaml"
 	}
+	// Use trailing whitespace below to render line breaks in Markdown
 	return `{{define "field_docs" -}}
 {{range $i, $field := .Fields -}}
 ### ` + "`{{$field.FullName}}`" + `


### PR DESCRIPTION
Trailing whitespaces are significant in Markdown and used to render line breaks.