### PR TITLE
Nanomsg input: Refactor to not leak socket on error

### DIFF
--- a/internal/impl/nanomsg/input.go
+++ b/internal/impl/nanomsg/input.go
@@ -125,7 +125,7 @@ func getInputSocketFromType(t string) (mangos.Socket, error) {
 	return nil, errors.New("invalid Scalability Protocols socket type")
 }
 
-func (s *nanomsgReader) Connect(ctx context.Context) error {
+func (s *nanomsgReader) Connect(ctx context.Context) (err error) {
 	s.cMut.Lock()
 	defer s.cMut.Unlock()
 
@@ -134,7 +134,6 @@ func (s *nanomsgReader) Connect(ctx context.Context) error {
 	}
 
 	var socket mangos.Socket
-	var err error
 
 	defer func() {
 		if err != nil && socket != nil {


### PR DESCRIPTION
This is another instance of https://github.com/benthosdev/benthos/issues/2303. 

In this case, we leak the socket if there are any errors when setting options on subfilters. 