### PR TITLE
Fix `azure_blob_storage` input pagination

### DIFF
--- a/internal/impl/azure/input_blob_storage.go
+++ b/internal/impl/azure/input_blob_storage.go
@@ -150,7 +150,6 @@ func newAzureObjectTarget(key string, ackFn codec.ReaderAckFn) *azureObjectTarge
 //------------------------------------------------------------------------------
 
 func deleteAzureObjectAckFn(
-	ctx context.Context,
 	client *azblob.Client,
 	containerName string,
 	key string,
@@ -202,7 +201,7 @@ func newAzureTargetReader(ctx context.Context, conf bsiConfig) (*azureTargetRead
 			return nil, fmt.Errorf("error getting page of blobs: %w", err)
 		}
 		for _, blob := range page.Segment.BlobItems {
-			ackFn := deleteAzureObjectAckFn(ctx, conf.client, conf.Container, *blob.Name, conf.DeleteObjects, nil)
+			ackFn := deleteAzureObjectAckFn(conf.client, conf.Container, *blob.Name, conf.DeleteObjects, nil)
 			staticKeys.pending = append(staticKeys.pending, newAzureObjectTarget(*blob.Name, ackFn))
 		}
 		staticKeys.pager = pager
@@ -219,7 +218,7 @@ func (s *azureTargetReader) Pop(ctx context.Context) (*azureObjectTarget, error)
 			return nil, fmt.Errorf("error getting page of blobs: %w", err)
 		}
 		for _, blob := range page.Segment.BlobItems {
-			ackFn := deleteAzureObjectAckFn(ctx, s.conf.client, s.conf.Container, *blob.Name, s.conf.DeleteObjects, nil)
+			ackFn := deleteAzureObjectAckFn(s.conf.client, s.conf.Container, *blob.Name, s.conf.DeleteObjects, nil)
 			s.pending = append(s.pending, newAzureObjectTarget(*blob.Name, ackFn))
 		}
 	}


### PR DESCRIPTION
I wonder if this is the right way to implement it... I noticed that we can cache the pager that's returned by `NewListBlobsFlatPager()` which I think avoids some extra calls, but it needs testing with a large bucket that has over 5k items due to the way `MaxResults` is implemented (details [here](https://learn.microsoft.com/en-us/rest/api/storageservices/list-blobs?tabs=microsoft-entra-id#uri-parameters)).