### PR TITLE
Update docs for the `branch` processor

### DIFF
--- a/internal/bloblang/query/functions.go
+++ b/internal/bloblang/query/functions.go
@@ -508,7 +508,7 @@ func NewMetaFunction(key string) Function {
 var _ = registerFunction(
 	NewFunctionSpec(
 		FunctionCategoryMessage, "metadata",
-		"Returns the value of a metadata key from the input message, or `null` if the key does not exist. Since values are extracted from the read-only input message they do NOT reflect changes made from within the map, in order to query metadata mutations made within a mapping use the `@.foo` syntax. This function supports extracting metadata from other messages of a batch with the `from` method.",
+		"Returns the value of a metadata key from the input message, or `null` if the key does not exist. Since values are extracted from the read-only input message they do NOT reflect changes made from within the map, in order to query metadata mutations made within a mapping use the [`@` operator](/docs/guides/bloblang/about#metadata). This function supports extracting metadata from other messages of a batch with the `from` method.",
 		NewExampleSpec("", `root.topic = metadata("kafka_topic")`),
 		NewExampleSpec(
 			"The key parameter is optional and if omitted the entire metadata contents are returned as an object.",

--- a/internal/impl/pure/processor_branch.go
+++ b/internal/impl/pure/processor_branch.go
@@ -37,7 +37,7 @@ This is useful for preserving the original message contents when using processor
 
 ### Metadata
 
-Metadata fields that are added to messages during branch processing will not be automatically copied into the resulting message. In order to do this you should explicitly declare in your `+"`result_map`"+` either a wholesale copy with `+"`meta = meta()`"+`, or selective copies with `+"`meta foo = meta(\"bar\")`"+` and so on.
+Metadata fields that are added to messages during branch processing will not be automatically copied into the resulting message. In order to do this you should explicitly declare in your `+"`result_map`"+` either a wholesale copy with `+"`meta = metadata()`"+`, or selective copies with `+"`meta foo = metadata(\"bar\")`"+` and so on. It is also possible to reference the metadata of the origin message in the `+"`result_map`"+` using the [`+"`@`"+` operator](/docs/guides/bloblang/about#metadata).
 
 ### Error Handling
 
@@ -108,7 +108,7 @@ pipeline:
           - cache:
               resource: TODO
               operator: set
-              key: ${! meta("id") }
+              key: ${! @id }
               value: ${! content() }
 `).
 		Fields(branchSpecFields()...)
@@ -132,17 +132,18 @@ func branchSpecFields() []*service.ConfigField {
 			Description("A list of processors to apply to mapped requests. When processing message batches the resulting batch must match the size and ordering of the input batch, therefore filtering, grouping should not be performed within these processors."),
 		service.NewBloblangField(branchProcFieldResMap).
 			Description("A [Bloblang mapping](/docs/guides/bloblang/about) that describes how the resulting messages from branched processing should be mapped back into the original payload. If left empty the origin message will remain unchanged (including metadata).").
-			Examples(`meta foo_code = meta("code")
+			Examples(`meta foo_code = metadata("code")
 root.foo_result = this`,
-				`meta = meta()
+				`meta = metadata()
 root.bar.body = this.body
 root.bar.id = this.user.id`,
 				`root.raw_result = content().string()`,
-				`root.enrichments.foo = if meta("request_failed") != null {
-  throw(meta("request_failed"))
+				`root.enrichments.foo = if metadata("request_failed") != null {
+  throw(metadata("request_failed"))
 } else {
   this
-}`).
+}`, `# Retain only the updated metadata fields which were present in the origin message
+meta = metadata().filter(v -> @.get(v.key) != null)`).
 			Default(""),
 	}
 }

--- a/website/docs/components/processors/branch.md
+++ b/website/docs/components/processors/branch.md
@@ -30,7 +30,7 @@ This is useful for preserving the original message contents when using processor
 
 ### Metadata
 
-Metadata fields that are added to messages during branch processing will not be automatically copied into the resulting message. In order to do this you should explicitly declare in your `result_map` either a wholesale copy with `meta = meta()`, or selective copies with `meta foo = meta("bar")` and so on.
+Metadata fields that are added to messages during branch processing will not be automatically copied into the resulting message. In order to do this you should explicitly declare in your `result_map` either a wholesale copy with `meta = metadata()`, or selective copies with `meta foo = metadata("bar")` and so on. It is also possible to reference the metadata of the origin message in the `result_map` using the [`@` operator](/docs/guides/bloblang/about#metadata).
 
 ### Error Handling
 
@@ -86,22 +86,26 @@ Default: `""`
 # Examples
 
 result_map: |-
-  meta foo_code = meta("code")
+  meta foo_code = metadata("code")
   root.foo_result = this
 
 result_map: |-
-  meta = meta()
+  meta = metadata()
   root.bar.body = this.body
   root.bar.id = this.user.id
 
 result_map: root.raw_result = content().string()
 
 result_map: |-
-  root.enrichments.foo = if meta("request_failed") != null {
-    throw(meta("request_failed"))
+  root.enrichments.foo = if metadata("request_failed") != null {
+    throw(metadata("request_failed"))
   } else {
     this
   }
+
+result_map: |-
+  # Retain only the updated metadata fields which were present in the origin message
+  meta = metadata().filter(v -> @.get(v.key) != null)
 ```
 
 ## Examples
@@ -197,7 +201,7 @@ pipeline:
           - cache:
               resource: TODO
               operator: set
-              key: ${! meta("id") }
+              key: ${! @id }
               value: ${! content() }
 ```
 

--- a/website/docs/components/processors/workflow.md
+++ b/website/docs/components/processors/workflow.md
@@ -308,22 +308,26 @@ Default: `""`
 # Examples
 
 result_map: |-
-  meta foo_code = meta("code")
+  meta foo_code = metadata("code")
   root.foo_result = this
 
 result_map: |-
-  meta = meta()
+  meta = metadata()
   root.bar.body = this.body
   root.bar.id = this.user.id
 
 result_map: root.raw_result = content().string()
 
 result_map: |-
-  root.enrichments.foo = if meta("request_failed") != null {
-    throw(meta("request_failed"))
+  root.enrichments.foo = if metadata("request_failed") != null {
+    throw(metadata("request_failed"))
   } else {
     this
   }
+
+result_map: |-
+  # Retain only the updated metadata fields which were present in the origin message
+  meta = metadata().filter(v -> @.get(v.key) != null)
 ```
 
 ## Structured Metadata

--- a/website/docs/guides/bloblang/about.md
+++ b/website/docs/guides/bloblang/about.md
@@ -106,11 +106,11 @@ root.new_doc.type = $foo
 
 ### Metadata
 
-Benthos messages contain metadata that is separate from the main payload, in Bloblang you can modify the metadata of the resulting message with the `meta` assignment keyword. Metadata values of the resulting message are referenced within queries with `@`:
+Benthos messages contain metadata that is separate from the main payload, in Bloblang you can modify the metadata of the resulting message with the `meta` assignment keyword. Metadata values of the resulting message are referenced within queries with the `@` operator or the [`metadata()` function][blobl.functions.metadata]:
 
 ```coffee
 # Reference a metadata value
-root.new_doc.bar = @kafka_topic
+root.new_doc.bar = @kafka_topic # Or `@.kafka_topic` or `metadata("kafka_topic")`
 
 # Delete all metadata
 meta = deleted()
@@ -122,7 +122,7 @@ meta baz = {
 }
 
 # Get an object of key/values for all metadata
-root.meta_obj = @
+root.meta_obj = @ # Or `metadata()`
 ```
 
 ## Coalesce
@@ -418,6 +418,7 @@ Why? That's a good question. Bloblang supports non-JSON formats too, so it can't
 [blobl.interp]: /docs/configuration/interpolation#bloblang-queries
 [blobl.functions]: /docs/guides/bloblang/functions
 [blobl.functions.content]: /docs/guides/bloblang/functions#content
+[blobl.functions.metadata]: /docs/guides/bloblang/functions#metadata
 [blobl.methods]: /docs/guides/bloblang/methods
 [blobl.methods.apply]: /docs/guides/bloblang/methods#apply
 [blobl.methods.catch]: /docs/guides/bloblang/methods#catch

--- a/website/docs/guides/bloblang/functions.md
+++ b/website/docs/guides/bloblang/functions.md
@@ -410,7 +410,7 @@ root.doc = json()
 
 ### `metadata`
 
-Returns the value of a metadata key from the input message, or `null` if the key does not exist. Since values are extracted from the read-only input message they do NOT reflect changes made from within the map, in order to query metadata mutations made within a mapping use the `@.foo` syntax. This function supports extracting metadata from other messages of a batch with the `from` method.
+Returns the value of a metadata key from the input message, or `null` if the key does not exist. Since values are extracted from the read-only input message they do NOT reflect changes made from within the map, in order to query metadata mutations made within a mapping use the [`@` operator](/docs/guides/bloblang/about#metadata). This function supports extracting metadata from other messages of a batch with the `from` method.
 
 #### Parameters
 


### PR DESCRIPTION
Clarify how the `@` operator can be used to reference the metadata of the origin message and replace the deprecated `meta()` function with `metadata()`.

This is more of a conversation starter, but not sure if it ended up being too verbose or if it needs extra clarifications.