### PR TITLE
Add `persistent` field to the `amqp_1` output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to this project will be documented in this file.
 - New `reject_errored` output.
 - New `nats_request_reply` processor.
 - New `json_documents` scanner.
+- Field `persistent` added to the `amqp_1` output to specify whether message delivery should be persistent.
 
 ### Fixed
 

--- a/internal/impl/amqp1/config.go
+++ b/internal/impl/amqp1/config.go
@@ -28,6 +28,7 @@ const (
 	targetAddrField  = "target_address"
 	appPropsMapField = "application_properties_map"
 	metaFilterField  = "metadata"
+	persistentField  = "persistent"
 )
 
 // ErrSASLMechanismNotSupported is returned if a SASL mechanism was not recognized.

--- a/website/docs/components/outputs/amqp_1.md
+++ b/website/docs/components/outputs/amqp_1.md
@@ -62,6 +62,7 @@ output:
       password: ""
     metadata:
       exclude_prefixes: []
+    persistent: false
 ```
 
 </TabItem>
@@ -338,5 +339,13 @@ Provide a list of explicit metadata key prefixes to be excluded when adding meta
 
 Type: `array`  
 Default: `[]`  
+
+### `persistent`
+
+Whether message delivery should be persistent (transient by default).
+
+
+Type: `bool`  
+Default: `false`  
 
 


### PR DESCRIPTION
The `amqp_0_9` has this field already: https://www.benthos.dev/docs/components/outputs/amqp_0_9/#persistent

Implementation inspired from here: https://github.com/Azure/go-amqp/issues/11

This omission was reported on Slack: https://gophers.slack.com/archives/CLWCBK7FY/p1713189832118529

TODO:
- [ ] Wait for confirmation that it works as expected