### PR TITLE
Support Enhanced Fanout for kinesis inputs

### DIFF
--- a/internal/impl/aws/input_kinesis.go
+++ b/internal/impl/aws/input_kinesis.go
@@ -820,7 +820,9 @@ func (k *kinesisReader) runExplicitShards() {
 						return
 					}
 					failedShards = append(failedShards, shardID)
-					k.log.Errorf("Failed to start stream '%v' shard '%v' consumer: %v", id, shardID, err)
+					if k.conf.EFOConsumerName != "" {
+						k.log.Errorf("Failed to start stream '%v' shard '%v' consumer: %v", id, shardID, err)
+					}
 				}
 			}
 			if len(failedShards) > 0 {

--- a/internal/impl/aws/input_kinesis.go
+++ b/internal/impl/aws/input_kinesis.go
@@ -121,7 +121,7 @@ Use the `+"`batching`"+` fields to configure an optional [batching policy](/docs
 			Examples([]any{"foo", "arn:aws:kinesis:*:111122223333:stream/my-stream"}),
 		service.NewObjectField(kiFieldEnhancedFanout,
 			service.NewStringField(kiefoFieldConsumerName).
-				Description("The name of consumer.").
+				Description("The name of consumer. Will register a new consumer with this name if it isnt already registered.").
 				Default("")).
 			Description("Determines whether to ingest from Kinesis stream where Enhanced Fanout is enabled."),
 		service.NewObjectField(kiFieldDynamoDB,

--- a/internal/impl/aws/input_kinesis_enhanced_fanout.go
+++ b/internal/impl/aws/input_kinesis_enhanced_fanout.go
@@ -1,0 +1,289 @@
+package aws
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/service/kinesis"
+	"github.com/aws/aws-sdk-go-v2/service/kinesis/types"
+	"github.com/cenkalti/backoff/v4"
+)
+
+type efoConsumer struct {
+	consumerName string
+}
+
+func NewEfoConsumer(consumerName string) *efoConsumer {
+	return &efoConsumer{
+		consumerName: consumerName,
+	}
+}
+
+func (k *kinesisReader) registerEfoConsumer(ctx context.Context, info streamInfo, consumerName string) (*string, error) {
+	res, err := k.svc.DescribeStreamConsumer(ctx, &kinesis.DescribeStreamConsumerInput{
+		ConsumerName: &consumerName,
+		StreamARN:    &info.arn,
+	})
+	var consumer *string
+	// if the consumer isnt already registered, register it
+	if err != nil || res.ConsumerDescription == nil {
+		streamOutput, err := k.svc.RegisterStreamConsumer(ctx, &kinesis.RegisterStreamConsumerInput{
+			ConsumerName: &consumerName,
+			StreamARN:    &info.arn,
+		})
+
+		if err != nil {
+			return nil, err
+		}
+
+		if streamOutput.Consumer == nil {
+			return nil, errors.New("failed to register consumer - RegisterStreamConsumer returned nil")
+		}
+
+		consumer = streamOutput.Consumer.ConsumerARN
+	} else {
+		consumer = res.ConsumerDescription.ConsumerARN
+	}
+
+	return consumer, nil
+}
+
+func (k *kinesisReader) runEfoConsumer(wg *sync.WaitGroup, info streamInfo, shardID, startingSequence string) (initErr error) {
+	//register consumer
+	k.log.Info("hitting efo consumer")
+	consumerARN, err := k.registerEfoConsumer(k.ctx, info, k.conf.EFOConsumerName)
+	if err != nil {
+		return err
+	}
+	// busy read from consumer
+	subOutput, err := k.svc.SubscribeToShard(k.ctx, &kinesis.SubscribeToShardInput{
+		ConsumerARN: consumerARN,
+		ShardId:     &shardID,
+		StartingPosition: &types.StartingPosition{
+			Type:           types.ShardIteratorTypeAtSequenceNumber,
+			SequenceNumber: &startingSequence,
+		},
+	})
+
+	if err != nil {
+		return err
+	}
+	pendingChan := make(chan []types.Record)
+
+	go func() {
+		for {
+			select {
+			case <-k.ctx.Done():
+				k.log.Info("closing efo stream")
+				subOutput.GetStream().Close()
+				close(pendingChan)
+				k.log.Info("closed efo stream")
+				return
+
+			case ev := <-subOutput.GetStream().Events():
+				if event, ok := ev.(*types.SubscribeToShardEventStreamMemberSubscribeToShardEvent); !ok {
+					if ev == nil {
+						k.log.Infof("nil evt")
+						continue
+					}
+					k.log.Errorf("Received unexpected non nil event type: %T", ev)
+				} else {
+					if len(event.Value.Records) > 0 {
+						pendingChan <- event.Value.Records
+					}
+				}
+			}
+		}
+	}()
+	// copy code from runConsumer and use a channel to pass to pending
+	defer func() {
+		if initErr != nil {
+			wg.Done()
+			if _, err := k.checkpointer.Checkpoint(context.Background(), info.id, shardID, startingSequence, true); err != nil {
+				k.log.Errorf("Failed to gracefully yield checkpoint: %v\n", err)
+			}
+		}
+	}()
+
+	// Stores records, batches them up, and provides the batches for dispatch,
+	// whilst ensuring only N records are in flight at a given time.
+	var recordBatcher *awsKinesisRecordBatcher
+	if recordBatcher, initErr = k.newAWSKinesisRecordBatcher(info, shardID, startingSequence); initErr != nil {
+		return initErr
+	}
+
+	// Keeps track of retry attempts.
+	boff := k.boffPool.Get().(backoff.BackOff)
+
+	// Stores consumed records that have yet to be added to the batcher.
+	var pending []types.Record
+
+	// Keeps track of the latest state of the consumer.
+	state := awsKinesisConsumerConsuming
+	var pendingMsg asyncMessage
+
+	unblockedChan, blockedChan := make(chan time.Time), make(chan time.Time)
+	close(unblockedChan)
+
+	// Channels (and contexts) representing the four main actions of the
+	// consumer goroutine:
+	// 1. Timed batches, this might be nil when timed batches are disabled.
+	// 2. Record pulling, this might be unblocked (closed channel) when we run
+	//    out of pending records, or a timed channel when our last attempt
+	//    yielded zero records.
+	// 3. Message flush, this is the target of our current batched message, and
+	//    is nil when our current batched message is a zero value (we don't have
+	//    one prepared).
+	// 4. Next commit, is "done" when the next commit is due.
+	var nextTimedBatchChan <-chan time.Time
+	var nextPullChan <-chan time.Time = unblockedChan
+	var nextFlushChan chan<- asyncMessage
+	commitCtx, commitCtxClose := context.WithTimeout(k.ctx, k.commitPeriod)
+
+	go func() {
+		defer func() {
+			commitCtxClose()
+			recordBatcher.Close(context.Background(), state == awsKinesisConsumerFinished)
+			boff.Reset()
+			k.boffPool.Put(boff)
+
+			reason := ""
+			switch state {
+			case awsKinesisConsumerFinished:
+				k.log.Info("kinesis marked as closed")
+				reason = " because the shard is closed"
+				if err := k.checkpointer.Delete(k.ctx, info.id, shardID); err != nil {
+					k.log.Errorf("Failed to remove checkpoint for finished stream '%v' shard '%v': %v", info.id, shardID, err)
+				}
+			case awsKinesisConsumerYielding:
+				reason = " because the shard has been claimed by another client"
+				if err := k.checkpointer.Yield(k.ctx, info.id, shardID, recordBatcher.GetSequence()); err != nil {
+					k.log.Errorf("Failed to yield checkpoint for stolen stream '%v' shard '%v': %v", info.id, shardID, err)
+				}
+			case awsKinesisConsumerClosing:
+				reason = " because the pipeline is shutting down"
+				if _, err := k.checkpointer.Checkpoint(context.Background(), info.id, shardID, recordBatcher.GetSequence(), true); err != nil {
+					k.log.Errorf("Failed to store final checkpoint for stream '%v' shard '%v': %v", info.id, shardID, err)
+				}
+			}
+
+			wg.Done()
+			k.log.Debugf("Closing stream '%v' shard '%v' as client '%v'%v", info.id, shardID, k.checkpointer.clientID, reason)
+		}()
+
+		k.log.Debugf("Consuming stream '%v' shard '%v' as client '%v'", info.id, shardID, k.checkpointer.clientID)
+
+		// Switches our pull chan to unblocked only if it's currently blocked,
+		// as otherwise it's set to a timed channel that we do not want to
+		// disturb.
+		unblockPullChan := func() {
+			if nextPullChan == blockedChan {
+				nextPullChan = unblockedChan
+			}
+		}
+
+		for {
+			var err error
+			// Recieve on the channel being populated by the EFO Stream we've subscribed to.
+			// If its closed, then assume the consumer is finished
+
+			if state == awsKinesisConsumerConsuming && len(pending) == 0 && nextPullChan == unblockedChan {
+				// The getRecords method ensures that it returns the input
+				// iterator whenever it errors out. Therefore, regardless of the
+				// outcome of the call if iter is now empty we have definitely
+				// reached the end of the shard.
+				p, ok := <-pendingChan
+				if !ok {
+					state = awsKinesisConsumerFinished
+				} else {
+					if len(p) > 0 {
+						pending = p
+					}
+				}
+
+			} else {
+				unblockPullChan()
+			}
+
+			if pendingMsg.msg == nil {
+				// If our consumer is finished and we've run out of pending
+				// records then we're done.
+				if len(pending) == 0 && state == awsKinesisConsumerFinished {
+					if pendingMsg, _ = recordBatcher.FlushMessage(k.ctx); pendingMsg.msg == nil {
+						return
+					}
+				} else if recordBatcher.HasPendingMessage() {
+					if pendingMsg, err = recordBatcher.FlushMessage(commitCtx); err != nil {
+						k.log.Errorf("Failed to dispatch message due to checkpoint error: %v\n", err)
+					}
+				} else if len(pending) > 0 {
+					var i int
+					var r types.Record
+					for i, r = range pending {
+						k.log.Infof("adding record to batcher %v", string(r.Data))
+						if recordBatcher.AddRecord(r) {
+							if pendingMsg, err = recordBatcher.FlushMessage(commitCtx); err != nil {
+								k.log.Errorf("Failed to dispatch message due to checkpoint error: %v\n", err)
+							}
+							break
+						}
+					}
+					if pending = pending[i+1:]; len(pending) == 0 {
+						unblockPullChan()
+					}
+				} else {
+					unblockPullChan()
+				}
+			}
+
+			if pendingMsg.msg != nil {
+				nextFlushChan = k.msgChan
+			} else {
+				nextFlushChan = nil
+			}
+
+			if nextTimedBatchChan == nil {
+				k.log.Infof("no timed batcher chan")
+				if tNext, exists := recordBatcher.UntilNext(); exists {
+					nextTimedBatchChan = time.After(tNext)
+					k.log.Infof("new timed chan %v", tNext)
+				} else {
+					k.log.Infof("no timed batcher exists")
+				}
+			}
+
+			select {
+			case <-commitCtx.Done():
+				if k.ctx.Err() != nil {
+					// It could've been our parent context that closed, in which
+					// case we exit.
+					state = awsKinesisConsumerClosing
+					return
+				}
+
+				commitCtxClose()
+				commitCtx, commitCtxClose = context.WithTimeout(k.ctx, k.commitPeriod)
+
+				stillOwned, err := k.checkpointer.Checkpoint(k.ctx, info.id, shardID, recordBatcher.GetSequence(), false)
+				if err != nil {
+					k.log.Errorf("Failed to store checkpoint for Kinesis stream '%v' shard '%v': %v", info.id, shardID, err)
+				} else if !stillOwned {
+					state = awsKinesisConsumerYielding
+					return
+				}
+			case <-nextTimedBatchChan:
+				nextTimedBatchChan = nil
+			case nextFlushChan <- pendingMsg:
+				pendingMsg = asyncMessage{}
+			case <-nextPullChan:
+				nextPullChan = unblockedChan
+			case <-k.ctx.Done():
+				state = awsKinesisConsumerClosing
+				return
+			}
+		}
+	}()
+	return nil
+}

--- a/internal/impl/aws/integration_kinesis_test.go
+++ b/internal/impl/aws/integration_kinesis_test.go
@@ -192,3 +192,127 @@ input:
 		)
 	})
 }
+
+func TestIntegrationAWSKinesisWithEfoEnabledInput(t *testing.T) {
+	integration.CheckSkip(t)
+	t.Parallel()
+
+	pool, err := dockertest.NewPool("")
+	require.NoError(t, err)
+
+	pool.MaxWait = time.Minute * 2
+	if dline, ok := t.Deadline(); ok && time.Until(dline) < pool.MaxWait {
+		pool.MaxWait = time.Until(dline)
+	}
+
+	resource, err := pool.RunWithOptions(&dockertest.RunOptions{
+		Repository:   "localstack/localstack",
+		ExposedPorts: []string{"4566/tcp"},
+		Env:          []string{"SERVICES=dynamodb,kinesis"},
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		assert.NoError(t, pool.Purge(resource))
+	})
+
+	_ = resource.Expire(900)
+
+	require.NoError(t, pool.Retry(func() error {
+		_, err := createKinesisShards(context.Background(), t, resource.GetPort("4566/tcp"), "testtable", 2)
+		return err
+	}))
+
+	template := `
+output:
+  aws_kinesis:
+    endpoint: http://localhost:$PORT
+    region: us-east-1
+    stream: stream-$ID
+    partition_key: ${! uuid_v4() }
+    max_in_flight: $MAX_IN_FLIGHT
+    credentials:
+      id: xxxxx
+      secret: xxxxx
+      token: xxxxx
+    batching:
+      count: $OUTPUT_BATCH_COUNT
+
+input:
+  aws_kinesis:
+    endpoint: http://localhost:$PORT
+    streams: [ stream-$ID$VAR1 ]
+	enhanced_fanout:
+	  consumer_name: test_consumer
+    checkpoint_limit: $VAR2
+    dynamodb:
+      table: stream-$ID
+      create: true
+    start_from_oldest: true
+    region: us-east-1
+    credentials:
+      id: xxxxx
+      secret: xxxxx
+      token: xxxxx
+`
+
+	suite := integration.StreamTests(
+		integration.StreamTestOpenClose(),
+		integration.StreamTestSendBatch(10),
+		integration.StreamTestSendBatchCount(10),
+		integration.StreamTestStreamSequential(200),
+		integration.StreamTestStreamParallel(200),
+		integration.StreamTestStreamParallelLossy(200),
+		integration.StreamTestStreamParallelLossyThroughReconnect(200),
+	)
+
+	t.Run("with static shards", func(t *testing.T) {
+		suite.Run(
+			t, template,
+			integration.StreamTestOptPreTest(func(t testing.TB, ctx context.Context, testID string, vars *integration.StreamTestConfigVars) {
+				streamName := "stream-" + testID
+				shards, err := createKinesisShards(ctx, t, resource.GetPort("4566/tcp"), testID, 2)
+				require.NoError(t, err)
+
+				for i, shard := range shards {
+					if i == 0 {
+						vars.Var1 = fmt.Sprintf(":%v", shard)
+					} else {
+						vars.Var1 += fmt.Sprintf(",%v:%v", streamName, shard)
+					}
+				}
+			}),
+			integration.StreamTestOptPort(resource.GetPort("4566/tcp")),
+			integration.StreamTestOptAllowDupes(),
+			integration.StreamTestOptVarTwo("10"),
+		)
+	})
+
+	t.Run("with balanced shards", func(t *testing.T) {
+		suite.Run(
+			t, template,
+			integration.StreamTestOptPreTest(func(t testing.TB, ctx context.Context, testID string, vars *integration.StreamTestConfigVars) {
+				_, err := createKinesisShards(ctx, t, resource.GetPort("4566/tcp"), testID, 2)
+				require.NoError(t, err)
+			}),
+			integration.StreamTestOptPort(resource.GetPort("4566/tcp")),
+			integration.StreamTestOptAllowDupes(),
+			integration.StreamTestOptVarTwo("10"),
+		)
+	})
+
+	t.Run("single shard", func(t *testing.T) {
+		integration.StreamTests(
+			integration.StreamTestCheckpointCapture(),
+		).Run(
+			t, template,
+			integration.StreamTestOptPreTest(func(t testing.TB, ctx context.Context, testID string, vars *integration.StreamTestConfigVars) {
+				shards, err := createKinesisShards(ctx, t, resource.GetPort("4566/tcp"), testID, 1)
+				require.NoError(t, err)
+				vars.Var1 = ":" + shards[0]
+			}),
+			integration.StreamTestOptPort(resource.GetPort("4566/tcp")),
+			integration.StreamTestOptAllowDupes(),
+			integration.StreamTestOptVarTwo("10"),
+		)
+	})
+}

--- a/internal/impl/aws/integration_kinesis_test.go
+++ b/internal/impl/aws/integration_kinesis_test.go
@@ -241,8 +241,8 @@ input:
   aws_kinesis:
     endpoint: http://localhost:$PORT
     streams: [ stream-$ID$VAR1 ]
-	enhanced_fanout:
-	  consumer_name: test_consumer
+    enhanced_fanout:
+      consumer_name: test_consumer
     checkpoint_limit: $VAR2
     dynamodb:
       table: stream-$ID

--- a/website/docs/components/inputs/aws_kinesis.md
+++ b/website/docs/components/inputs/aws_kinesis.md
@@ -134,7 +134,7 @@ Type: `object`
 
 ### `enhanced_fanout.consumer_name`
 
-The name of consumer.
+The name of consumer. Will register a new consumer with this name if it isnt already registered.
 
 
 Type: `string`  

--- a/website/docs/components/inputs/aws_kinesis.md
+++ b/website/docs/components/inputs/aws_kinesis.md
@@ -33,6 +33,8 @@ input:
   label: ""
   aws_kinesis:
     streams: [] # No default (required)
+    enhanced_fanout:
+      consumer_name: ""
     dynamodb:
       table: ""
       create: false
@@ -55,6 +57,8 @@ input:
   label: ""
   aws_kinesis:
     streams: [] # No default (required)
+    enhanced_fanout:
+      consumer_name: ""
     dynamodb:
       table: ""
       create: false
@@ -120,6 +124,21 @@ streams:
   - foo
   - arn:aws:kinesis:*:111122223333:stream/my-stream
 ```
+
+### `enhanced_fanout`
+
+Determines whether to ingest from Kinesis stream where Enhanced Fanout is enabled.
+
+
+Type: `object`  
+
+### `enhanced_fanout.consumer_name`
+
+The name of consumer.
+
+
+Type: `string`  
+Default: `""`  
 
 ### `dynamodb`
 


### PR DESCRIPTION
This adds a new config field to the `aws_kinesis` input that allow for Benthos to ingest from a Kinesis stream using [EFO](https://aws.amazon.com/blogs/aws/kds-enhanced-fanout/), plus an integration test (that is functionally the same as the existing test, but with added EFO goodness)