### PR TITLE
fix: always bind a given stream when SubscribeSync()

### DIFF
--- a/internal/impl/nats/input_jetstream.go
+++ b/internal/impl/nats/input_jetstream.go
@@ -299,9 +299,9 @@ func (j *jetStreamReader) Connect(ctx context.Context) (err error) {
 		if j.bind {
 			if j.stream != "" && j.durable != "" {
 				options = append(options, nats.Bind(j.stream, j.durable))
-			} else if j.stream != "" {
-				options = append(options, nats.BindStream(j.stream))
 			}
+		} else if j.stream != "" {
+			options = append(options, nats.BindStream(j.stream))
 		}
 
 		if j.queue == "" {


### PR DESCRIPTION
When trying to use nats_jetstream input plugin, this was not possible for streams that were mirrored from a stream in a different jetstream domain. 

This is fixed by adding the given stream name always to the options when calling SubscribeSync().

What is not solved is the issue, that the stream cannot be resolved from the subject name, if the stream name is not explicitly given and the stream is a mirror of another stream from a different jetstream domain. 

In this case, the documentation "Either a subject or stream must be specified" is not valid, because both settings need to be set.