### PR TITLE
feat(tracing): use component labels as span name if available

### DIFF
--- a/cmd/tools/benthos_docs_gen/bloblang_test.go
+++ b/cmd/tools/benthos_docs_gen/bloblang_test.go
@@ -53,7 +53,7 @@ func TestFunctionExamples(t *testing.T) {
 						"traceparent": "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01",
 					}
 					otel.SetTextMapPropagator(propagation.NewCompositeTextMapPropagator(propagation.TraceContext{}))
-					require.NoError(t, tracing.InitSpansFromParentTextMap(noop.NewTracerProvider(), "test", textMap, msg))
+					require.NoError(t, tracing.InitSpansFromParentTextMap(noop.NewTracerProvider(), "test", "", textMap, msg))
 
 					p, err := m.MapPart(0, msg)
 					exp := io[1]

--- a/internal/component/input/async_reader.go
+++ b/internal/component/input/async_reader.go
@@ -85,7 +85,7 @@ func (r *AsyncReader) loop() {
 		mLostConn   = r.mgr.Metrics().GetCounter("input_connection_lost")
 		mLatency    = r.mgr.Metrics().GetTimer("input_latency_ns")
 
-		traceName = "input_" + r.typeStr
+		spanName = "input_" + r.typeStr
 	)
 
 	closeAtLeisureCtx, calDone := r.shutSig.CloseAtLeisureCtx(context.Background())
@@ -197,7 +197,7 @@ func (r *AsyncReader) loop() {
 		startedAt := time.Now()
 
 		resChan := make(chan error, 1)
-		tracing.InitSpans(r.mgr.Tracer(), traceName, msg)
+		tracing.InitSpans(r.mgr.Tracer(), spanName, r.mgr.Label(), msg)
 		select {
 		case r.transactions <- message.NewTransaction(msg, resChan):
 		case <-r.shutSig.CloseAtLeisureChan():

--- a/internal/component/observability.go
+++ b/internal/component/observability.go
@@ -15,6 +15,7 @@ type Observability interface {
 	Metrics() metrics.Type
 	Logger() log.Modular
 	Tracer() trace.TracerProvider
+	Label() string
 }
 
 type mockObs struct{}
@@ -29,6 +30,10 @@ func (m mockObs) Logger() log.Modular {
 
 func (m mockObs) Tracer() trace.TracerProvider {
 	return noop.NewTracerProvider()
+}
+
+func (m mockObs) Label() string {
+	return ""
 }
 
 // NoopObservability returns an implementation of Observability that does

--- a/internal/component/processor/auto_observed.go
+++ b/internal/component/processor/auto_observed.go
@@ -92,7 +92,7 @@ func (a *v2ToV1Processor) ProcessBatch(ctx context.Context, msg message.Batch) (
 
 	newParts := make([]*message.Part, 0, msg.Len())
 	_ = msg.Iter(func(i int, part *message.Part) error {
-		_, span := tracing.WithChildSpan(a.mgr.Tracer(), a.typeStr, part)
+		_, span := tracing.WithChildSpan(a.mgr.Tracer(), a.typeStr, a.mgr.Label(), part)
 
 		nextParts, err := a.p.Process(ctx, part)
 		if err != nil {
@@ -218,7 +218,7 @@ func (a *v2BatchedToV1Processor) ProcessBatch(ctx context.Context, msg message.B
 	a.mBatchReceived.Incr(1)
 
 	tStarted := time.Now()
-	_, spans := tracing.WithChildSpans(a.mgr.Tracer(), a.typeStr, msg)
+	_, spans := tracing.WithChildSpans(a.mgr.Tracer(), a.typeStr, a.mgr.Label(), msg)
 
 	outputBatches, err := a.p.ProcessBatch(&BatchProcContext{
 		ctx:    ctx,

--- a/internal/httpclient/client.go
+++ b/internal/httpclient/client.go
@@ -305,7 +305,7 @@ func (h *Client) checkStatus(code int) (succeeded bool, retStrat retryStrategy) 
 func (h *Client) SendToResponse(ctx context.Context, sendMsg service.MessageBatch) (res *http.Response, err error) {
 	var spans []*tracing.Span
 	if sendMsg != nil {
-		sendMsg, spans = tracing.WithChildSpans(h.mgr.OtelTracer(), "http_request", sendMsg)
+		sendMsg, spans = tracing.WithChildSpans(h.mgr.OtelTracer(), "http_request", h.mgr.Label(), sendMsg)
 		defer func() {
 			for _, s := range spans {
 				s.Finish()

--- a/internal/impl/io/input_http_server.go
+++ b/internal/impl/io/input_http_server.go
@@ -465,7 +465,7 @@ func (h *httpServerInput) extractMessageFromRequest(r *http.Request) (message.Ba
 		}
 	}
 
-	_ = tracing.InitSpansFromParentTextMap(h.mgr.Tracer(), "input_http_server_post", textMapGeneric, msg)
+	_ = tracing.InitSpansFromParentTextMap(h.mgr.Tracer(), "input_http_server", h.mgr.Label(), textMapGeneric, msg)
 	return msg, nil
 }
 
@@ -742,7 +742,7 @@ func (h *httpServerInput) wsHandler(w http.ResponseWriter, r *http.Request) {
 		for _, c := range r.Cookies() {
 			part.MetaSetMut(c.Name, c.Value)
 		}
-		tracing.InitSpans(h.mgr.Tracer(), "input_http_server_websocket", msg)
+		tracing.InitSpans(h.mgr.Tracer(), "input_http_server_websocket", h.mgr.Label(), msg)
 
 		store := transaction.NewResultStore()
 		transaction.AddResultStore(msg, store)

--- a/internal/impl/pure/processor_branch.go
+++ b/internal/impl/pure/processor_branch.go
@@ -166,6 +166,7 @@ func init() {
 type Branch struct {
 	log    log.Modular
 	tracer trace.TracerProvider
+	label  string
 
 	requestMap *mapping.Executor
 	resultMap  *mapping.Executor
@@ -185,6 +186,7 @@ func newBranchFromParsed(conf *service.ParsedConfig, mgr bundle.NewManagement) (
 	b = &Branch{
 		log:    mgr.Logger(),
 		tracer: mgr.Tracer(),
+		label:  mgr.Label(),
 
 		mReceived:      stats.GetCounter("processor_received"),
 		mBatchReceived: stats.GetCounter("processor_batch_received"),
@@ -283,7 +285,7 @@ func (b *Branch) ProcessBatch(ctx context.Context, batch message.Batch) ([]messa
 	b.mBatchReceived.Incr(1)
 	startedAt := time.Now()
 
-	branchMsg, propSpans := tracing.WithChildSpans(b.tracer, "branch", batch.ShallowCopy())
+	branchMsg, propSpans := tracing.WithChildSpans(b.tracer, "branch", b.label, batch.ShallowCopy())
 	defer func() {
 		for _, s := range propSpans {
 			s.Finish()

--- a/internal/tracing/otel.go
+++ b/internal/tracing/otel.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/propagation"
 	"go.opentelemetry.io/otel/trace"
 
@@ -12,7 +13,8 @@ import (
 )
 
 const (
-	name = "benthos"
+	name                   = "benthos"
+	componentTypeAttribute = "benthos.component.type"
 )
 
 // GetSpan returns a span attached to a message part. Returns nil if the part
@@ -51,14 +53,20 @@ func GetTraceID(p *message.Part) string {
 // WithChildSpan takes a message, extracts a span, creates a new child span,
 // and returns a new message with that span embedded. The original message is
 // unchanged.
-func WithChildSpan(prov trace.TracerProvider, operationName string, part *message.Part) (*message.Part, *Span) {
+func WithChildSpan(prov trace.TracerProvider, componentType string, componentLabel string, part *message.Part) (*message.Part, *Span) {
 	span := GetActiveSpan(part)
+
+	var (
+		spanName      = GetSpanName(componentType, componentLabel)
+		spanAttribute = attribute.String(componentTypeAttribute, componentType)
+	)
+
 	if span == nil {
-		ctx, t := prov.Tracer(name).Start(part.GetContext(), operationName)
+		ctx, t := prov.Tracer(name).Start(part.GetContext(), spanName, trace.WithAttributes(spanAttribute))
 		span = OtelSpan(ctx, t)
 		part = part.WithContext(ctx)
 	} else {
-		ctx, t := prov.Tracer(name).Start(span.ctx, operationName)
+		ctx, t := prov.Tracer(name).Start(span.ctx, spanName, trace.WithAttributes(spanAttribute))
 		span = OtelSpan(ctx, t)
 		part = part.WithContext(ctx)
 	}
@@ -68,7 +76,7 @@ func WithChildSpan(prov trace.TracerProvider, operationName string, part *messag
 // WithChildSpans takes a message, extracts spans per message part, creates new
 // child spans, and returns a new message with those spans embedded. The
 // original message is unchanged.
-func WithChildSpans(prov trace.TracerProvider, operationName string, batch message.Batch) (message.Batch, []*Span) {
+func WithChildSpans(prov trace.TracerProvider, componentType string, componentLabel string, batch message.Batch) (message.Batch, []*Span) {
 	spans := make([]*Span, 0, len(batch))
 	newParts := make(message.Batch, len(batch))
 	for i, part := range batch {
@@ -76,7 +84,7 @@ func WithChildSpans(prov trace.TracerProvider, operationName string, batch messa
 			continue
 		}
 		var otSpan *Span
-		newParts[i], otSpan = WithChildSpan(prov, operationName, part)
+		newParts[i], otSpan = WithChildSpan(prov, componentType, componentLabel, part)
 		spans = append(spans, otSpan)
 	}
 	return newParts, spans
@@ -85,21 +93,28 @@ func WithChildSpans(prov trace.TracerProvider, operationName string, batch messa
 // WithSiblingSpans takes a message, extracts spans per message part, creates
 // new sibling spans, and returns a new message with those spans embedded. The
 // original message is unchanged.
-func WithSiblingSpans(prov trace.TracerProvider, operationName string, batch message.Batch) (message.Batch, []*Span) {
+func WithSiblingSpans(prov trace.TracerProvider, componentType string, componentLabel string, batch message.Batch) (message.Batch, []*Span) {
 	spans := make([]*Span, 0, len(batch))
 	newParts := make([]*message.Part, batch.Len())
+
+	var (
+		spanName      = GetSpanName(componentType, componentLabel)
+		spanAttribute = attribute.String(componentTypeAttribute, componentType)
+	)
+
 	for i, part := range batch {
 		if part == nil {
 			continue
 		}
 		otSpan := GetActiveSpan(part)
 		if otSpan == nil {
-			ctx, t := prov.Tracer(name).Start(part.GetContext(), operationName)
+			ctx, t := prov.Tracer(name).Start(part.GetContext(), spanName, trace.WithAttributes(spanAttribute))
 			otSpan = OtelSpan(ctx, t)
 		} else {
 			ctx, t := prov.Tracer(name).Start(
-				part.GetContext(), operationName,
+				part.GetContext(), spanName,
 				trace.WithLinks(trace.LinkFromContext(otSpan.ctx)),
+				trace.WithAttributes(spanAttribute),
 			)
 			otSpan = OtelSpan(ctx, t)
 		}
@@ -113,25 +128,25 @@ func WithSiblingSpans(prov trace.TracerProvider, operationName string, batch mes
 
 // InitSpans sets up OpenTracing spans on each message part if one does not
 // already exist.
-func InitSpans(prov trace.TracerProvider, operationName string, batch message.Batch) {
+func InitSpans(prov trace.TracerProvider, componentType string, componentLabel string, batch message.Batch) {
 	for i, p := range batch {
-		batch[i] = InitSpan(prov, operationName, p)
+		batch[i] = InitSpan(prov, componentType, componentLabel, p)
 	}
 }
 
 // InitSpan sets up an OpenTracing span on a message part if one does not
 // already exist.
-func InitSpan(prov trace.TracerProvider, operationName string, part *message.Part) *message.Part {
+func InitSpan(prov trace.TracerProvider, componentType string, componentLabel string, part *message.Part) *message.Part {
 	if GetActiveSpan(part) != nil {
 		return part
 	}
-	ctx, _ := prov.Tracer(name).Start(part.GetContext(), operationName)
+	ctx, _ := prov.Tracer(name).Start(part.GetContext(), GetSpanName(componentType, componentLabel), trace.WithAttributes(attribute.String(componentTypeAttribute, componentType)))
 	return message.WithContext(ctx, part)
 }
 
 // InitSpansFromParentTextMap obtains a span parent reference from a text map
 // and creates child spans for each message.
-func InitSpansFromParentTextMap(prov trace.TracerProvider, operationName string, textMapGeneric map[string]any, batch message.Batch) error {
+func InitSpansFromParentTextMap(prov trace.TracerProvider, componentType string, componentLabel string, textMapGeneric map[string]any, batch message.Batch) error {
 	c := propagation.MapCarrier{}
 	for k, v := range textMapGeneric {
 		if vStr, ok := v.(string); ok {
@@ -142,7 +157,7 @@ func InitSpansFromParentTextMap(prov trace.TracerProvider, operationName string,
 	textProp := otel.GetTextMapPropagator()
 	for i, p := range batch {
 		ctx := textProp.Extract(p.GetContext(), c)
-		pCtx, _ := prov.Tracer(name).Start(ctx, operationName)
+		pCtx, _ := prov.Tracer(name).Start(ctx, GetSpanName(componentType, componentLabel), trace.WithAttributes(attribute.String(componentTypeAttribute, componentType)))
 		batch[i] = message.WithContext(pCtx, p)
 	}
 	return nil

--- a/internal/tracing/otel_test.go
+++ b/internal/tracing/otel_test.go
@@ -26,7 +26,7 @@ func TestInitSpansFromParentTextMap(t *testing.T) {
 		otel.SetTextMapPropagator(propagation.NewCompositeTextMapPropagator(propagation.TraceContext{}))
 		tp := noop.NewTracerProvider()
 
-		err := InitSpansFromParentTextMap(tp, "test", textMap, batch)
+		err := InitSpansFromParentTextMap(tp, "test", "", textMap, batch)
 		assert.Nil(t, err)
 
 		spanOne := trace.SpanFromContext(batch[0].GetContext())

--- a/internal/tracing/span.go
+++ b/internal/tracing/span.go
@@ -16,6 +16,15 @@ type Span struct {
 	w   trace.Span
 }
 
+// GetSpanName creates a span name from a component type and a label.
+func GetSpanName(componentType string, label string) string {
+	if label == "" {
+		return componentType
+	}
+
+	return label
+}
+
 // OtelSpan creates a common span from the open telemetry package.
 func OtelSpan(ctx context.Context, s trace.Span) *Span {
 	if s == nil {

--- a/internal/tracing/v2/otel_test.go
+++ b/internal/tracing/v2/otel_test.go
@@ -26,7 +26,7 @@ func TestInitSpansFromParentTextMap(t *testing.T) {
 		otel.SetTextMapPropagator(propagation.NewCompositeTextMapPropagator(propagation.TraceContext{}))
 		tp := noop.NewTracerProvider()
 
-		err := InitSpansFromParentTextMap(tp, "test", textMap, batch)
+		err := InitSpansFromParentTextMap(tp, "test", "", textMap, batch)
 		assert.Nil(t, err)
 
 		spanOne := trace.SpanFromContext(batch[0].Context())

--- a/internal/tracing/v2/span.go
+++ b/internal/tracing/v2/span.go
@@ -16,6 +16,15 @@ type Span struct {
 	w   trace.Span
 }
 
+// GetSpanName creates a span name from a component type and a label.
+func GetSpanName(componentType string, label string) string {
+	if label == "" {
+		return componentType
+	}
+
+	return label
+}
+
 // OtelSpan creates a common span from the open telemetry package.
 func OtelSpan(ctx context.Context, s trace.Span) *Span {
 	if s == nil {


### PR DESCRIPTION
Fixes #1239 

Result example:

![image](https://github.com/benthosdev/benthos/assets/10624972/d3460c02-85c7-4eeb-8b03-f019e8a28eff)

For the following config:

```yaml
# Common config fields, showing default values
input:
  label: "this_is_my_input"
  http_server:
    path: /post/bla

pipeline:
  processors:
    - label: teste
      workflow:
        branches:
          A:
            request_map: |
              root = if this.document.type != "foo" {
                  deleted()
              }
            processors:
              - label: log_something
                log:
                  message: "This is a log message"
            result_map: 'root.tmp.result = this'
          B:
            request_map: |
              root = if this.document.type == "foo" {
                  deleted()
              }
            processors:
              - label: log_something2
                log:
                  message: "This is a log message 2"
            result_map: 'root.tmp.result = this'
          C:
            request_map: |
              root = if this.tmp.result != null {
                  deleted()
              }
            processors:
              - label: log_something3
                log:
                  message: "This is a log message 3"
            result_map: 'root.tmp.result = this'

# Config fields, showing default values
output:
  label: ""
  stdout:
    codec: lines

tracer:
  open_telemetry_collector:
    tags: { "service.name": "my_test" }
    grpc: 
      - url: localhost:4317
```