### PR TITLE
Fix DockerHub REST API examples

### DIFF
--- a/config/examples/track_benthos_downloads.yaml
+++ b/config/examples/track_benthos_downloads.yaml
@@ -1,7 +1,7 @@
 pipeline:
   threads: 20
   processors:
-    - bloblang: 'root = {}'
+    - mapping: 'root = {}'
     - workflow:
         meta_path: results
         order: [ [ dockerhub, github, homebrew ] ]
@@ -17,7 +17,9 @@ processor_resources:
               url: https://hub.docker.com/v2/repositories/jeffail/benthos/
               verb: GET
               retries: 0
-          - bloblang: |
+              headers:
+                Content-Type: application/json
+          - mapping: |
               root.source = "docker"
               root.dist = "docker"
               root.download_count = this.pull_count
@@ -34,7 +36,7 @@ processor_resources:
               url: https://api.github.com/repos/benthosdev/benthos/releases
               verb: GET
               retries: 0
-          - bloblang: |
+          - mapping: |
               root = this.map_each(release -> release.assets.map_each(asset -> {
                 "source":         "github",
                 "dist":           asset.name.re_replace_all("^benthos-?((lambda_)|_)[0-9\\.]+(-rc[0-9]+)?_([^\\.]+).*", "$2$4"),
@@ -44,7 +46,7 @@ processor_resources:
           - unarchive:
               format: json_array
           - resource: metric_gauge
-          - bloblang: 'root = if batch_index() != 0 { deleted() }'
+          - mapping: 'root = if batch_index() != 0 { deleted() }'
 
   - label: homebrew
     branch:
@@ -55,7 +57,7 @@ processor_resources:
               url: https://formulae.brew.sh/api/formula/benthos.json
               verb: GET
               retries: 0
-          - bloblang: |
+          - mapping: |
               root.source = "homebrew"
               root.dist = "brew"
               root.download_count = this.analytics.install.30d.benthos

--- a/internal/impl/io/processor_http.go
+++ b/internal/impl/io/processor_http.go
@@ -51,6 +51,8 @@ pipeline:
           - http:
               url: https://hub.docker.com/v2/repositories/jeffail/benthos
               verb: GET
+              headers:
+                Content-Type: application/json
         result_map: 'root.repo.status = this'
 `,
 		).

--- a/internal/impl/pure/processor_branch.go
+++ b/internal/impl/pure/processor_branch.go
@@ -56,6 +56,8 @@ pipeline:
           - http:
               url: https://hub.docker.com/v2/repositories/jeffail/benthos
               verb: GET
+              headers:
+                Content-Type: application/json
         result_map: root.image.pull_count = this.pull_count
 
 # Example input:  {"id":"foo","some":"pre-existing data"}

--- a/website/cookbooks/custom_metrics.md
+++ b/website/cookbooks/custom_metrics.md
@@ -88,7 +88,7 @@ pipeline:
         verb: GET
 
     - metric:
-        type: gauge 
+        type: gauge
         name: downloads
         labels:
           source: homebrew
@@ -139,6 +139,8 @@ Easy! The Dockerhub API is also pretty simple, and adding it to our pipeline is 
 +    - http:
 +        url: https://hub.docker.com/v2/repositories/jeffail/benthos/
 +        verb: GET
++        headers:
++          Content-Type: application/json
 +
 +    - metric:
 +        type: gauge
@@ -169,7 +171,7 @@ pipeline:
         verb: GET
 
     - metric:
-        type: gauge 
+        type: gauge
         name: downloads
         labels:
           source: homebrew
@@ -180,6 +182,8 @@ pipeline:
     - http:
         url: https://hub.docker.com/v2/repositories/jeffail/benthos/
         verb: GET
+        headers:
+          Content-Type: application/json
 
     - metric:
         type: gauge
@@ -305,6 +309,8 @@ processor_resources:
           - http:
               url: https://hub.docker.com/v2/repositories/jeffail/benthos/
               verb: GET
+              headers:
+                Content-Type: application/json
           - mapping: |
               root.source = "docker"
               root.dist = "docker"

--- a/website/docs/components/processors/branch.md
+++ b/website/docs/components/processors/branch.md
@@ -127,6 +127,8 @@ pipeline:
           - http:
               url: https://hub.docker.com/v2/repositories/jeffail/benthos
               verb: GET
+              headers:
+                Content-Type: application/json
         result_map: root.image.pull_count = this.pull_count
 
 # Example input:  {"id":"foo","some":"pre-existing data"}

--- a/website/docs/components/processors/http.md
+++ b/website/docs/components/processors/http.md
@@ -144,6 +144,8 @@ pipeline:
           - http:
               url: https://hub.docker.com/v2/repositories/jeffail/benthos
               verb: GET
+              headers:
+                Content-Type: application/json
         result_map: 'root.repo.status = this'
 ```
 


### PR DESCRIPTION
Fixes #2422.

Looks like DockerHub now rejects the default `Content-Type:application/octet-stream` header which Benthos sends by default with HTTP error 406.