### PR TITLE
Fix link to NATS JWT docs

### DIFF
--- a/internal/impl/nats/auth.go
+++ b/internal/impl/nats/auth.go
@@ -23,7 +23,7 @@ There are several components within Benthos which utilise NATS services. You wil
 support optional advanced authentication parameters for [NKeys](https://docs.nats.io/nats-server/configuration/securing_nats/auth_intro/nkey_auth)
 and [User Credentials](https://docs.nats.io/developing-with-nats/security/creds).
 
-An in depth tutorial can be found [here](https://docs.nats.io/developing-with-nats/tutorials/jwt).
+An in depth tutorial can be found [here](https://docs.nats.io/running-a-nats-service/nats_admin/security/jwt).
 
 #### NKey file
 

--- a/website/docs/components/caches/nats_kv.md
+++ b/website/docs/components/caches/nats_kv.md
@@ -78,7 +78,7 @@ There are several components within Benthos which utilise NATS services. You wil
 support optional advanced authentication parameters for [NKeys](https://docs.nats.io/nats-server/configuration/securing_nats/auth_intro/nkey_auth)
 and [User Credentials](https://docs.nats.io/developing-with-nats/security/creds).
 
-An in depth tutorial can be found [here](https://docs.nats.io/developing-with-nats/tutorials/jwt).
+An in depth tutorial can be found [here](https://docs.nats.io/running-a-nats-service/nats_admin/security/jwt).
 
 #### NKey file
 

--- a/website/docs/components/inputs/nats.md
+++ b/website/docs/components/inputs/nats.md
@@ -94,7 +94,7 @@ There are several components within Benthos which utilise NATS services. You wil
 support optional advanced authentication parameters for [NKeys](https://docs.nats.io/nats-server/configuration/securing_nats/auth_intro/nkey_auth)
 and [User Credentials](https://docs.nats.io/developing-with-nats/security/creds).
 
-An in depth tutorial can be found [here](https://docs.nats.io/developing-with-nats/tutorials/jwt).
+An in depth tutorial can be found [here](https://docs.nats.io/running-a-nats-service/nats_admin/security/jwt).
 
 #### NKey file
 

--- a/website/docs/components/inputs/nats_jetstream.md
+++ b/website/docs/components/inputs/nats_jetstream.md
@@ -111,7 +111,7 @@ There are several components within Benthos which utilise NATS services. You wil
 support optional advanced authentication parameters for [NKeys](https://docs.nats.io/nats-server/configuration/securing_nats/auth_intro/nkey_auth)
 and [User Credentials](https://docs.nats.io/developing-with-nats/security/creds).
 
-An in depth tutorial can be found [here](https://docs.nats.io/developing-with-nats/tutorials/jwt).
+An in depth tutorial can be found [here](https://docs.nats.io/running-a-nats-service/nats_admin/security/jwt).
 
 #### NKey file
 

--- a/website/docs/components/inputs/nats_kv.md
+++ b/website/docs/components/inputs/nats_kv.md
@@ -100,7 +100,7 @@ There are several components within Benthos which utilise NATS services. You wil
 support optional advanced authentication parameters for [NKeys](https://docs.nats.io/nats-server/configuration/securing_nats/auth_intro/nkey_auth)
 and [User Credentials](https://docs.nats.io/developing-with-nats/security/creds).
 
-An in depth tutorial can be found [here](https://docs.nats.io/developing-with-nats/tutorials/jwt).
+An in depth tutorial can be found [here](https://docs.nats.io/running-a-nats-service/nats_admin/security/jwt).
 
 #### NKey file
 

--- a/website/docs/components/inputs/nats_stream.md
+++ b/website/docs/components/inputs/nats_stream.md
@@ -100,7 +100,7 @@ There are several components within Benthos which utilise NATS services. You wil
 support optional advanced authentication parameters for [NKeys](https://docs.nats.io/nats-server/configuration/securing_nats/auth_intro/nkey_auth)
 and [User Credentials](https://docs.nats.io/developing-with-nats/security/creds).
 
-An in depth tutorial can be found [here](https://docs.nats.io/developing-with-nats/tutorials/jwt).
+An in depth tutorial can be found [here](https://docs.nats.io/running-a-nats-service/nats_admin/security/jwt).
 
 #### NKey file
 

--- a/website/docs/components/outputs/nats.md
+++ b/website/docs/components/outputs/nats.md
@@ -88,7 +88,7 @@ There are several components within Benthos which utilise NATS services. You wil
 support optional advanced authentication parameters for [NKeys](https://docs.nats.io/nats-server/configuration/securing_nats/auth_intro/nkey_auth)
 and [User Credentials](https://docs.nats.io/developing-with-nats/security/creds).
 
-An in depth tutorial can be found [here](https://docs.nats.io/developing-with-nats/tutorials/jwt).
+An in depth tutorial can be found [here](https://docs.nats.io/running-a-nats-service/nats_admin/security/jwt).
 
 #### NKey file
 

--- a/website/docs/components/outputs/nats_jetstream.md
+++ b/website/docs/components/outputs/nats_jetstream.md
@@ -88,7 +88,7 @@ There are several components within Benthos which utilise NATS services. You wil
 support optional advanced authentication parameters for [NKeys](https://docs.nats.io/nats-server/configuration/securing_nats/auth_intro/nkey_auth)
 and [User Credentials](https://docs.nats.io/developing-with-nats/security/creds).
 
-An in depth tutorial can be found [here](https://docs.nats.io/developing-with-nats/tutorials/jwt).
+An in depth tutorial can be found [here](https://docs.nats.io/running-a-nats-service/nats_admin/security/jwt).
 
 #### NKey file
 

--- a/website/docs/components/outputs/nats_kv.md
+++ b/website/docs/components/outputs/nats_kv.md
@@ -88,7 +88,7 @@ There are several components within Benthos which utilise NATS services. You wil
 support optional advanced authentication parameters for [NKeys](https://docs.nats.io/nats-server/configuration/securing_nats/auth_intro/nkey_auth)
 and [User Credentials](https://docs.nats.io/developing-with-nats/security/creds).
 
-An in depth tutorial can be found [here](https://docs.nats.io/developing-with-nats/tutorials/jwt).
+An in depth tutorial can be found [here](https://docs.nats.io/running-a-nats-service/nats_admin/security/jwt).
 
 #### NKey file
 

--- a/website/docs/components/outputs/nats_stream.md
+++ b/website/docs/components/outputs/nats_stream.md
@@ -78,7 +78,7 @@ There are several components within Benthos which utilise NATS services. You wil
 support optional advanced authentication parameters for [NKeys](https://docs.nats.io/nats-server/configuration/securing_nats/auth_intro/nkey_auth)
 and [User Credentials](https://docs.nats.io/developing-with-nats/security/creds).
 
-An in depth tutorial can be found [here](https://docs.nats.io/developing-with-nats/tutorials/jwt).
+An in depth tutorial can be found [here](https://docs.nats.io/running-a-nats-service/nats_admin/security/jwt).
 
 #### NKey file
 

--- a/website/docs/components/processors/nats_kv.md
+++ b/website/docs/components/processors/nats_kv.md
@@ -115,7 +115,7 @@ There are several components within Benthos which utilise NATS services. You wil
 support optional advanced authentication parameters for [NKeys](https://docs.nats.io/nats-server/configuration/securing_nats/auth_intro/nkey_auth)
 and [User Credentials](https://docs.nats.io/developing-with-nats/security/creds).
 
-An in depth tutorial can be found [here](https://docs.nats.io/developing-with-nats/tutorials/jwt).
+An in depth tutorial can be found [here](https://docs.nats.io/running-a-nats-service/nats_admin/security/jwt).
 
 #### NKey file
 

--- a/website/docs/components/processors/nats_request_reply.md
+++ b/website/docs/components/processors/nats_request_reply.md
@@ -105,7 +105,7 @@ There are several components within Benthos which utilise NATS services. You wil
 support optional advanced authentication parameters for [NKeys](https://docs.nats.io/nats-server/configuration/securing_nats/auth_intro/nkey_auth)
 and [User Credentials](https://docs.nats.io/developing-with-nats/security/creds).
 
-An in depth tutorial can be found [here](https://docs.nats.io/developing-with-nats/tutorials/jwt).
+An in depth tutorial can be found [here](https://docs.nats.io/running-a-nats-service/nats_admin/security/jwt).
 
 #### NKey file
 


### PR DESCRIPTION
This MR simply corrects the link to the NATS JWT docs which have moved and currently lead to a "Page not found" error page.