### PR TITLE
Add credit property to amqp1 input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 
 - Field `address_cache` added to the `socket_server` input.
-- Field `read_header` added to the `amqp_1` input.
+- Field `read_header` and `credit` added to the `amqp_1` input.
 - All inputs with a `codec` field now support a new field `scanner` to replace it. Scanners are more powerful as they are configured in a structured way similar to other component types rather than via a single string field, for more information [check out the scanners page](https://www.benthos.dev/docs/components/scanners/about).
 - New `diff` and `patch` Bloblang methods.
 - New `processors` processor.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+### Added
+
+- Field `credit` added to the `amqp_1` input to specify the maximum number of unacknowledged messages the sender can transmit. 
+
+### Changed
+
+- The default value of the `amqp_1.credit` input has changed from `1` to `64` 
+
 ## 4.25.1 - 2024-03-01
 
 ### Fixed
@@ -16,7 +24,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 
 - Field `address_cache` added to the `socket_server` input.
-- Field `read_header` and `credit` added to the `amqp_1` input.
+- Field `read_header` added to the `amqp_1` input.
 - All inputs with a `codec` field now support a new field `scanner` to replace it. Scanners are more powerful as they are configured in a structured way similar to other component types rather than via a single string field, for more information [check out the scanners page](https://www.benthos.dev/docs/components/scanners/about).
 - New `diff` and `patch` Bloblang methods.
 - New `processors` processor.

--- a/internal/impl/amqp1/config.go
+++ b/internal/impl/amqp1/config.go
@@ -22,6 +22,7 @@ const (
 	sourceAddrField       = "source_address"
 	azureRenewLockField   = "azure_renew_lock"
 	getMessageHeaderField = "read_header"
+	creditField           = "credit"
 
 	// Output
 	targetAddrField  = "target_address"

--- a/internal/impl/amqp1/input.go
+++ b/internal/impl/amqp1/input.go
@@ -19,14 +19,14 @@ import (
 )
 
 //go:embed input_description.md
-var input_description string
+var inputDescription string
 
 func amqp1InputSpec() *service.ConfigSpec {
 	return service.NewConfigSpec().
 		Stable().
 		Categories("Services").
 		Summary("Reads messages from an AMQP (1.0) server.").
-		Description(input_description).
+		Description(inputDescription).
 		Fields(
 			service.NewURLField(urlField).
 				Description("A URL to connect to.").

--- a/internal/impl/amqp1/input.go
+++ b/internal/impl/amqp1/input.go
@@ -57,9 +57,9 @@ func amqp1InputSpec() *service.ConfigSpec {
 				Default(false).Advanced(),
 			service.NewIntField(creditField).
 				Description("Specifies the maximum number of unacknowledged messages the sender can transmit. Once this limit is reached, no more messages will arrive until messages are acknowledged and settled.").
-				LintRule(`root = if this < 1 { [ "`+creditField+`must be at least 1" ] }`).
-				Version("4.25.0").
-				Default(1).
+				LintRule(`root = if this < 1 { [ "`+creditField+` must be at least 1" ] }`).
+				Version("4.26.0").
+				Default(64).
 				Advanced(),
 			service.NewTLSToggledField(tlsField),
 			saslFieldSpec(),

--- a/internal/impl/amqp1/input.go
+++ b/internal/impl/amqp1/input.go
@@ -2,6 +2,7 @@ package amqp1
 
 import (
 	"context"
+	_ "embed"
 	"errors"
 	"fmt"
 	"math/rand"
@@ -17,34 +18,15 @@ import (
 	"github.com/benthosdev/benthos/v4/public/service"
 )
 
+//go:embed input_description.md
+var input_description string
+
 func amqp1InputSpec() *service.ConfigSpec {
 	return service.NewConfigSpec().
 		Stable().
 		Categories("Services").
 		Summary("Reads messages from an AMQP (1.0) server.").
-		Description(`
-### Metadata
-
-This input adds the following metadata fields to each message:
-
-`+"``` text"+`
-- amqp_content_type
-- amqp_content_encoding
-- amqp_creation_time
-- All string typed message annotations
-`+"```"+`
-
-You can access these metadata fields using [function interpolation](/docs/configuration/interpolation#bloblang-queries).
-
-By setting `+"`read_header` to `true`"+`, additional message header properties will be added to each message:
-
-`+"``` text"+`
-- amqp_durable
-- amqp_priority
-- amqp_ttl
-- amqp_first_acquirer
-- amqp_delivery_count
-`+"```").
+		Description(input_description).
 		Fields(
 			service.NewURLField(urlField).
 				Description("A URL to connect to.").
@@ -73,6 +55,12 @@ By setting `+"`read_header` to `true`"+`, additional message header properties w
 				Description("Read additional message header fields into `amqp_*` metadata properties.").
 				Version("4.25.0").
 				Default(false).Advanced(),
+			service.NewIntField(creditField).
+				Description("Specifies the maximum number of unacknowledged messages the sender can transmit. Once this limit is reached, no more messages will arrive until messages are acknowledged and settled.").
+				LintRule(`root = if this < 1 { [ "`+creditField+`must be at least 1" ] }`).
+				Version("4.25.0").
+				Default(1).
+				Advanced(),
 			service.NewTLSToggledField(tlsField),
 			saslFieldSpec(),
 		).LintRule(`
@@ -99,6 +87,7 @@ type amqp1Reader struct {
 	sourceAddr string
 	renewLock  bool
 	getHeader  bool
+	credit     int // max_in_flight
 	connOpts   *amqp.ConnOptions
 	log        *service.Logger
 
@@ -148,6 +137,10 @@ func amqp1ReaderFromParsed(conf *service.ParsedConfig, mgr *service.Resources) (
 		return nil, err
 	}
 
+	if a.credit, err = conf.FieldInt(creditField); err != nil {
+		return nil, err
+	}
+
 	if err := saslOptFnsFromParsed(conf, a.connOpts); err != nil {
 		return nil, err
 	}
@@ -188,7 +181,9 @@ func (a *amqp1Reader) Connect(ctx context.Context) (err error) {
 	}
 
 	// Create a receiver
-	if conn.receiver, err = conn.session.NewReceiver(ctx, a.sourceAddr, nil); err != nil {
+	if conn.receiver, err = conn.session.NewReceiver(ctx, a.sourceAddr, &amqp.ReceiverOptions{
+		Credit: int32(a.credit),
+	}); err != nil {
 		_ = conn.Close(ctx)
 		return
 	}

--- a/internal/impl/amqp1/input_description.md
+++ b/internal/impl/amqp1/input_description.md
@@ -1,0 +1,27 @@
+### Metadata
+
+This input adds the following metadata fields to each message:
+
+``` text
+- amqp_content_type
+- amqp_content_encoding
+- amqp_creation_time
+- All string typed message annotations
+```
+
+You can access these metadata fields using [function interpolation](/docs/configuration/interpolation#bloblang-queries).
+
+By setting `read_header` to `true`, additional message header properties will be added to each message:
+
+``` text
+- amqp_durable
+- amqp_priority
+- amqp_ttl
+- amqp_first_acquirer
+- amqp_delivery_count
+```
+
+## Performance
+
+This input benefits from receiving multiple messages in flight in parallel for improved performance. 
+You can tune the max number of in flight messages with the field `credit`.

--- a/website/docs/components/inputs/amqp_1.md
+++ b/website/docs/components/inputs/amqp_1.md
@@ -46,7 +46,7 @@ input:
     source_address: /foo # No default (required)
     azure_renew_lock: false
     read_header: false
-    credit: 1
+    credit: 64
     tls:
       enabled: false
       skip_cert_verify: false
@@ -157,8 +157,8 @@ Specifies the maximum number of unacknowledged messages the sender can transmit.
 
 
 Type: `int`  
-Default: `1`  
-Requires version 4.25.0 or newer  
+Default: `64`  
+Requires version 4.26.0 or newer  
 
 ### `tls`
 

--- a/website/docs/components/inputs/amqp_1.md
+++ b/website/docs/components/inputs/amqp_1.md
@@ -46,6 +46,7 @@ input:
     source_address: /foo # No default (required)
     azure_renew_lock: false
     read_header: false
+    credit: 1
     tls:
       enabled: false
       skip_cert_verify: false
@@ -84,6 +85,12 @@ By setting `read_header` to `true`, additional message header properties will be
 - amqp_first_acquirer
 - amqp_delivery_count
 ```
+
+## Performance
+
+This input benefits from receiving multiple messages in flight in parallel for improved performance. 
+You can tune the max number of in flight messages with the field `credit`.
+
 
 ## Fields
 
@@ -142,6 +149,15 @@ Read additional message header fields into `amqp_*` metadata properties.
 
 Type: `bool`  
 Default: `false`  
+Requires version 4.25.0 or newer  
+
+### `credit`
+
+Specifies the maximum number of unacknowledged messages the sender can transmit. Once this limit is reached, no more messages will arrive until messages are acknowledged and settled.
+
+
+Type: `int`  
+Default: `1`  
 Requires version 4.25.0 or newer  
 
 ### `tls`


### PR DESCRIPTION
Exposing the `credit` property of the amqp ReceiverOptions allows for a performance increase when receiving messages.
My tests with a local broker went up from ~50 msg/sec with `credit = 1` to 1k or more msg/sec with `credit = 64`
It's similar to existing `max_in_flight` properties, but to keep the parameter recognizable for amqp1 users, we will stick to `credit`.

Since the default of the property has always been `1`, this should not introduce any issues to existing flows.

The description of the `amqp1` component has been externalized into a separate markdown file and is reinjected with `go:embed` for much better readability (IMHO).
