### PR TITLE
gcp: Switch BigQuery output to Storage Write API.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -129,6 +129,7 @@ require (
 	golang.org/x/sync v0.6.0
 	golang.org/x/text v0.14.0
 	google.golang.org/api v0.157.0
+	google.golang.org/grpc v1.60.1
 	google.golang.org/protobuf v1.32.0
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1
 	gopkg.in/yaml.v3 v3.0.1
@@ -312,7 +313,6 @@ require (
 	google.golang.org/genproto v0.0.0-20240102182953-50ed04b92917 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20240102182953-50ed04b92917 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20240116215550-a9fa1716bcac // indirect
-	google.golang.org/grpc v1.60.1 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/jcmturner/aescts.v1 v1.0.1 // indirect
 	gopkg.in/jcmturner/dnsutils.v1 v1.0.1 // indirect

--- a/internal/impl/gcp/fake_bigquery_storage_server.go
+++ b/internal/impl/gcp/fake_bigquery_storage_server.go
@@ -1,0 +1,87 @@
+package gcp
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+
+	"cloud.google.com/go/bigquery/storage/apiv1/storagepb"
+)
+
+const (
+	// Test messages.
+	msg1 = `{"what1":"meow1","what2":1,"what3":true}`
+	msg2 = `{"what1":"meow2","what2":2,"what3":false}`
+)
+
+var (
+	// Protobuf-encoded variants of msg1 (different field orderings).
+	msg1EncodedV1 = []byte{10, 5, 109, 101, 111, 119, 49, 16, 1, 24, 1}
+	msg1EncodedV2 = []byte{24, 1, 10, 5, 109, 101, 111, 119, 49, 16, 1}
+	msg1EncodedV3 = []byte{16, 1, 24, 1, 10, 5, 109, 101, 111, 119, 49}
+
+	// Protobuf-encoded variants of msg2 (different field orderings).
+	msg2EncodedV1 = []byte{10, 5, 109, 101, 111, 119, 50, 16, 2}
+	msg2EncodedV2 = []byte{24, 1, 10, 5, 109, 101, 111, 119, 49, 16, 1}
+	msg2EncodedV3 = []byte{16, 2, 10, 5, 109, 101, 111, 119, 50}
+)
+
+type fakeBigQueryWriteServer struct {
+	storagepb.UnimplementedBigQueryWriteServer
+
+	// Internal state captured from AppendRows.
+	Data []byte
+}
+
+func (f *fakeBigQueryWriteServer) GetWriteStream(ctx context.Context, req *storagepb.GetWriteStreamRequest) (*storagepb.WriteStream, error) {
+	return &storagepb.WriteStream{}, nil
+}
+
+func (f *fakeBigQueryWriteServer) AppendRows(stream storagepb.BigQueryWrite_AppendRowsServer) error {
+	for {
+		req, err := stream.Recv()
+		if err == io.EOF {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		for _, row := range req.GetProtoRows().GetRows().GetSerializedRows() {
+			msg, err := decodeRow(row)
+			if err != nil {
+				return err
+			}
+			f.Data = append(f.Data, []byte(msg)...)
+			f.Data = append(f.Data, byte('\n'))
+		}
+		resp := &storagepb.AppendRowsResponse{
+			WriteStream: "_default",
+		}
+		if err := stream.Send(resp); err != nil {
+			return err
+		}
+	}
+}
+
+func decodeRow(row []byte) (string, error) {
+	if bytes.Equal(row, msg1EncodedV1) {
+		return msg1, nil
+	}
+	if bytes.Equal(row, msg1EncodedV2) {
+		return msg1, nil
+	}
+	if bytes.Equal(row, msg1EncodedV3) {
+		return msg1, nil
+	}
+	if bytes.Equal(row, msg2EncodedV1) {
+		return msg2, nil
+	}
+	if bytes.Equal(row, msg2EncodedV2) {
+		return msg2, nil
+	}
+	if bytes.Equal(row, msg2EncodedV3) {
+		return msg2, nil
+	}
+	return "", fmt.Errorf("cannot decode row: %v", row)
+}

--- a/website/docs/components/outputs/gcp_bigquery.md
+++ b/website/docs/components/outputs/gcp_bigquery.md
@@ -39,7 +39,6 @@ output:
     table: "" # No default (required)
     format: NEWLINE_DELIMITED_JSON
     max_in_flight: 64
-    job_labels: {}
     csv:
       header: []
       field_delimiter: ','
@@ -63,12 +62,6 @@ output:
     table: "" # No default (required)
     format: NEWLINE_DELIMITED_JSON
     max_in_flight: 64
-    write_disposition: WRITE_APPEND
-    create_disposition: CREATE_IF_NEEDED
-    ignore_unknown_values: false
-    max_bad_records: 0
-    auto_detect: false
-    job_labels: {}
     csv:
       header: []
       field_delimiter: ','
@@ -172,56 +165,6 @@ The maximum number of message batches to have in flight at a given time. Increas
 
 Type: `int`  
 Default: `64`  
-
-### `write_disposition`
-
-Specifies how existing data in a destination table is treated.
-
-
-Type: `string`  
-Default: `"WRITE_APPEND"`  
-Options: `WRITE_APPEND`, `WRITE_EMPTY`, `WRITE_TRUNCATE`.
-
-### `create_disposition`
-
-Specifies the circumstances under which destination table will be created. If CREATE_IF_NEEDED is used the GCP BigQuery will create the table if it does not already exist and tables are created atomically on successful completion of a job. The CREATE_NEVER option ensures the table must already exist and will not be automatically created.
-
-
-Type: `string`  
-Default: `"CREATE_IF_NEEDED"`  
-Options: `CREATE_IF_NEEDED`, `CREATE_NEVER`.
-
-### `ignore_unknown_values`
-
-Causes values not matching the schema to be tolerated. Unknown values are ignored. For CSV this ignores extra values at the end of a line. For JSON this ignores named values that do not match any column name. If this field is set to false (the default value), records containing unknown values are treated as bad records. The max_bad_records field can be used to customize how bad records are handled.
-
-
-Type: `bool`  
-Default: `false`  
-
-### `max_bad_records`
-
-The maximum number of bad records that will be ignored when reading data.
-
-
-Type: `int`  
-Default: `0`  
-
-### `auto_detect`
-
-Indicates if we should automatically infer the options and schema for CSV and JSON sources. If the table doesn't exist and this field is set to `false` the output may not be able to insert data and will throw insertion error. Be careful using this field since it delegates to the GCP BigQuery service the schema detection and values like `"no"` may be treated as booleans for the CSV format.
-
-
-Type: `bool`  
-Default: `false`  
-
-### `job_labels`
-
-A list of labels to add to the load job.
-
-
-Type: `object`  
-Default: `{}`  
 
 ### `csv`
 


### PR DESCRIPTION
Currently, the BigQuery output uses the "load jobs" API to batch load data, which works but has limitations when used to make frequent updates as is typically done in a streaming system. For example, the default quota is 1,500 load jobs per table per day, which means you can only create ~1 load job per minute. See:

https://cloud.google.com/bigquery/quotas#load_jobs

The Storage Write API is a newer API that works for both batch and streaming and has some advantages. See:

https://cloud.google.com/bigquery/docs/write-api#advantages

This change switches the BQ output to use the Storage Write API. At a high level, it now creates a "managed stream" and then repeatedly calls `AppendRows` on it to send batches of data. Each row is a seralized protobuf message, and the API uses gRPC bi-directional streaming:

https://github.com/googleapis/googleapis/tree/master/google/cloud/bigquery/storage/v1

Notes:

- Only simple JSON messages have been tested with `STRING`, `INTEGER`, and `DATETIME` fields. CSV messages have not been tested.

- The type of each field in a message needs to be mapped to a protobuf field type for transport, which is handled using reflection and heuristics. To make this work reliably, the BQ table must exist in order to infer the target schema.

- The "default" stream (at-least-once delivery) is always used. Using an application-created stream (exactly-once delivery, ACID features) is not supported.

- The options `write_disposition`, `create_disposition`, `ignore_unknown_values`, `max_bad_records`, and `auto_detect` are no longer supported because they were features of the load jobs API. Some of them could potentially be reimplemented.

- The option `job_labels` is no longer supported because it is specific to the load jobs API.

Fixes: #1167