### PR TITLE
Fix parse_form_url_encoded bloblang method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ All notable changes to this project will be documented in this file.
 - The `nats_kv` processor `history` operation now returns a single message with an array of objects containing the record fields instead of a batch of messages.
 - Field `timeout` added to the `nats_kv` processor to specify the maximum period to wait on an operation before aborting and returning an error.
 - Bloblang comparison operators (`>`, `<`, `<=`, `>=`) now match the precision of the compared integers when applicable.
+- The `parse_form_url_encoded` Bloblang method no longer produces results with an unknown data type for repeated query parameters.
 
 ### Changed
 

--- a/internal/impl/pure/bloblang_string.go
+++ b/internal/impl/pure/bloblang_string.go
@@ -17,8 +17,8 @@ func init() {
 			Description(`Attempts to parse a url-encoded query string (from an x-www-form-urlencoded request body) and returns a structured result.`).
 			Example("", `root.values = this.body.parse_form_url_encoded()`,
 				[2]string{
-					`{"body":"noise=meow&animal=cat"}`,
-					`{"values":{"animal":"cat","noise":"meow"}}`,
+					`{"body":"noise=meow&animal=cat&fur=orange&fur=fluffy"}`,
+					`{"values":{"animal":"cat","fur":["orange","fluffy"],"noise":"meow"}}`,
 				},
 			),
 		func(args *bloblang.ParsedParams) (bloblang.Method, error) {
@@ -35,13 +35,17 @@ func init() {
 }
 
 func urlValuesToMap(values url.Values) map[string]any {
-	root := make(map[string]any)
+	root := make(map[string]any, len(values))
 
 	for k, v := range values {
 		if len(v) == 1 {
 			root[k] = v[0]
 		} else {
-			root[k] = v
+			elements := make([]any, 0, len(v))
+			for _, e := range v {
+				elements = append(elements, e)
+			}
+			root[k] = elements
 		}
 	}
 

--- a/internal/impl/pure/bloblang_string_test.go
+++ b/internal/impl/pure/bloblang_string_test.go
@@ -30,7 +30,7 @@ func TestParseUrlencoded(t *testing.T) {
 			method: "parse_form_url_encoded",
 			target: "usernames=userA&usernames=userB",
 			args:   []any{},
-			exp:    map[string]any{"usernames": []string{"userA", "userB"}},
+			exp:    map[string]any{"usernames": []any{"userA", "userB"}},
 		},
 		{
 			name:   "decodes data correctly",

--- a/website/docs/guides/bloblang/methods.md
+++ b/website/docs/guides/bloblang/methods.md
@@ -2923,8 +2923,8 @@ Attempts to parse a url-encoded query string (from an x-www-form-urlencoded requ
 ```coffee
 root.values = this.body.parse_form_url_encoded()
 
-# In:  {"body":"noise=meow&animal=cat"}
-# Out: {"values":{"animal":"cat","noise":"meow"}}
+# In:  {"body":"noise=meow&animal=cat&fur=orange&fur=fluffy"}
+# Out: {"values":{"animal":"cat","fur":["orange","fluffy"],"noise":"meow"}}
 ```
 
 ### `parse_json`


### PR DESCRIPTION
Use correct data type when a query parameter is repeated multiple times.