### PR TITLE
Added direct support for oauth2 tokens in kafka using franz-lib

### DIFF
--- a/internal/impl/kafka/sasl.go
+++ b/internal/impl/kafka/sasl.go
@@ -320,6 +320,7 @@ func SaramaSASLField() *service.ConfigField {
 			Secret(),
 		service.NewStringField(saramaFieldSASLAccessToken).
 			Description("A static OAUTHBEARER access token").
+			Secret().
 			Default(""),
 		service.NewStringField(saramaFieldSASLTokenCache).
 			Description("Instead of using a static `access_token` allows you to query a [`cache`](/docs/components/caches/about) resource to fetch OAUTHBEARER tokens from").

--- a/internal/impl/kafka/sasl.go
+++ b/internal/impl/kafka/sasl.go
@@ -2,8 +2,14 @@ package kafka
 
 import (
 	"context"
+	"encoding/base64"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
 
 	"github.com/IBM/sarama"
 
@@ -42,6 +48,18 @@ func saslField() *service.ConfigField {
 			Default("").Secret(),
 		service.NewStringField("token").
 			Description("The token to use for a single session's OAUTHBEARER authentication.").
+			Default(""),
+		service.NewStringField("tokenEndpoint").
+			Description("The endpoint to use for OAUTHBEARER token acquisition.").
+			Default(""),
+		service.NewStringField("clientId").
+			Description("The client ID to use for OAUTHBEARER token acquisition.").
+			Default(""),
+		service.NewStringField("clientSecret").
+			Description("The client secret to use for OAUTHBEARER token acquisition.").
+			Default("").Secret(),
+		service.NewStringField("scope").
+			Description("The scope to use for OAUTHBEARER token acquisition.").
 			Default(""),
 		service.NewStringMapField("extensions").
 			Description("Key/value pairs to add to OAUTHBEARER authentication requests.").
@@ -129,22 +147,101 @@ func plainSaslFromConfig(c *service.ParsedConfig) (sasl.Mechanism, error) {
 }
 
 func oauthSaslFromConfig(c *service.ParsedConfig) (sasl.Mechanism, error) {
-	token, err := c.FieldString("token")
-	if err != nil {
-		return nil, err
-	}
-	var extensions map[string]string
-	if c.Contains("extensions") {
-		if extensions, err = c.FieldStringMap("extensions"); err != nil {
+	if c.Contains("token") {
+		token, err := c.FieldString("token")
+		if err != nil {
 			return nil, err
 		}
+		var extensions map[string]string
+		if c.Contains("extensions") {
+			if extensions, err = c.FieldStringMap("extensions"); err != nil {
+				return nil, err
+			}
+		}
+		return oauth.Oauth(func(c context.Context) (oauth.Auth, error) {
+			return oauth.Auth{
+				Token:      token,
+				Extensions: extensions,
+			}, nil
+		}), nil
+	} else if c.Contains("tokenEndpoint") {
+		return oauth.Oauth(func(ctx context.Context) (oauth.Auth, error) {
+			shortToken, err := acquireToken(ctx, c)
+			return oauth.Auth{Token: shortToken}, err
+		}), nil
 	}
-	return oauth.Oauth(func(c context.Context) (oauth.Auth, error) {
-		return oauth.Auth{
-			Token:      token,
-			Extensions: extensions,
-		}, nil
-	}), nil
+	return nil, errors.New("field 'token' or 'tokenEndpoint' was not found in the config")
+}
+
+func acquireToken(ctx context.Context, c *service.ParsedConfig) (string, error) {
+
+	tokenEndpoint, err := c.FieldString("tokenEndpoint")
+	if err != nil {
+		return "", err
+	}
+
+	clientId, err := c.FieldString("clientId")
+	if err != nil {
+		return "", err
+	}
+
+	clientSecret, err := c.FieldString("clientSecret")
+	if err != nil {
+		return "", err
+	}
+
+	scope, err := c.FieldString("scope")
+	if err != nil {
+		return "", err
+	}
+
+	authHeaderValue := base64.StdEncoding.EncodeToString([]byte(clientId + ":" + clientSecret))
+
+	queryParams := url.Values{}
+	queryParams.Set("grant_type", "client_credentials")
+	queryParams.Set("scope", scope)
+
+	req, err := http.NewRequestWithContext(ctx, "POST", tokenEndpoint, strings.NewReader(queryParams.Encode()))
+	if err != nil {
+		return "", err
+	}
+
+	req.URL.RawQuery = queryParams.Encode()
+
+	req.Header.Set("Authorization", "Basic "+authHeaderValue)
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", err
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+
+	if err := resp.Body.Close(); err != nil {
+		return "", err
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("token request failed with status code %d", resp.StatusCode)
+	}
+
+	var tokenResponse map[string]interface{}
+	err = json.Unmarshal(body, &tokenResponse)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse token response: %s", err)
+	}
+
+	accessToken, ok := tokenResponse["access_token"].(string)
+	if !ok {
+		return "", fmt.Errorf("access_token not found in token response")
+	}
+
+	return accessToken, nil
 }
 
 func scram256SaslFromConfig(c *service.ParsedConfig) (sasl.Mechanism, error) {

--- a/internal/impl/kafka/sasl.go
+++ b/internal/impl/kafka/sasl.go
@@ -147,8 +147,9 @@ func plainSaslFromConfig(c *service.ParsedConfig) (sasl.Mechanism, error) {
 }
 
 func oauthSaslFromConfig(c *service.ParsedConfig) (sasl.Mechanism, error) {
-	if c.Contains("token") {
-		token, err := c.FieldString("token")
+	token, err := c.FieldString("token")
+
+	if err != nil && token != "" {
 		if err != nil {
 			return nil, err
 		}

--- a/internal/impl/kafka/sasl/sasl.go
+++ b/internal/impl/kafka/sasl/sasl.go
@@ -33,7 +33,7 @@ func FieldSpec() docs.FieldSpec {
 		),
 		docs.FieldString("user", "A PLAIN username. It is recommended that you use environment variables to populate this field.", "${USER}"),
 		docs.FieldString("password", "A PLAIN password. It is recommended that you use environment variables to populate this field.", "${PASSWORD}").Secret(),
-		docs.FieldString("access_token", "A static OAUTHBEARER access token"),
+		docs.FieldString("access_token", "A static OAUTHBEARER access token").Secret(),
 		docs.FieldString("token_cache", "Instead of using a static `access_token` allows you to query a [`cache`](/docs/components/caches/about) resource to fetch OAUTHBEARER tokens from"),
 		docs.FieldString("token_key", "Required when using a `token_cache`, the key to query the cache with for tokens."),
 	).Advanced()

--- a/website/docs/components/inputs/kafka.md
+++ b/website/docs/components/inputs/kafka.md
@@ -391,6 +391,9 @@ password: ${PASSWORD}
 ### `sasl.access_token`
 
 A static OAUTHBEARER access token
+:::warning Secret
+This field contains sensitive information that usually shouldn't be added to a config directly, read our [secrets page for more info](/docs/configuration/secrets).
+:::
 
 
 Type: `string`  

--- a/website/docs/components/inputs/kafka_franz.md
+++ b/website/docs/components/inputs/kafka_franz.md
@@ -410,6 +410,41 @@ The token to use for a single session's OAUTHBEARER authentication.
 Type: `string`  
 Default: `""`  
 
+### `sasl[].tokenEndpoint`
+
+The endpoint to use for OAUTHBEARER token acquisition.
+
+
+Type: `string`  
+Default: `""`  
+
+### `sasl[].clientId`
+
+The client ID to use for OAUTHBEARER token acquisition.
+
+
+Type: `string`  
+Default: `""`  
+
+### `sasl[].clientSecret`
+
+The client secret to use for OAUTHBEARER token acquisition.
+:::warning Secret
+This field contains sensitive information that usually shouldn't be added to a config directly, read our [secrets page for more info](/docs/configuration/secrets).
+:::
+
+
+Type: `string`  
+Default: `""`  
+
+### `sasl[].scope`
+
+The scope to use for OAUTHBEARER token acquisition.
+
+
+Type: `string`  
+Default: `""`  
+
 ### `sasl[].extensions`
 
 Key/value pairs to add to OAUTHBEARER authentication requests.

--- a/website/docs/components/outputs/kafka.md
+++ b/website/docs/components/outputs/kafka.md
@@ -359,6 +359,9 @@ password: ${PASSWORD}
 ### `sasl.access_token`
 
 A static OAUTHBEARER access token
+:::warning Secret
+This field contains sensitive information that usually shouldn't be added to a config directly, read our [secrets page for more info](/docs/configuration/secrets).
+:::
 
 
 Type: `string`  

--- a/website/docs/components/outputs/kafka_franz.md
+++ b/website/docs/components/outputs/kafka_franz.md
@@ -571,6 +571,41 @@ The token to use for a single session's OAUTHBEARER authentication.
 Type: `string`  
 Default: `""`  
 
+### `sasl[].tokenEndpoint`
+
+The endpoint to use for OAUTHBEARER token acquisition.
+
+
+Type: `string`  
+Default: `""`  
+
+### `sasl[].clientId`
+
+The client ID to use for OAUTHBEARER token acquisition.
+
+
+Type: `string`  
+Default: `""`  
+
+### `sasl[].clientSecret`
+
+The client secret to use for OAUTHBEARER token acquisition.
+:::warning Secret
+This field contains sensitive information that usually shouldn't be added to a config directly, read our [secrets page for more info](/docs/configuration/secrets).
+:::
+
+
+Type: `string`  
+Default: `""`  
+
+### `sasl[].scope`
+
+The scope to use for OAUTHBEARER token acquisition.
+
+
+Type: `string`  
+Default: `""`  
+
 ### `sasl[].extensions`
 
 Key/value pairs to add to OAUTHBEARER authentication requests.


### PR DESCRIPTION
Initially I thought it was not supported, but I talked to the author of the library a while ago and got it confirmed:
https://github.com/twmb/franz-go/issues/482

I then implemented the setup in this project:
https://github.com/redpanda-data/console/issues/699

And would like to do the same here.

I prefer not to use the external cache mechanism for oauth2 tokens, also from a security standpoint of having the token stored several places.