### PR TITLE
Prepare for pr 2458: fix misspell

### DIFF
--- a/internal/docs/format_yaml.go
+++ b/internal/docs/format_yaml.go
@@ -261,7 +261,7 @@ func SanitiseYAML(cType Type, node *yaml.Node, conf SanitiseConfig) error {
 		if node.Content[i].Value == "plugin" && cSpec.Plugin {
 			if !yamlIsNil(node.Content[i+1]) {
 				// Plugin conf is here but the value is null because it's
-				// non-existant. This can happen in cases where a config is
+				// non-existent. This can happen in cases where a config is
 				// parsed out with `{type: foo}` form.
 				node.Content[i].Value = name
 			}

--- a/internal/impl/gcp/output_pubsub.go
+++ b/internal/impl/gcp/output_pubsub.go
@@ -89,7 +89,7 @@ pipeline:
 				Description("For a given topic, configures the PubSub client's internal buffer for messages to be published.").
 				Advanced(),
 			service.NewBatchPolicyField("batching").
-				Description("Configures a batching policy on this output. While the PubSub client maintains its own internal buffering mechanism, preparing larger batches of messages can futher trade-off some latency for throughput."),
+				Description("Configures a batching policy on this output. While the PubSub client maintains its own internal buffering mechanism, preparing larger batches of messages can further trade-off some latency for throughput."),
 		)
 }
 

--- a/website/docs/components/outputs/gcp_pubsub.md
+++ b/website/docs/components/outputs/gcp_pubsub.md
@@ -243,7 +243,7 @@ Options: `ignore`, `block`, `signal_error`.
 
 ### `batching`
 
-Configures a batching policy on this output. While the PubSub client maintains its own internal buffering mechanism, preparing larger batches of messages can futher trade-off some latency for throughput.
+Configures a batching policy on this output. While the PubSub client maintains its own internal buffering mechanism, preparing larger batches of messages can further trade-off some latency for throughput.
 
 
 Type: `object`  

--- a/website/docs/components/outputs/gcp_pubsub.md
+++ b/website/docs/components/outputs/gcp_pubsub.md
@@ -243,7 +243,7 @@ Options: `ignore`, `block`, `signal_error`.
 
 ### `batching`
 
-Configures a batching policy on this output. While the PubSub client maintains its own internal buffering mechanism, preparing larger batches of messages can further trade-off some latency for throughput.
+Configures a batching policy on this output. While the PubSub client maintains its own internal buffering mechanism, preparing larger batches of messages can futher trade-off some latency for throughput.
 
 
 Type: `object`  


### PR DESCRIPTION
this is a preparation for pull request https://github.com/benthosdev/benthos/pull/2458

just run linter misspell and autofix

did not enable misspell

enjoy