### PR TITLE
Enable pprof /allocs endpoint

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -180,6 +180,10 @@ func New(
 			pprof.Index,
 		)
 		t.RegisterEndpoint(
+			"/debug/pprof/allocs", "DEBUG: Responds with a pprof-formatted allocs profile.",
+			pprof.Index,
+		)
+		t.RegisterEndpoint(
 			"/debug/pprof/symbol", "DEBUG: looks up the program counters listed"+
 				" in the request, responding with a table mapping program"+
 				" counters to function names.",


### PR DESCRIPTION
This profile type was missing, from https://pkg.go.dev/runtime/pprof

```
The allocs profile is the same as the heap profile but changes the
default pprof display to -alloc_space, the total number of bytes
allocated since the program began (including garbage-collected bytes).
```