### PR TITLE
Sarama input: Refactor to fix error handling

### DIFF
--- a/internal/impl/kafka/input_sarama_kafka_parts.go
+++ b/internal/impl/kafka/input_sarama_kafka_parts.go
@@ -132,11 +132,10 @@ func (k *kafkaReader) offsetPartitionPutRequest(consumerGroup string) *sarama.Of
 	return req
 }
 
-func (k *kafkaReader) connectExplicitTopics(ctx context.Context, config *sarama.Config) error {
+func (k *kafkaReader) connectExplicitTopics(ctx context.Context, config *sarama.Config) (err error) {
 	var coordinator *sarama.Broker
 	var consumer sarama.Consumer
 	var client sarama.Client
-	var err error
 
 	defer func() {
 		if err != nil {


### PR DESCRIPTION
Another instance of https://github.com/benthosdev/benthos/issues/2303. 

However, the bug seems really subtle if it's even possible: it looks like there are some code paths where we set `err` and then handle the error: 
```
	var offsetRes *sarama.OffsetFetchResponse
	if coordinator != nil {
		if offsetRes, err = coordinator.FetchOffset(&offsetGetReq); err != nil {
			if errors.Is(err, io.EOF) {
				offsetRes = &sarama.OffsetFetchResponse{}
			} else {
				return fmt.Errorf("failed to acquire offsets from broker: %v", err)
			}
		}
	} else {
		offsetRes = &sarama.OffsetFetchResponse{}
	}
```

In this case, on an `io.EOF` error, `err` might still be set, even though we don't return. If there are no more errors in the function, we'll hit the final `return nil` but the `defer` cleanup function should still see the `err` to be `io.EOF` and might cleanup resources even though they're probably not safe to cleanup. 

I can't tell if this is right, I've never used this code. Either way the change seems desirable. 