### PR TITLE
NATS: Refactor errors so that defer can cleanup

### DIFF
--- a/internal/impl/nats/input_jetstream.go
+++ b/internal/impl/nats/input_jetstream.go
@@ -221,7 +221,7 @@ func newJetStreamReaderFromConfig(conf *service.ParsedConfig, mgr *service.Resou
 
 //------------------------------------------------------------------------------
 
-func (j *jetStreamReader) Connect(ctx context.Context) error {
+func (j *jetStreamReader) Connect(ctx context.Context) (err error) {
 	j.connMut.Lock()
 	defer j.connMut.Unlock()
 
@@ -231,7 +231,6 @@ func (j *jetStreamReader) Connect(ctx context.Context) error {
 
 	var natsConn *nats.Conn
 	var natsSub *nats.Subscription
-	var err error
 
 	defer func() {
 		if err != nil {

--- a/internal/impl/nats/input_kv.go
+++ b/internal/impl/nats/input_kv.go
@@ -144,15 +144,13 @@ func newKVReader(conf *service.ParsedConfig, mgr *service.Resources) (*kvReader,
 	return r, nil
 }
 
-func (r *kvReader) Connect(ctx context.Context) error {
+func (r *kvReader) Connect(ctx context.Context) (err error) {
 	r.connMut.Lock()
 	defer r.connMut.Unlock()
 
 	if r.natsConn != nil {
 		return nil
 	}
-
-	var err error
 
 	defer func() {
 		if err != nil {

--- a/internal/impl/nats/output_jetstream.go
+++ b/internal/impl/nats/output_jetstream.go
@@ -139,7 +139,7 @@ func newJetStreamWriterFromConfig(conf *service.ParsedConfig, mgr *service.Resou
 
 //------------------------------------------------------------------------------
 
-func (j *jetStreamOutput) Connect(ctx context.Context) error {
+func (j *jetStreamOutput) Connect(ctx context.Context) (err error) {
 	j.connMut.Lock()
 	defer j.connMut.Unlock()
 
@@ -149,7 +149,6 @@ func (j *jetStreamOutput) Connect(ctx context.Context) error {
 
 	var natsConn *nats.Conn
 	var jCtx nats.JetStreamContext
-	var err error
 
 	defer func() {
 		if err != nil && natsConn != nil {

--- a/internal/impl/nats/output_kv.go
+++ b/internal/impl/nats/output_kv.go
@@ -124,7 +124,7 @@ func newKVOutput(conf *service.ParsedConfig, mgr *service.Resources) (*kvOutput,
 
 //------------------------------------------------------------------------------
 
-func (kv *kvOutput) Connect(ctx context.Context) error {
+func (kv *kvOutput) Connect(ctx context.Context) (err error) {
 	kv.connMut.Lock()
 	defer kv.connMut.Unlock()
 
@@ -133,7 +133,6 @@ func (kv *kvOutput) Connect(ctx context.Context) error {
 	}
 
 	var natsConn *nats.Conn
-	var err error
 
 	defer func() {
 		if err != nil && natsConn != nil {

--- a/internal/impl/nats/processor_kv.go
+++ b/internal/impl/nats/processor_kv.go
@@ -347,15 +347,13 @@ func (p *kvProcessor) addMetadata(msg *service.Message, key string, revision uin
 	msg.MetaSetMut(metaKVOperation, operation.String())
 }
 
-func (p *kvProcessor) Connect(ctx context.Context) error {
+func (p *kvProcessor) Connect(ctx context.Context) (err error) {
 	p.connMut.Lock()
 	defer p.connMut.Unlock()
 
 	if p.natsConn != nil {
 		return nil
 	}
-
-	var err error
 
 	defer func() {
 		if err != nil {


### PR DESCRIPTION
This fixes a connection leak on the NATS Jestream input when there is an error with the consumer. 
See https://github.com/benthosdev/benthos/issues/2303 for A LOT more details. 

TL;DR: There is an `err` variable that shadows the top level one and the deferred cleanup function misses the error. With this fix we don't rely on closures to check the error. 

There are 4 other sites in the code where I'm doing the same refactor. There don't seem to be any bugs there but it's nice to be consistent and also to help future PRs not introduce the same error.  