### PR TITLE
Remove redundant wasm import from x_benthos_extra.go

### DIFF
--- a/public/components/all/x_benthos_extra.go
+++ b/public/components/all/x_benthos_extra.go
@@ -5,6 +5,5 @@ package all
 import (
 	// Import extra packages, these are packages only imported with the tag
 	// x_benthos_extra, which is normally reserved for -cgo suffixed builds
-	_ "github.com/benthosdev/benthos/v4/internal/impl/wasm"
 	_ "github.com/benthosdev/benthos/v4/internal/impl/zeromq"
 )


### PR DESCRIPTION
I'm not sure why this was added here, but it's also imported via `public/components/all/package.go`, which imports
`github.com/benthosdev/benthos/v4/public/components/wasm`.