### PR TITLE
Fix panic when calling `zip()` in Bloblang

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ All notable changes to this project will be documented in this file.
 
 - The `javascript` processor now handles module imports correctly.
 
+### Fixed
+
+- The `zip` Bloblang method no longer fails when executed without arguments.
+
 ### Changed
 
 - The `parse_parquet` Bloblang function, `parquet_decode`, `parquet_encode` processors and the `parquet` input have all been upgraded to the latest version of the underlying Parquet library. Since this underlying library is experimental it is likely that behaviour changes will result. One significant change is that encoding numerical values that are larger than the column type (`float64` into `FLOAT`, `int64` into `INT32`, etc) will no longer be automatically converted.

--- a/internal/impl/pure/bloblang_objects.go
+++ b/internal/impl/pure/bloblang_objects.go
@@ -112,6 +112,8 @@ If a key within a nested path does not exist then it is ignored.`).
 			),
 		func(args *bloblang.ParsedParams) (bloblang.Method, error) {
 			sizeError := fmt.Errorf("can't zip different length array values")
+			argError := fmt.Errorf("zip requires at least one argument")
+
 			argAnys := args.AsSlice()
 			argSlices := make([][]any, len(argAnys))
 			for i, a := range argAnys {
@@ -125,6 +127,9 @@ If a key within a nested path does not exist then it is ignored.`).
 			}
 
 			return bloblang.ArrayMethod(func(i []any) (any, error) {
+				if len(argSlices) == 0 {
+					return nil, argError
+				}
 				if len(i) != len(argSlices[0]) {
 					return nil, sizeError
 				}


### PR DESCRIPTION
This change prevents the Bloblang `zip()` method from panicking when invoked without arguments.