### PR TITLE
Fix sensitive field scrubber

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ All notable changes to this project will be documented in this file.
 - Field `timeout` added to the `nats_kv` processor to specify the maximum period to wait on an operation before aborting and returning an error.
 - Bloblang comparison operators (`>`, `<`, `<=`, `>=`) now match the precision of the compared integers when applicable.
 - The `parse_form_url_encoded` Bloblang method no longer produces results with an unknown data type for repeated query parameters.
+- The `echo` CLI command no longer fails to sanitise configs when encountering an empty `password` field.
 
 ### Changed
 

--- a/internal/docs/field.go
+++ b/internal/docs/field.go
@@ -165,16 +165,16 @@ func (f FieldSpec) Optional() FieldSpec {
 	return f
 }
 
-const bloblREEnvVar = "\\${[0-9A-Za-z_.]+(:((\\${[^}]+})|[^}])*)?}"
+const bloblREEnvVar = `\${[0-9A-Za-z_.]+(:((\${[^}]+})|[^}])*)?}`
 
 // Secret marks this field as being a secret, which means it represents
 // information that is generally considered sensitive such as passwords or
 // access tokens.
 func (f FieldSpec) Secret() FieldSpec {
 	f.IsSecret = true
-	f.Scrubber = fmt.Sprintf(`root = if this != "" && !this.trim().re_match("""^%v$""") {
+	f.Scrubber = fmt.Sprintf(`root = if this != null && this != "" && !this.trim().re_match("""^%v$""") {
   "!!!SECRET_SCRUBBED!!!"
-}`, bloblREEnvVar)
+} else if this == null { "" }`, bloblREEnvVar)
 	return f
 }
 

--- a/internal/docs/field_test.go
+++ b/internal/docs/field_test.go
@@ -156,6 +156,12 @@ func TestSecretScrubbing(t *testing.T) {
 			output: "!!!SECRET_SCRUBBED!!!",
 		},
 		{
+			name:   "raw secret with empty value",
+			f:      docs.FieldString("foo", "").Secret(),
+			input:  "",
+			output: "",
+		},
+		{
 			name:   "env var secret",
 			f:      docs.FieldString("foo", "").Secret(),
 			input:  "${FOO}",
@@ -190,6 +196,12 @@ func TestSecretScrubbing(t *testing.T) {
 			f:      docs.FieldURL("foo", ""),
 			input:  "tcp://admin:${FOO}@example.com",
 			output: "tcp://admin:${FOO}@example.com",
+		},
+		{
+			name:   "url user with empty password",
+			f:      docs.FieldURL("foo", ""),
+			input:  "tcp://admin:@example.com",
+			output: "tcp://admin:@example.com",
 		},
 	}
 	for _, test := range tests {


### PR DESCRIPTION
Don't throw an error when scrubbing empty password fields.