### PR TITLE
added support for `new` and `last_per_subject` delivery strategies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ TODO.md
 release_notes.md
 .idea
 .vscode
+.op

--- a/internal/impl/nats/input_jetstream.go
+++ b/internal/impl/nats/input_jetstream.go
@@ -68,8 +68,10 @@ You can access these metadata fields using
 			Description("Indicates that the subscription should use an existing consumer.").
 			Optional()).
 		Field(service.NewStringAnnotatedEnumField("deliver", map[string]string{
-			"all":  "Deliver all available messages.",
-			"last": "Deliver starting with the last published messages.",
+			"all":              "Deliver all available messages.",
+			"last":             "Deliver starting with the last published messages.",
+			"last_per_subject": "Deliver starting with the last published message per subject.",
+			"new":              "Deliver starting from now, not taking into account any previous messages.",
 		}).
 			Description("Determines which messages to deliver when consuming without a durable subscriber.").
 			Default("all")).
@@ -153,6 +155,10 @@ func newJetStreamReaderFromConfig(conf *service.ParsedConfig, mgr *service.Resou
 		j.deliverOpt = nats.DeliverAll()
 	case "last":
 		j.deliverOpt = nats.DeliverLast()
+	case "last_per_subject":
+		j.deliverOpt = nats.DeliverLastPerSubject()
+	case "new":
+		j.deliverOpt = nats.DeliverNew()
 	default:
 		return nil, fmt.Errorf("deliver option %v was not recognised", deliver)
 	}

--- a/website/docs/components/inputs/nats_jetstream.md
+++ b/website/docs/components/inputs/nats_jetstream.md
@@ -213,6 +213,8 @@ Default: `"all"`
 |---|---|
 | `all` | Deliver all available messages. |
 | `last` | Deliver starting with the last published messages. |
+| `last_per_subject` | Deliver starting with the last published message per subject. |
+| `new` | Deliver starting from now, not taking into account any previous messages. |
 
 
 ### `ack_wait`


### PR DESCRIPTION
NATS supports the retrieval of last messages per subject and only new messages. Now benthos does as well