### PR TITLE
Silence some output logs

### DIFF
--- a/internal/impl/aws/output_dynamodb.go
+++ b/internal/impl/aws/output_dynamodb.go
@@ -234,7 +234,7 @@ func (d *dynamoDBWriter) Connect(ctx context.Context) error {
 	}
 
 	d.client = client
-	d.log.Infof("Sending messages to DynamoDB table: %v\n", d.conf.Table)
+	d.log.Debugf("Sending messages to DynamoDB table: %v\n", d.conf.Table)
 	return nil
 }
 

--- a/internal/impl/aws/output_kinesis.go
+++ b/internal/impl/aws/output_kinesis.go
@@ -196,7 +196,7 @@ func (a *kinesisWriter) Connect(ctx context.Context) error {
 
 	a.streamARN = *out.StreamDescription.StreamARN
 	a.kinesis = k
-	a.log.Infof("Sending messages to Kinesis stream: %v\n", a.conf.Stream)
+	a.log.Debugf("Sending messages to Kinesis stream: %v\n", a.conf.Stream)
 
 	return nil
 }

--- a/internal/impl/aws/output_kinesis_firehose.go
+++ b/internal/impl/aws/output_kinesis_firehose.go
@@ -151,7 +151,7 @@ func (a *kinesisFirehoseWriter) Connect(ctx context.Context) error {
 		return err
 	}
 
-	a.log.Infof("Sending messages to Kinesis Firehose delivery stream: %v\n", a.conf.Stream)
+	a.log.Debugf("Sending messages to Kinesis Firehose delivery stream: %v\n", a.conf.Stream)
 	return nil
 }
 

--- a/internal/impl/aws/output_sns.go
+++ b/internal/impl/aws/output_sns.go
@@ -135,7 +135,7 @@ func (a *snsWriter) Connect(ctx context.Context) error {
 	}
 	a.sns = sns.NewFromConfig(a.conf.aconf)
 
-	a.log.Infof("Sending messages to Amazon SNS ARN: %v\n", a.conf.TopicArn)
+	a.log.Debugf("Sending messages to Amazon SNS ARN: %v\n", a.conf.TopicArn)
 	return nil
 }
 

--- a/internal/impl/aws/output_sqs.go
+++ b/internal/impl/aws/output_sqs.go
@@ -158,7 +158,7 @@ func (a *sqsWriter) Connect(ctx context.Context) error {
 	}
 
 	a.sqs = sqs.NewFromConfig(a.conf.aconf)
-	a.log.Infof("Sending messages to Amazon SQS URL: %v\n", a.conf.URL)
+	a.log.Debugf("Sending messages to Amazon SQS URL: %v\n", a.conf.URL)
 	return nil
 }
 

--- a/internal/impl/cassandra/output.go
+++ b/internal/impl/cassandra/output.go
@@ -176,7 +176,7 @@ func (c *cassandraWriter) Connect(ctx context.Context) error {
 	}
 
 	c.session = session
-	c.log.Infof("Sending messages to Cassandra: %v\n", c.clientConf.addresses)
+	c.log.Debugf("Sending messages to Cassandra: %v\n", c.clientConf.addresses)
 	return nil
 }
 

--- a/internal/impl/elasticsearch/output.go
+++ b/internal/impl/elasticsearch/output.go
@@ -297,7 +297,7 @@ func (e *Output) Connect(ctx context.Context) error {
 	}
 
 	e.client = client
-	e.log.Infof("Sending messages to Elasticsearch index at urls: %s\n", e.conf.urls)
+	e.log.Debugf("Sending messages to Elasticsearch index at urls: %s", e.conf.urls)
 	return nil
 }
 

--- a/internal/impl/opensearch/output.go
+++ b/internal/impl/opensearch/output.go
@@ -231,7 +231,7 @@ func (e *Output) Connect(ctx context.Context) error {
 	}
 
 	e.client = client
-	e.log.Infof("Sending messages to Elasticsearch index at urls: %s\n", e.conf.clientOpts.Client.Addresses)
+	e.log.Debugf("Sending messages to Elasticsearch index at urls: %s\n", e.conf.clientOpts.Client.Addresses)
 	return nil
 }
 


### PR DESCRIPTION
Fixes #2489.

Not sure if logging this entry is really all that useful TBH. Maybe we should remove it entirely? It doesn't seem to be consistent across all outputs anyway.