### PR TITLE
Fix deadlock in nats_kv cache

### DIFF
--- a/internal/impl/nats/cache_kv.go
+++ b/internal/impl/nats/cache_kv.go
@@ -89,16 +89,16 @@ func (p *kvCache) connect(ctx context.Context) error {
 	}
 
 	var err error
-
-	defer func() {
-		if err != nil {
-			p.disconnect()
-		}
-	}()
-
 	if p.natsConn, err = p.connDetails.get(ctx); err != nil {
 		return err
 	}
+
+	defer func() {
+		if err != nil {
+			p.natsConn.Close()
+			p.natsConn = nil
+		}
+	}()
 
 	var js nats.JetStreamContext
 	if js, err = p.natsConn.JetStream(); err != nil {


### PR DESCRIPTION
The process will exit if connect() fails, but it's probably best to up resources anyway.