### PR TITLE
Add nats_reply_subject to NATS message metadata

### DIFF
--- a/internal/impl/nats/input.go
+++ b/internal/impl/nats/input.go
@@ -24,6 +24,7 @@ This input adds the following metadata fields to each message:
 
 ` + "``` text" + `
 - nats_subject
+- nats_reply_subject
 - All message headers (when supported by the connection)
 ` + "```" + `
 
@@ -198,6 +199,7 @@ func (n *natsReader) Read(ctx context.Context) (*service.Message, service.AckFun
 
 	bmsg := service.NewMessage(msg.Data)
 	bmsg.MetaSetMut("nats_subject", msg.Subject)
+	bmsg.MetaSetMut("nats_reply_subject", msg.Reply)
 	// process message headers if server supports the feature
 	if natsConn.HeadersSupported() {
 		for key := range msg.Header {


### PR DESCRIPTION
This is not an ideal solution to #2232, but this change does make it possible to reply to NATS requests. Just add a NATS output that publishes on the subject `${! metadata("nats_reply_subject") }`. Even with the more ideal `sync_response` implementation, I think this would still be good to have.