### PR TITLE
Add cookie handling for http client

### DIFF
--- a/internal/httpclient/client.go
+++ b/internal/httpclient/client.go
@@ -208,6 +208,15 @@ func (h *Client) ResponseToBatch(res *http.Response) (service.MessageBatch, erro
 				}
 			}
 		}
+		// Handle cookies returned by the server. Create a Cookie header to be used by the client for subsequent requests
+		if len(res.Cookies()) > 0 {
+			var cookie strings.Builder
+			for _, c := range res.Cookies() {
+				// We're not checkig expiration or other properties like Domain here
+				cookie.WriteString(fmt.Sprintf("%s=%s; ", c.Name, c.Value))
+			}
+			p.MetaSetMut("Cookie", strings.TrimSuffix(cookie.String(), "; "))
+		}
 	}
 
 	if res.Body == nil {

--- a/internal/httpclient/client_test.go
+++ b/internal/httpclient/client_test.go
@@ -712,3 +712,46 @@ tls:
 	require.NoError(t, err)
 	assert.Equal(t, "HELLO WORLD", string(mBytes))
 }
+
+func TestHTTPClientExtensiveCookies(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Add("Content-Type", "application/json")
+		w.Header().Add("x-demo", "Hello")
+		http.SetCookie(w, &http.Cookie{Name: "a", Value: "b", Path: "/", HttpOnly: true, Secure: true})
+		http.SetCookie(w, &http.Cookie{Name: "x", Value: "y"})
+		http.SetCookie(w, &http.Cookie{Name: "foo", Value: "bar"})
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"json": "content"}`))
+	}))
+	defer ts.Close()
+
+	conf := clientConfig(t, `
+url: %v
+extract_headers:
+  include_patterns: [".*"]
+`, ts.URL+"/testpost")
+
+	h, err := NewClientFromOldConfig(conf, service.MockResources())
+	require.NoError(err)
+
+	resBatch, err := h.Send(context.Background(), service.MessageBatch{
+		service.NewMessage([]byte("hello world")),
+	})
+	require.NoError(err)
+	require.Len(resBatch, 1)
+
+	mBytes, err := resBatch[0].AsBytes()
+	require.NoError(err)
+	assert.Equal(`{"json": "content"}`, string(mBytes))
+
+	xHeader, exists := resBatch[0].MetaGet("x-demo")
+	require.True(exists)
+	assert.Equal(xHeader, "Hello")
+
+	resCookie, exists := resBatch[0].MetaGet("Cookie")
+	require.True(exists)
+	assert.Equal(resCookie, "a=b; x=y; foo=bar")
+}

--- a/internal/impl/io/processor_http.go
+++ b/internal/impl/io/processor_http.go
@@ -36,6 +36,11 @@ If the request returns an error response code this processor sets a metadata fie
 
 Use the field `+"`extract_headers`"+` to specify rules for which other headers should be copied into the resulting message from the response.
 
+### Cookies
+
+If the server returns cookies in the response header, this processor sets a metadata field `+"`Cookie`"+` on the resulting message.
+This metadata field can be used in subsequent calls to the same server as http header, containing all received cookies in the format `+"`name=value; name=value`"+`
+
 ## Error Handling
 
 When all retry attempts for a message are exhausted the processor cancels the attempt. These failed messages will continue through the pipeline unchanged, but can be dropped or placed in a dead letter queue according to your config, you can read about these patterns [here](/docs/configuration/error_handling).`).


### PR DESCRIPTION
In one of our integrations, we have the challenge, that every call of our http output must contain a `csrf` token plus a set of cookies, because the receiving server is not truly stateless.
Therefore we're calling a `get token` method via branch processor to receive the token and all necessary cookies, like a loadbalancer session id etc..

Unfortunately, Benthos currently does not accept multiple http headers with the same name properly, which is especially problematic for the `Set-Cookie` header.

This PR does not change the handling of headers in general, but it introduces a new Metadata field called `Cookie` which aggregates all incoming `Set-Cookie` headers in a ready-to-use `Cookie` value for subsequent calls.

Example Inbound:
```
Set-Cookie a=b; path=/, Httponly; Secure
Set-Cookie foo=bar; path=/
```
Resulting Metadata:
```
Cookie a=b; foo=bar
```

Since this would add a new metadata field whenever cookie headers are sent by the server, 
I'm not sure if this would need a separate config flag to disable this feature. Or if it even must be off by default?
