### PR TITLE
Zeromq: Refactor error for better cleanup

### DIFF
--- a/internal/impl/zeromq/input_zmq4.go
+++ b/internal/impl/zeromq/input_zmq4.go
@@ -137,7 +137,7 @@ func getZMQInputType(t string) (zmq4.Type, error) {
 	return zmq4.PULL, errors.New("invalid ZMQ socket type")
 }
 
-func (z *zmqInput) Connect(ignored context.Context) error {
+func (z *zmqInput) Connect(ignored context.Context) (err error) {
 	if z.socket != nil {
 		return nil
 	}

--- a/internal/impl/zeromq/output_zmq4.go
+++ b/internal/impl/zeromq/output_zmq4.go
@@ -129,7 +129,7 @@ func getZMQOutputType(t string) (zmq4.Type, error) {
 
 //------------------------------------------------------------------------------
 
-func (z *zmqOutput) Connect(_ context.Context) error {
+func (z *zmqOutput) Connect(_ context.Context) (err error) {
 	if z.socket != nil {
 		return nil
 	}


### PR DESCRIPTION
This is an instance of https://github.com/benthosdev/benthos/issues/2303. 

For the `input`, this should fix a potential issue where we don't close the socket if we fail any of the `SetSubscribe` calls for any subfilter. 

The `output` seems fine, I'm just changing it for completeness. 