### PR TITLE
Add jetstream domain to kv-components

### DIFF
--- a/internal/impl/nats/docs.go
+++ b/internal/impl/nats/docs.go
@@ -7,7 +7,8 @@ import (
 )
 
 const (
-	kvFieldBucket = "bucket"
+	kvFieldBucket     = "bucket"
+	kvJetstreamDomain = "domain"
 )
 
 const (
@@ -39,6 +40,8 @@ func kvDocs(extraFields ...*service.ConfigField) []*service.ConfigField {
 		[]*service.ConfigField{
 			service.NewStringField(kvFieldBucket).
 				Description("The name of the KV bucket.").Example("my_kv_bucket"),
+			service.NewStringField(kvJetstreamDomain).
+				Description("An optional jetstream domain").Example("my_js_domain").Advanced().Optional(),
 		}...,
 	)
 	fields = append(fields, extraFields...)


### PR DESCRIPTION
I noticed that the nats components using jetstream is missing the ability to specify jetstream-domain allowing a client to use jetstream-enabled leaf nodes. However, I opted for changing the key-value store components since these already use the new jetstream api and the old ones prob. needs to be rewritten at some point anyway.

I also took the liberty to add username and password authentication to the nats auth section. This isn't really something one would want to use in production, but helps with testing leafnodes connectivity since they need to be bound with an account and connects user credentials (preferably username/password when testing locally). 

This is my first PR for Benthos so i'm not super-familiar with the structure. Things seemed to fit, runs tests/compiles, and works when i try it locally so hopefully it isn't that bad. Some integration-tests failed, but that seems to have nothing to do with the changes i made.

