### PR TITLE
Subprocess: Refactor errors so that we can cancel on error

### DIFF
--- a/internal/impl/io/processor_subprocess.go
+++ b/internal/impl/io/processor_subprocess.go
@@ -280,11 +280,10 @@ func netstringSplitFunc(data []byte, atEOF bool) (advance int, token []byte, err
 	return 0, nil, nil
 }
 
-func (s *subprocWrapper) start() error {
+func (s *subprocWrapper) start() (err error) {
 	s.cmdMut.Lock()
 	defer s.cmdMut.Unlock()
 
-	var err error
 	cmdCtx, cmdCancelFn := context.WithCancel(context.Background())
 	defer func() {
 		if err != nil {


### PR DESCRIPTION
This is another instance of https://github.com/benthosdev/benthos/issues/2303. 

I can't tell for sure what the correct behavior is (should `cmdCancelFn()` be called if `cmd.Start()` fails?). I'm inclined to say yes. 

Also, of note, the behavior changed in https://github.com/benthosdev/benthos/pull/739 (change [here](https://github.com/benthosdev/benthos/pull/739/files#diff-79cf46ea450b66657d2eabe4d6c06ed116a66b1943f75abdd326bc08bbde262fL354)), which looks like an unintentional change.

